### PR TITLE
Better tests and testsets

### DIFF
--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -89,8 +89,10 @@ function _testset_implementations_inner(title, modules::Union{Expr,Vector}, code
         # Manually define the testset macrocall and all string interpolation
         # This instantiates a ContextTestSet that holds the contents of the let block as "context"
         # and displays it as:
-        #   Expression: compare_GO_LG_clipping(GO_f, LG_f, p1, p2)
-        #   Context: GEOMETRY_MODULE = GeoInterface
+        # ```
+        # Expression: compare_GO_LG_clipping(GO_f, LG_f, p1, p2)
+        # Context: Testing geometry from module = GeoInterface
+        # ```
         # This is a bit of a hack to get around the 90000 different testsets you see if we did this
         # per testset.
         # Ideally, we'd have a custom testset that can (a) display whether the test failed for _every_ geom
@@ -100,7 +102,7 @@ function _testset_implementations_inner(title, modules::Union{Expr,Vector}, code
             :macrocall, 
             Symbol("@testset"), 
             LineNumberNode(@__LINE__, @__FILE__), 
-            Expr(:let, :(GEOMETRY_MODULE=$(mod)), code1),
+            Expr(:let, :(var"Testing geometry from module"=$(mod)), code1),
         )
         push!(expr.args, testset)
         push!(testsets.args, expr)


### PR DESCRIPTION
This stops the testset spam, or at least reduces it, by using context instead.  `@testset let ...` creates a special testset that doesn't instantiate itself, meaning that each `@testset_implementations` is a single testset, not four testsets wearing a hoodie.

Output now looks like this:
```julia
p50 union p51 - Intersection polygons with opposite winding orders and repeated points: Test Failed at /Users/anshul/.julia/dev/geo/GeometryOps.jl/test/methods/clipping/polygon_clipping.jl:209
  Expression: compare_GO_LG_clipping(GO_f, LG_f, p1, p2)
     Context: Testing geometry from module = GeoInterface
```

and
```
 Union                                                                                                                          |  188     4    192  1.4s
    p1 union p1 - Same polygon                                                                                                   |    4            4  0.1s
    p1 union p2 - Convex polygons that intersect (diamonds, four vertices)                                                       |    4            4  0.0s
    p3 union p4 - Convex polygons that intersect (randomly generated, many edges)                                                |    4            4  0.0s
    p5 union p6 - Convex polygons that intersect (randomly generated, many edges)                                                |    4            4  0.0s
    p7 union p8 - Concave polygons that intersect (randomly generated, many edges)                                               |    4            4  0.0s
    p5 union p7 - Convex and concave polygons intersect                                                                          |    4            4  0.0s
    p9 union p10 - Figure 10 from Greiner Hormann paper                                                                          |    4            4  0.0s
```

which is substantially better than what we had before.

This also adds a module that densifies geoms when converting to its own geomtype (:O) so we can test the strtree stuff.