### PR TITLE
fix testset string interpolation

### DIFF
--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -92,7 +92,7 @@ function _testset_implementations_inner(title, modules::Union{Expr,Vector}, code
         testset = Expr(
             :macrocall, 
             Symbol("@testset"), 
-            LineNumberNode(95, @__FILE__), 
+            LineNumberNode(@__LINE__, @__FILE__), 
             Expr(:string, mod, " ", title), 
             code1
         )

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -67,7 +67,7 @@ macro testset_implementations(code::Expr)
     _testset_implementations_inner("", TEST_MODULES, code)
 end
 macro testset_implementations(arg, code::Expr)
-    if arg isa Union{String,Symbol} || arg isa Expr && arg.head == :string
+    if arg isa String || arg isa Expr && arg.head == :string
         _testset_implementations_inner(arg, TEST_MODULES, code)
     else
         _testset_implementations_inner("", arg, code)


### PR DESCRIPTION
Adds some manual macro and string definitions so the nested string interpolation in `@testset_implementations` actually works.

@asinghvi17 lets quick merge this and rebase your other PR. I've tested locally that string implementation prints messages correctly now but its kind of annoying to actually test that it works.