### PR TITLE
Currying functions for performance gain

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -54,7 +54,7 @@ n_points_values = round.(Int, exp10.(LinRange(log10(10), log10(100_000), 5)))
     circle_area_suite["LibGEOS"][n_points] = @be LG.area($lg_circle) seconds=1
 end
 
-plot_trials(circle_area_suite)
+# plot_trials(circle_area_suite)
 
 
 # ## Vancouver watershed benchmarks
@@ -175,9 +175,9 @@ n_points_values = round.(Int, exp10.(LinRange(1, 4, 10)))
     circle_union_suite["LibGEOS"][n_points]     = @be LG.union($lg_circle_left, $lg_circle_right)
 end
 
-plot_trials(circle_difference_suite)
-plot_trials(circle_intersection_suite)
-plot_trials(circle_union_suite)
+# plot_trials(circle_difference_suite)
+# plot_trials(circle_intersection_suite)
+# plot_trials(circle_union_suite)
 
 usa_poly_suite = BenchmarkGroup()
 usa_difference_suite = usa_poly_suite["difference"] = BenchmarkGroup(["title:USA difference", "subtitle:Tested on CONUS"])

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -54,7 +54,7 @@ n_points_values = round.(Int, exp10.(LinRange(log10(10), log10(100_000), 5)))
     circle_area_suite["LibGEOS"][n_points] = @be LG.area($lg_circle) seconds=1
 end
 
-# plot_trials(circle_area_suite)
+plot_trials(circle_area_suite)
 
 
 # ## Vancouver watershed benchmarks
@@ -175,9 +175,9 @@ n_points_values = round.(Int, exp10.(LinRange(1, 4, 10)))
     circle_union_suite["LibGEOS"][n_points]     = @be LG.union($lg_circle_left, $lg_circle_right)
 end
 
-# plot_trials(circle_difference_suite)
-# plot_trials(circle_intersection_suite)
-# plot_trials(circle_union_suite)
+plot_trials(circle_difference_suite)
+plot_trials(circle_intersection_suite)
+plot_trials(circle_union_suite)
 
 usa_poly_suite = BenchmarkGroup()
 usa_difference_suite = usa_poly_suite["difference"] = BenchmarkGroup(["title:USA difference", "subtitle:Tested on CONUS"])

--- a/src/methods/angles.jl
+++ b/src/methods/angles.jl
@@ -47,8 +47,9 @@ Result will be a Vector, or nested set of vectors, of type T where an optional a
 a default value of Float64.
 """
 function angles(geom, ::Type{T} = Float64; threaded =false) where T <: AbstractFloat
+    _angles_partial(x) = _angles(T, GI.trait(x), x)
     applyreduce(vcat, _ANGLE_TARGETS, geom; threaded, init = Vector{T}()) do g
-        _angles(T, GI.trait(g), g)
+        _angles_partial(g)
     end
 end
 
@@ -87,8 +88,9 @@ within the polyogn, the angles will be listed after the exterior ring angles in 
 holes. All angles, including the hole angles, are interior angles of the polygon.=#
 function _angles(::Type{T}, ::GI.PolygonTrait, geom) where T
     angles = _angles(T, GI.LinearRingTrait(), GI.getexterior(geom); interior = true)
+    append!_partial(x) = append!(angles, _angles(T, GI.LinearRingTrait(), x; interior = false))
     for h in GI.gethole(geom)
-        append!(angles, _angles(T, GI.LinearRingTrait(), h; interior = false))
+        append!_partial(h)
     end
     return angles
 end

--- a/src/methods/clipping/difference.jl
+++ b/src/methods/clipping/difference.jl
@@ -116,9 +116,10 @@ function _difference(
     kwargs...,
 ) where T
     polys = [tuples(poly_a, T)]
+    mapreduce_partial(x) = mapreduce(p -> difference(p, x; target), append!, polys)
     for poly_b in GI.getpolygon(multipoly_b)
         isempty(polys) && break
-        polys = mapreduce(p -> difference(p, poly_b; target), append!, polys)
+        polys = mapreduce_partial(poly_b)
     end
     return polys
 end
@@ -138,8 +139,9 @@ function _difference(
     end
     polys = Vector{_get_poly_type(T)}()
     sizehint!(polys, GI.npolygon(multipoly_a))
+    append!_partial(x) = append!(polys, difference(x, poly_b; target))
     for poly_a in GI.getpolygon(multipoly_a)
-        append!(polys, difference(poly_a, poly_b; target))
+        append!_partial(poly_a)
     end
     return polys
 end
@@ -160,8 +162,10 @@ function _difference(
         fix_multipoly = nothing
     end
     local polys
+    #difference_partial(x,y, z) = difference(z == 1 ? multipoly_a : x, y; target, fix_multipoly)
+    #Can't curry for some reason?
     for (i, poly_b) in enumerate(GI.getpolygon(multipoly_b))
-        polys = difference(i == 1 ? multipoly_a : GI.MultiPolygon(polys), poly_b; target, fix_multipoly)
+        polys = difference(i == 1 ? multipoly_a : GI.MultiPolygon(polys), poly_b; target, fix_multipoly)#difference_partial(GI.MultiPolygon(polys),poly_b, i)
     end
     return polys
 end

--- a/src/methods/clipping/intersection.jl
+++ b/src/methods/clipping/intersection.jl
@@ -121,8 +121,9 @@ function _intersection(
         multipoly_b = fix_multipoly(multipoly_b)
     end
     polys = Vector{_get_poly_type(T)}()
+    append!_partial(x) = append!(polys, intersection(poly_a, x; target))
     for poly_b in GI.getpolygon(multipoly_b)
-        append!(polys, intersection(poly_a, poly_b; target))
+        append!_partial(poly_b)
     end
     return polys
 end
@@ -154,8 +155,9 @@ function _intersection(
         fix_multipoly = nothing
     end
     polys = Vector{_get_poly_type(T)}()
+    append!_partial(x) = append!(polys, intersection(x, multipoly_b; target, fix_multipoly))
     for poly_a in GI.getpolygon(multipoly_a)
-        append!(polys, intersection(poly_a, multipoly_b; target, fix_multipoly))
+        append!_partial(poly_a)
     end
     return polys
 end
@@ -207,8 +209,9 @@ function _intersection_points(::Type{T}, ::GI.AbstractTrait, a, ::GI.AbstractTra
     b_closed = npoints_b > 1 && edges_b[1][1] == edges_b[end][1]
     if npoints_a > 0 && npoints_b > 0
         # Loop over pairs of edges and add any intersection points to results
+        _intersection_point_partial(x,y) = _intersection_point(T, x, y; exact)
         for i in eachindex(edges_a), j in eachindex(edges_b)
-            line_orient, intr1, _ = _intersection_point(T, edges_a[i], edges_b[j]; exact)
+            line_orient, intr1, _ = _intersection_point_partial(edges_a[i], edges_b[j])#_intersection_point(T, edges_a[i], edges_b[j]; exact)
             # TODO: Add in degenerate intersection points when line_over
             if line_orient == line_cross || line_orient == line_hinge
                 #=

--- a/src/methods/distance.jl
+++ b/src/methods/distance.jl
@@ -265,9 +265,10 @@ function _distance_curve(::Type{T}, point, curve; close_curve = false) where T
     # find minimum distance
     min_dist = typemax(T)
     p1 = GI.getpoint(curve, close_curve ? np : 1)
+    _distance_line_partial(x,y) = _distance_line(T, point, x, y)
     for i in (close_curve ? 1 : 2):np
         p2 = GI.getpoint(curve, i)
-        dist = _distance_line(T, point, p1, p2)
+        dist = _distance_line_partial(p1, p2)
         min_dist = dist < min_dist ? dist : min_dist
         p1 = p2
     end
@@ -281,8 +282,9 @@ treats the exterior and each hole as a linear ring.
 =#
 function _distance_polygon(::Type{T}, point, poly) where T
     min_dist = _distance_curve(T, point, GI.getexterior(poly); close_curve = true)
+    _distance_curve_partial(x) = _distance_curve(T, point, x; close_curve = true)
     @inbounds for hole in GI.gethole(poly)
-        dist = _distance_curve(T, point, hole; close_curve = true)
+        dist = _distance_curve_partial(hole)
         min_dist = dist < min_dist ? dist : min_dist
     end
     return min_dist

--- a/src/methods/equals.jl
+++ b/src/methods/equals.jl
@@ -128,9 +128,10 @@ Two multipoints are equal if they share the same set of points.
 """
 function equals(::GI.MultiPointTrait, mp1, ::GI.MultiPointTrait, mp2)
     GI.npoint(mp1) == GI.npoint(mp2) || return false
+    mp2_points = GI.getpoint(mp2)
     for p1 in GI.getpoint(mp1)
         has_match = false  # if point has a matching point in other multipoint
-        for p2 in GI.getpoint(mp2)
+        for p2 in mp2_points
             if equals(p1, p2)
                 has_match = true
                 break
@@ -275,10 +276,11 @@ function equals(::GI.PolygonTrait, geom_a, ::GI.PolygonTrait, geom_b)
     ) || return false
     # Check if number of holes are equal
     GI.nhole(geom_a) == GI.nhole(geom_b) || return false
+    geom_b_holes = GI.gethole(geom_b)
     # Check if holes are equal
     for ihole in GI.gethole(geom_a)
         has_match = false
-        for jhole in GI.gethole(geom_b)
+        for jhole in geom_b_holes
             if _equals_curves(
                 ihole, jhole,
                 true, true,  # linear rings are closed by definition
@@ -320,10 +322,11 @@ Two multipolygons are equal if they share the same set of polygons.
 function equals(::GI.MultiPolygonTrait, geom_a, ::GI.MultiPolygonTrait, geom_b)
     # Check if same number of polygons
     GI.npolygon(geom_a) == GI.npolygon(geom_b) || return false
+    geom_b_polygon = GI.getpolygon(geom_b)
     # Check if each polygon has a matching polygon
     for poly_a in GI.getpolygon(geom_a)
         has_match = false
-        for poly_b in GI.getpolygon(geom_b)
+        for poly_b in geom_b_polygon
             if equals(poly_a, poly_b)
                 has_match = true
                 break

--- a/src/methods/geom_relations/coveredby.jl
+++ b/src/methods/geom_relations/coveredby.jl
@@ -249,8 +249,9 @@ function _coveredby(
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
     }, g2,
 )
+    coveredby_partial(x) = coveredby(g1, x)
     for sub_g2 in GI.getgeom(g2)
-        coveredby(g1, sub_g2) && return true
+        coveredby_partial(sub_g2) && return true
     end
     return false
 end
@@ -265,9 +266,10 @@ function _coveredby(
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
     }, g1,
     ::GI.AbstractGeometryTrait, g2,
-)
+)   
+    coveredby_partial(x) = coveredby(x, g2)
     for sub_g1 in GI.getgeom(g1)
-        !coveredby(sub_g1, g2) && return false
+        !coveredby_partial(sub_g1) && return false
     end
     return true
 end

--- a/src/methods/geom_relations/crosses.jl
+++ b/src/methods/geom_relations/crosses.jl
@@ -33,7 +33,7 @@ function multipoint_crosses_line(geom1, geom2)
     np2 = GI.npoint(geom2)
 
     while i < GI.npoint(geom1) && !int_point && !ext_point
-        for j in 1:GI.npoint(geom2) - 1
+        for j in 1:np2 - 1
             exclude_boundary = (j === 1 || j === np2 - 2) ? :none : :both
             if _point_on_segment(GI.getpoint(geom1, i), (GI.getpoint(geom2, j), GI.getpoint(geom2, j + 1)); exclude_boundary)
                 int_point = true
@@ -50,7 +50,7 @@ function line_crosses_line(line1, line2)
     np2 = GI.npoint(line2)
     if GeometryOps.intersects(line1, line2)
         for i in 1:GI.npoint(line1) - 1
-            for j in 1:GI.npoint(line2) - 1
+            for j in 1:np2 - 1
                 exclude_boundary = (j === 1 || j === np2 - 2) ? :none : :both
                 pa = GI.getpoint(line1, i)
                 pb = GI.getpoint(line1, i + 1)
@@ -63,6 +63,7 @@ function line_crosses_line(line1, line2)
 end
 
 function line_crosses_poly(line, poly)
+    intersect_partial(x) = intersects(line, x)
     for l in flatten(AbstractCurveTrait, poly)
         intersects(line, l) && return true
     end
@@ -72,12 +73,12 @@ end
 function multipoint_crosses_poly(mp, poly)
     int_point = false
     ext_point = false
-
+    _point_polygon_process_partial(x) = _point_polygon_process(
+        x, poly;
+        in_allow = true, on_allow = true, out_allow = false, exact = _False()
+    )
     for p in GI.getpoint(mp)
-        if _point_polygon_process(
-            p, poly;
-            in_allow = true, on_allow = true, out_allow = false, exact = _False()
-        )
+        if _point_polygon_process_partial(p)
             int_point = true
         else
             ext_point = true

--- a/src/methods/geom_relations/disjoint.jl
+++ b/src/methods/geom_relations/disjoint.jl
@@ -233,8 +233,9 @@ function _disjoint(
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
     }, g2,
 )
+    disjoint_partial(x) = disjoint(g1, x)
     for sub_g2 in GI.getgeom(g2)
-        !disjoint(g1, sub_g2) && return false
+        !disjoint_partial(sub_g2) && return false
     end
     return true
 end
@@ -250,8 +251,9 @@ function _disjoint(
     }, g1,
     ::GI.AbstractGeometryTrait, g2,
 )
+    disjoint_partial(x) = disjoint(x, g2)
     for sub_g1 in GI.getgeom(g1)
-        !disjoint(sub_g1, g2) && return false
+        !disjoint_partial(sub_g1) && return false
     end
     return true
 end

--- a/src/methods/geom_relations/overlaps.jl
+++ b/src/methods/geom_relations/overlaps.jl
@@ -137,8 +137,9 @@ function overlaps(
 )
     edges_a, edges_b = map(sort! ∘ to_edges, (line1, line2))
     for edge_a in edges_a
+        _overlaps_partial(x) = _overlaps(edge_a, x)
         for edge_b in edges_b
-            _overlaps(edge_a, edge_b) && return true
+            _overlaps_partial(edge_b) && return true
         end
     end
     return false
@@ -175,8 +176,9 @@ function overlaps(
     ::GI.PolygonTrait, poly1,
     ::GI.MultiPolygonTrait, polys2,
 )
+    overlaps_partial(x) = overlaps(poly1, x)
     for poly2 in GI.getgeom(polys2)
-        overlaps(poly1, poly2) && return true
+        overlaps_partial(poly2) && return true
     end
     return false
 end
@@ -206,8 +208,9 @@ function overlaps(
     ::GI.MultiPolygonTrait, polys1,
     ::GI.MultiPolygonTrait, polys2,
 )
+    overlaps_partial(x) = overlaps(x, polys2)
     for poly1 in GI.getgeom(polys1)
-        overlaps(poly1, polys2) && return true
+        overlaps_partial(poly1) && return true
     end
     return false
 end
@@ -259,8 +262,9 @@ function _line_intersects(
 )
     # Extents.intersects(to_extent(edges_a), to_extent(edges_b)) || return false
     for edge_a in edges_a
+        _line_intersects_partial(x) = _line_intersects(edge_a, x)
         for edge_b in edges_b
-            _line_intersects(edge_a, edge_b) && return true 
+            _line_intersects_partial(edge_b) && return true 
         end
     end
     return false

--- a/src/methods/geom_relations/touches.jl
+++ b/src/methods/geom_relations/touches.jl
@@ -234,8 +234,9 @@ function _touches(
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
     }, g2,
 )
+    touches_partial(x) = touches(g1, x)
     for sub_g2 in GI.getgeom(g2)
-        !touches(g1, sub_g2) && return false
+        !touches_partial(sub_g2) && return false
     end
     return true
 end
@@ -251,8 +252,9 @@ function _touches(
     }, g1,
     ::GI.AbstractGeometryTrait, g2,
 )
+    touches_partial(x) = touches(x, g2)
     for sub_g1 in GI.getgeom(g1)
-        !touches(sub_g1, g2) && return false
+        !touches_partial(sub_g1) && return false
     end
     return true
 end

--- a/src/methods/geom_relations/within.jl
+++ b/src/methods/geom_relations/within.jl
@@ -256,8 +256,9 @@ function _within(
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
     }, g2,
 )
+    within_partial(x) = within(g1, x)
     for sub_g2 in GI.getgeom(g2)
-        within(g1, sub_g2) && return true
+        within_partial(sub_g2) && return true
     end
     return false
 end
@@ -273,8 +274,9 @@ function _within(
     }, g1,
     ::GI.AbstractGeometryTrait, g2,
 )
+    within_partial(x) = within(x, g2)
     for sub_g1 in GI.getgeom(g1)
-        !within(sub_g1, g2) && return false
+        !within_partial(sub_g1) && return false
     end
     return true
 end

--- a/src/methods/polygonize.jl
+++ b/src/methods/polygonize.jl
@@ -157,13 +157,14 @@ function _polygonize(f, xs::AbstractVector{T}, ys::AbstractVector{T}, A::Abstrac
         found = false
         local firstnode, nextnodes, nodestatus
 
+        map_partial(x,y) = map(!=(typemax(first(x))) ∘ first, y)
         # Loop until we find a key that hasn't been removed,
         # decrementing nkeys as we go.
         while nkeys > 0
             # Take the first node from the array
             firstnode::T = edgekeys[nkeys]
             nextnodes = edges[firstnode]
-            nodestatus = map(!=(typemax(first(firstnode))) ∘ first, nextnodes)
+            nodestatus = map_partial(firstnode, nextnodes)
             if any(nodestatus)
                 found = true
                 break
@@ -195,7 +196,7 @@ function _polygonize(f, xs::AbstractVector{T}, ys::AbstractVector{T}, A::Abstrac
         while true
             # Find a node that matches the next node
             (c1, c2) = possiblenodes = edges[nextnode]
-            nodestatus = map(!=(typemax(first(firstnode))) ∘ first, possiblenodes)
+            nodestatus = map_partial(firstnode, possiblenodes)
             if nodestatus[2]
                 # When there are two possible node, 
                 # choose the node that is the furthest to the left

--- a/src/transformations/correction/geometry_correction.jl
+++ b/src/transformations/correction/geometry_correction.jl
@@ -47,12 +47,14 @@ application_level(gc::GeometryCorrection) = error("Not implemented yet for $(gc)
 function fix(geometry; corrections = GeometryCorrection[ClosedRing(),], kwargs...)
     traits = application_level.(corrections)
     final_geometry = geometry
+    reduce_partial(x) = reduce(∘, corrections[x])
+    apply_partial(x,y,z) = apply(x, y, z; kwargs...)
     for Trait in (GI.PointTrait, GI.MultiPointTrait, GI.LineStringTrait, GI.LinearRingTrait, GI.MultiLineStringTrait, GI.PolygonTrait, GI.MultiPolygonTrait)
         available_corrections = findall(x -> x == Trait, traits)
         isempty(available_corrections) && continue
         @debug "Correcting for $(Trait)"
-        net_function = reduce(∘, corrections[available_corrections])
-        final_geometry = apply(net_function, Trait, final_geometry; kwargs...)
+        net_function = reduce_partial(available_corrections)
+        final_geometry = apply_partial(net_function, Trait, final_geometry)
     end
     return final_geometry
 end

--- a/src/transformations/segmentize.jl
+++ b/src/transformations/segmentize.jl
@@ -188,9 +188,10 @@ function _segmentize(method::Union{LinearSegments, GeodesicSegments}, geom, T::U
     new_coords = NTuple{2, Float64}[]
     sizehint!(new_coords, GI.npoint(geom))
     push!(new_coords, (x1, y1))
+    _fill_linear_kernel!_partial(a,b,c,d) = _fill_linear_kernel!(method, new_coords, a, b, c, d)
     for coord in Iterators.drop(GI.getpoint(geom), 1)
         x2, y2 = GI.x(coord), GI.y(coord)
-        _fill_linear_kernel!(method, new_coords, x1, y1, x2, y2)
+        _fill_linear_kernel!_partial(x1, y1, x2, y2)
         x1, y1 = x2, y2
     end 
     return rebuild(geom, new_coords)

--- a/src/transformations/simplify.jl
+++ b/src/transformations/simplify.jl
@@ -393,8 +393,9 @@ value will be used, which might cause differences in results from other algorith
 function _find_max_squared_dist(points, start_idx, end_idx)
     max_idx = start_idx
     max_dist = zero(Float64)
+    _squared_distance_line_partial(x) = _squared_distance_line(Float64, points[x], points[start_idx], points[end_idx])
     for i in (start_idx + 1):(end_idx - 1)
-        d = _squared_distance_line(Float64, points[i], points[start_idx], points[end_idx])
+        d = _squared_distance_line_partial(i)
         if d > max_dist
             max_dist = d
             max_idx = i

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -64,21 +64,24 @@ end
 
 _to_edges!(edges::Vector, x, n) = _to_edges!(edges, trait(x), x, n)
 function _to_edges!(edges::Vector, ::GI.FeatureCollectionTrait, fc, n)
+    _to_edges!_partial(x,y) = _to_edges!(edges, x, y)
     for f in GI.getfeature(fc)
-        n = _to_edges!(edges, f, n)
+        n = _to_edges!_partial(f, n)
     end
 end
 _to_edges!(edges::Vector, ::GI.FeatureTrait, f, n) = _to_edges!(edges, GI.geometry(f), n)
 function _to_edges!(edges::Vector, ::GI.AbstractGeometryTrait, fc, n)
+    _to_edges!_partial(x,y) = _to_edges!(edges, x, y)
     for f in GI.getgeom(fc)
-        n = _to_edges!(edges, f, n)
+        n = _to_edges!_partial(f, n)
     end
 end
 function _to_edges!(edges::Vector, ::GI.AbstractCurveTrait, geom, n)
     p1 = GI.getpoint(geom, 1) 
     p1x, p1y = GI.x(p1), GI.y(p1)
+    getpoint_partial(x) = GI.getpoint(geom, x)
     for i in 2:GI.npoint(geom)
-        p2 = GI.getpoint(geom, i)
+        p2 = getpoint_partial(i)
         p2x, p2y = GI.x(p2), GI.y(p2)
         edges[n] = (p1x, p1y), (p2x, p2y)
         p1x, p1y = p2x, p2y
@@ -103,14 +106,16 @@ end
 
 _to_points!(points::Vector, x, n) = _to_points!(points, trait(x), x, n)
 function _to_points!(points::Vector, ::FeatureCollectionTrait, fc, n)
+    _to_points!_partial(x,y) = _to_points!(points, x, y)
     for f in GI.getfeature(fc)
-        n = _to_points!(points, f, n)
+        n = _to_points!_partial(f, n)
     end
 end
 _to_points!(points::Vector, ::FeatureTrait, f, n) = _to_points!(points, GI.geometry(f), n)
 function _to_points!(points::Vector, ::AbstractGeometryTrait, fc, n)
+    _to_points!_partial(x,y) = _to_points!(points, x, y)
     for f in GI.getgeom(fc)
-        n = _to_points!(points, f, n)
+        n = _to_points!_partial(f, n)
     end
 end
 function _to_points!(points::Vector, ::Union{AbstractCurveTrait,MultiPointTrait}, geom, n)


### PR DESCRIPTION
I went through all the files in `src/*`, and curried functions that were repeatedly used within a while or for loop outside of an if statement. I've tried to have some form of literate programming by maintaining the naming convention and appending `_partial`. I did not add comments, since it seemed somewhat straightforward what was going on. I would be more than happy to add comments if you will tell me what you would like me to explain. This should address #148 . 