### PR TITLE
Create a `PolygonContents` fix that fixes the contents of polygons to be linear rings

### DIFF
--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -60,6 +60,7 @@ include("transformations/transform.jl")
 include("transformations/correction/geometry_correction.jl")
 include("transformations/correction/closed_ring.jl")
 include("transformations/correction/intersecting_polygons.jl")
+include("transformations/correction/polygon_contents.jl")
 
 # Import all names from GeoInterface and Extents, so users can do `GO.extent` or `GO.trait`.
 for name in names(GeoInterface)

--- a/src/transformations/correction/geometry_correction.jl
+++ b/src/transformations/correction/geometry_correction.jl
@@ -44,7 +44,18 @@ application_level(gc::GeometryCorrection) = error("Not implemented yet for $(gc)
 
 (gc::GeometryCorrection)(trait::GI.AbstractGeometryTrait, geometry) = error("Not implemented yet for $(gc) and $(trait).")
 
-function fix(geometry; corrections = GeometryCorrection[ClosedRing(),], kwargs...)
+"""
+    fix(x; corrections = GeometryCorrection[], kwargs...)
+
+Apply the given corrections to `x`, and return the corrected version.
+
+`x` may be a geometry, vector of geometries, feature collection, or table - 
+anything which [`apply`](@ref) will accept!
+
+Some available corrections are: [`ClosedRing`](@ref), [`PolygonContents`](@ref), [`UnionIntersectingPolygons`](@ref), [`DiffIntersectingPolygons`](@ref).
+
+"""
+function fix(geometry; corrections = GeometryCorrection[PolygonContents(), ClosedRing(),], kwargs...)
     traits = application_level.(corrections)
     final_geometry = geometry
     for Trait in (GI.PointTrait, GI.MultiPointTrait, GI.LineStringTrait, GI.LinearRingTrait, GI.MultiLineStringTrait, GI.PolygonTrait, GI.MultiPolygonTrait)

--- a/src/transformations/correction/polygon_contents.jl
+++ b/src/transformations/correction/polygon_contents.jl
@@ -1,0 +1,33 @@
+# # PolygonContents
+
+export PolygonContents
+
+#=
+Polygons should only contain linear rings.  This fix checks
+whether the contents of the polygon are linear rings or linestrings,
+and converts linestrings to linear rings.
+
+It does **NOT** check whether the linear rings are valid - it only checks
+the types of the polygon's constituent geometries.  You can use the [`ClosedRing`](@ref)
+geometry fix to check for validity after applying this fix.
+=#
+
+struct PolygonContents <: GeometryCorrection end
+
+application_level(::PolygonContents) = GI.PolygonTrait
+
+function (::PolygonContents)(::GI.PolygonTrait, polygon)
+    exterior = GI.getexterior(polygon)
+    fixed_exterior = _ls2lr(exterior)
+    holes = GI.gethole(polygon)
+    if isempty(holes)
+        return GI.Polygon([fixed_exterior])
+    end
+    fixed_holes = _ls2lr.(holes)
+    return GI.Polygon([fixed_exterior, fixed_holes...])
+end
+
+_ls2lr(x) = _ls2lr(GI.geomtrait(x), x)
+
+_ls2lr(::GI.LineStringTrait, x) = GI.LinearRing(GI.getpoint(x))
+_ls2lr(::GI.LinearRingTrait, x) = x


### PR DESCRIPTION
I run into this issue a lot when trying to union polygons from different packages or even `GO.tuples(wkt)`.

This PR introduces a correction that fixes that, and also integrates it into the cases of `_union` that I hit.  I haven't looked for all of the places this could go but I imagine there are quite a few.  

TODOs:
- [ ] Tests
- [ ] Test the cases that failed for me