### PR TITLE
Fix `overlaps` on polygons that only interact at vertices

### DIFF
--- a/src/methods/geom_relations/overlaps.jl
+++ b/src/methods/geom_relations/overlaps.jl
@@ -55,7 +55,7 @@ const OVERLAPS_POINT_ALLOWS = (in_allow = true, on_allow = true, out_allow = tru
 const OVERLAPS_CURVE_ALLOWS = (over_allow = true, cross_allow = true, on_allow = true, out_allow = true)
 const OVERLAPS_POLYGON_ALLOWS = (in_allow = true, on_allow = true, out_allow = true)
 const OVERLAPS_REQUIRES = (in_require = true, on_require = false, out_require = false)
-const OVERLAPS_EXACT = (exact = _False(),)
+const OVERLAPS_EXACT = (exact = False(),)
 
 
 """

--- a/src/methods/geom_relations/overlaps.jl
+++ b/src/methods/geom_relations/overlaps.jl
@@ -138,6 +138,10 @@ outside of the other line, return true. Else false.
 overlaps(::GI.LineTrait, line1, ::GI.LineTrait, line) =
     _overlaps((a1, a2), (b1, b2))
 
+# The code below is more robust, 
+# but fails when a linestring is contained within another linestring.
+# TODO: make this work better, maybe with full de9im support...
+#=
 """
     overlaps(
         ::Union{GI.LineStringTrait, GI.LinearRing}, line1,
@@ -184,6 +188,22 @@ function overlaps(
         closed_line = false,
         closed_curve = true,
     )
+end
+
+=#
+# This is the old code which was previously working.
+
+function overlaps(
+    ::Union{GI.LineStringTrait, GI.LinearRingTrait}, line1,
+    ::Union{GI.LineStringTrait, GI.LinearRingTrait}, line2,
+)
+    edges_a, edges_b = map(sort! ∘ to_edges, (line1, line2))
+    for edge_a in edges_a
+        for edge_b in edges_b
+            _overlaps(edge_a, edge_b) && return true
+        end
+    end
+    return false
 end
 
 function overlaps(

--- a/test/methods/geom_relations.jl
+++ b/test/methods/geom_relations.jl
@@ -55,6 +55,11 @@ p10 = LG.Polygon([
     [[0.15, 0.55], [0.15, 0.95], [0.55, 0.95], [0.55, 0.55], [0.15, 0.55]]
 ])
 p11 = LG.Polygon(r3)
+"Rectangle going from 0,0 to 1,1"
+p12 = GI.Polygon([Tuple{Float64, Float64}[(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]])
+"Pentagon - take a rectangle going from (1, 0) to (2, 1), and add a point at (0.5, 0.5)"
+p13 = GI.Polygon([Tuple{Float64, Float64}[(1, 0), (2, 0), (2, 1), (1, 1), (0.5, 0.5),  (1, 0)]])
+
 
 mpt1 = LG.MultiPoint([pt1, pt2])
 mpt2 = LG.MultiPoint([pt2, pt3])
@@ -149,6 +154,7 @@ test_pairs = [
     (p6, p1, "p6", "p1", "Polygon inside of other polygon's hole"),
     (p7, p1, "p7", "p1", "Polygons overlap"),
     (p10, p1, "p10", "p1", "Polygon's with nested holes"),
+    (p12, p13, "p12", "p13", "Polygons only intersect at vertices, but intersect and overlap"),
     # Multigeometries
     (mpt1, mpt1, "mpt1", "mpt1", "Same set of points for multipoints"),
     (mpt1, mpt2, "mpt1", "mpt2", "Some point matches, others are different"),


### PR DESCRIPTION
Overlaps failed for a polygon like this (see the changes to `test` for the polygons), where the polygons overlap but only intersect at vertices (so every line-line intersection is a hinge intersection)
![display](https://github.com/user-attachments/assets/338c291a-8e83-438a-ae90-76c9d0c20816)
this PR attempts to move the implementation to the geom_geom_processor interface.  Still fails for lines where one line covers another.  Maybe I need some adjustments to the allows/requires?

cc @skygering 