### PR TITLE
Add DataAPI metadata passthrough to `apply`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.11"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DelaunayTriangulation = "927a84f5-c5f4-47a5-9785-b46e178433df"
 ExactPredicates = "429591f6-91af-11e9-00e2-59fbe8cec110"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"

--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -6,7 +6,7 @@ using GeoInterface
 using GeometryBasics
 using LinearAlgebra, Statistics
 
-import Tables
+import Tables, DataAPI
 import GeometryBasics.StaticArrays
 import DelaunayTriangulation # for convex hull and triangulation
 import ExactPredicates

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -202,12 +202,41 @@ function _apply_table(f::F, target, iterable::IterableType; threaded, kw...) whe
     new_names = filter(Base.Fix1(!==, geometry_column), old_schema.names)
     # and try to rebuild the same table as the best type - either the original type of `iterable`,
     # or a named tuple which is the default fallback.
-    return Tables.materializer(iterable)(
+    result = Tables.materializer(iterable)(
         merge(
             NamedTuple{(geometry_column,), Base.Tuple{typeof(new_geometry)}}((new_geometry,)),
             NamedTuple(Iterators.map(_get_col_pair, new_names))
         )
     )
+    # Finally, we ensure that metadata is propagated correctly.
+    # This can only happen if the original table supports metadata reads,
+    # and the result supports metadata writes.
+    if DataAPI.metadatasupport(IterableType).read && DataAPI.metadatasupport(typeof(result)).write
+        for (key, (value, style)) in DataAPI.metadata(iterable; style = true)
+            # Default styles are not preserved on data transformation, so we must skip them!
+            style == :default && continue
+            # We assume that any other style is preserved.
+            DataAPI.metadata!(result, key, value; style)
+        end
+        # Ensure that `GEOINTERFACE:geometrycolumns` and `GEOINTERFACE:crs` are set!
+        mdk = DataAPI.metadatakeys(result)
+        # If the user has asked for geometry columns to persist, they would be here,
+        # so we don't need to set them.
+        if !("GEOINTERFACE:geometrycolumns" in mdk)
+            # If the geometry columns are not already set, we need to set them.
+            DataAPI.metadata!(result, "GEOINTERFACE:geometrycolumns", (geometry_column,); style = :default)
+        end
+        # Force reset CRS always, since you can pass `crs` to `apply`.
+        new_crs = if haskey(kw, :crs)
+            kw[:crs]
+        else
+            GI.crs(iterable)
+        end
+
+        DataAPI.metadata!(result, "GEOINTERFACE:crs", new_crs; style = :default)
+    end
+
+    return result
 end
 
 # Rewrap all FeatureCollectionTrait feature collections as GI.FeatureCollection


### PR DESCRIPTION
This PR propagates all non-`:default` style metadata through to the result table in `apply` on tables, if:
- there is metadata that can be read in the input table
- the result table type supports metadata writes (so not a named tuple table, for example)

This PR also adds `GEOINTERFACE:geometrycolumns` and `GEOINTERFACE:crs` tags to the resulting table, and ensures that the CRS is correct according to:
a. the `crs` kwarg to `apply`
if that is not present,
b. `GI.crs(input_table)`

this way, `GO.reproject` automatically changes the table metadata too!

