### PR TITLE
dont rebuild to GeometryBasics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,8 +48,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - name: Add custom versions of packages
-        run: julia --project=docs -e 'using Pkg; Pkg.add(PackageSpec(; url = "https://github.com/JuliaGeo/NaturalEarth.jl", rev = "as/scratchspaces"))'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -571,21 +571,11 @@ rebuild(geom, child_geoms; kw...) = rebuild(GI.trait(geom), geom, child_geoms; k
 function rebuild(trait::GI.AbstractTrait, geom, child_geoms; crs=GI.crs(geom), extent=nothing)
     T = GI.geointerface_geomtype(trait)
     if GI.is3d(geom)
-        # The Boolean type parameters here indicate 3d-ness and measure coordinate presence respectively.
+        # The Boolean type parameters here indicate "3d-ness" and "measure" coordinate, respectively.
         return T{true,false}(child_geoms; crs, extent)
     else
         return T{false,false}(child_geoms; crs, extent)
     end
-end
-# So that GeometryBasics geoms rebuild as themselves
-function rebuild(trait::GI.AbstractTrait, geom::BasicsGeoms, child_geoms; crs=nothing)
-    GB.geointerface_geomtype(trait)(child_geoms)
-end
-function rebuild(trait::GI.AbstractTrait, geom::Union{GB.LineString,GB.MultiPoint}, child_geoms; crs=nothing)
-    GB.geointerface_geomtype(trait)(GI.convert.(GB.Point, child_geoms))
-end
-function rebuild(trait::GI.PolygonTrait, geom::GB.Polygon, child_geoms; crs=nothing)
-    Polygon(child_geoms[1], child_geoms[2:end])
 end
 
 using Base.Threads: nthreads, @threads, @spawn

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -168,10 +168,11 @@ if the outer object has `MultiPolygonTrait`, but should work if it has `FeatureT
 
 Objects "shallower" than the target trait are always completely rebuilt, like
 a `Vector` of `FeatureCollectionTrait` of `FeatureTrait` when the target
-has `PolygonTrait` and is held in the features. But "deeper" objects may remain
-unchanged - such as points and linear rings if the target is the same `PolygonTrait`.
+has `PolygonTrait` and is held in the features. These will always be GeoInterface 
+geometries/feature/feature collections. But "deeper" objects may remain
+unchanged or be whatever GeoInterface compatible objects `f` returns.
 
-The result is a functionally similar geometry with values depending on `f`
+The result is a functionally similar geometry with values depending on `f`.
 
 $APPLY_KEYWORDS
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -89,14 +89,14 @@ end
     @test reconstructed isa GI.Polygon
 
 
-    gb_revlr1 = GB.LineString(GB.Point.(reverse(pv2)))
-    gb_revlr2 = GB.LineString(GB.Point.(reverse(pv1)))
-    gb_revpoly = GB.Polygon(gb_revlr1, [gb_revlr2])
+    revlr1 = GI.LineString(GB.Point.(reverse(pv2)))
+    revlr2 = GI.LineString(GB.Point.(reverse(pv1)))
+    revpoly = GI.Polygon([revlr1, revlr2])
     gb_lr1 = GB.LineString(GB.Point.(pv1))
     gb_lr2 = GB.LineString(GB.Point.(pv2))
     gb_poly = GB.Polygon(gb_lr1, [gb_lr2])
     gb_points = collect(GO.flatten(GI.PointTrait, gb_poly))
     gb_reconstructed = GO.reconstruct(gb_poly, reverse(gb_points))
-    @test gb_reconstructed == gb_revpoly
-    @test gb_reconstructed isa GB.Polygon
+    @test gb_reconstructed == revpoly
+    @test gb_reconstructed isa GI.Polygon
 end


### PR DESCRIPTION
This removes all GeometryBasics `rebuild` customisation so that GI geometries are always returned.

Fixes #133

