### PR TITLE
Add a utility function to GeometryOpsCore, to get geometries from any data structure

### DIFF
--- a/GeometryOpsCore/src/geometry_utils.jl
+++ b/GeometryOpsCore/src/geometry_utils.jl
@@ -1,3 +1,35 @@
 
 _linearring(geom::GI.LineString) = GI.LinearRing(parent(geom); extent=geom.extent, crs=geom.crs)
 _linearring(geom::GI.LinearRing) = geom
+
+
+function get_geometries(x)
+    if GI.isgeometry(x)
+        return x
+    # elseif GI.isgeometrycollection(x)
+    #     return GI.getgeom(x)
+    elseif GI.isfeature(x)
+        return GI.geometry(x)
+    elseif GI.isfeaturecollection(x)
+        return [GI.geometry(f) for f in GI.getfeature(x)]
+    elseif Tables.istable(x) && Tables.hascolumn(x, first(GI.geometrycolumns(x)))
+        return Tables.getcolumn(x, first(GI.geometrycolumns(x)))
+    else
+        c = collect(x)
+        if c isa AbstractArray && GI.trait(first(c)) isa GI.AbstractGeometryTrait
+            return c
+        else
+            throw(ArgumentError("""
+                Expected a geometry, feature, feature collection, table with geometry column, or iterable of geometries.
+                Got $(typeof(x)).
+                
+                The input must be one of:
+                - A GeoInterface geometry (has trait <: AbstractGeometryTrait)
+                - A GeoInterface feature (has trait FeatureTrait) 
+                - A GeoInterface feature collection (has trait FeatureCollectionTrait)
+                - A Tables.jl table with a geometry column
+                - An iterable containing geometries
+                """))
+        end
+    end
+end


### PR DESCRIPTION
a generic utility inspired by similar functions in Rasters.jl and elsewhere - returns a vector of the geometries in a given object, be it a feature collection, table, iterable of geometries, or whatever.

Potential next steps:
- `get_geometries(x) do geom` that rebuilds the given structure as far as possible - this is the same as `apply(::AbstractGeometryTrait)` though....
- treatment of dataframes with multiple columns

Also: do we want this here?  in GeoInterface?