### PR TITLE
Enable exotic array polygonization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,16 +36,19 @@ julia = "1.9"
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FlexiJoins = "e37f2e79-19fa-4eb7-8510-b63b51fe0a37"
 GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LibGEOS = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
+Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Shapefile = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ArchGDAL", "CoordinateTransformations", "DataFrames", "Distributions", "FlexiJoins", "GeoFormatTypes", "GeoJSON", "Proj", "JLD2", "LibGEOS", "Random", "Shapefile", "Test"]
+test = ["ArchGDAL", "CoordinateTransformations", "DataFrames", "Distributions", "DimensionalData", "FlexiJoins", "GeoFormatTypes", "GeoJSON", "Proj", "JLD2", "LibGEOS", "Random", "Rasters", "OffsetArrays", "Shapefile", "Test"]

--- a/src/methods/polygonize.jl
+++ b/src/methods/polygonize.jl
@@ -321,9 +321,9 @@ function _polygonize(f, xs::AbstractVector{T}, ys::AbstractVector{T}, A::Abstrac
     assigned = fill(false, length(holes))
     for i in eachindex(holes)
         hole = holes[i]
-        prepared_hole = GI.LinearRing(holes[i]; extent=GI.extent(holes[i]), crs)
+        prepared_hole = GI.LinearRing(holes[i]; extent=GI.extent(holes[i]))
         for poly in polygons
-            exterior = GI.Polygon(StaticArrays.SVector(GI.getexterior(poly)); extent=GI.extent(poly), crs)
+            exterior = GI.Polygon(StaticArrays.SVector(GI.getexterior(poly)); extent=GI.extent(poly))
             if covers(exterior, prepared_hole)
                 # Hole is in the exterior, so add it to the polygon
                 push!(poly.geom, hole)

--- a/src/methods/polygonize.jl
+++ b/src/methods/polygonize.jl
@@ -343,7 +343,7 @@ function _polygonize(f, xs::AbstractVector{T}, ys::AbstractVector{T}, A::Abstrac
         return nothing
     else
         # Otherwise return a wrapped MultiPolygon
-        return GI.MultiPolygon(polygons; crs, extent = reduce(Extents.union, GI.extent.(polygons)))
+        return GI.MultiPolygon(polygons; crs, extent = mapreduce(GI.extent, Extents.union, polygons))
     end
 end
 

--- a/src/methods/polygonize.jl
+++ b/src/methods/polygonize.jl
@@ -343,7 +343,7 @@ function _polygonize(f, xs::AbstractVector{T}, ys::AbstractVector{T}, A::Abstrac
         return nothing
     else
         # Otherwise return a wrapped MultiPolygon
-        return GI.MultiPolygon(polygons)
+        return GI.MultiPolygon(polygons; crs, extent = reduce(Extents.union, GI.extent.(polygons)))
     end
 end
 

--- a/src/methods/polygonize.jl
+++ b/src/methods/polygonize.jl
@@ -3,7 +3,6 @@
 export polygonize
 
 #=
-
 The methods in this file convert a raster image into a set of polygons, 
 by contour detection using a clockwise Moore neighborhood method.
 

--- a/src/methods/polygonize.jl
+++ b/src/methods/polygonize.jl
@@ -137,13 +137,13 @@ function _polygonize(f::Base.Callable, xs::AbstractRange, ys::AbstractRange, A::
     ybounds = first(ys) - yhalf : step(ys) : last(ys) + yhalf
     Tx = eltype(xbounds)
     Ty = eltype(ybounds)
-    xvec = Vector{Tuple{Tx,Tx}}(undef, length(xs))
-    yvec = Vector{Tuple{Ty,Ty}}(undef, length(ys))
-    for i in eachindex(xvec)
-        xvec[i] = xbounds[i], xbounds[i+1]
+    xvec = similar(Vector{Tuple{Tx,Tx}}, xs)
+    yvec = similar(Vector{Tuple{Ty,Ty}}, ys)
+    for (xind, i) in enumerate(eachindex(xvec))
+        xvec[i] = xbounds[xind], xbounds[xind+1]
     end
-    for i in eachindex(yvec)
-        yvec[i] = ybounds[i], ybounds[i+1]
+    for (yind, i) in enumerate(eachindex(yvec))
+        yvec[i] = ybounds[yind], ybounds[yind+1]
     end
     return _polygonize(f, xvec, yvec, A; kw...)
 end


### PR DESCRIPTION
- Enable exotic array polygonization by propagating axis semantics to edge vectors (replaced explicit vector of tuples with `similar(Vector{Tuple{...}}, xs)`).
- Propagate `GI.crs(A)` through to the output points, for Rasters
- Test with OffsetArrays, DimensionalData, and Rasters
- Try to fix Literate not detecting the comment in the source file