### PR TITLE
AdaptivePredicates + minor predicate fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Anshul Singhvi <anshulsinghvi@gmail.com>", "Rafael Schouten <rafaels
 version = "0.1.15"
 
 [deps]
+AdaptivePredicates = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DelaunayTriangulation = "927a84f5-c5f4-47a5-9785-b46e178433df"
@@ -30,6 +31,7 @@ GeometryOpsProjExt = "Proj"
 GeometryOpsTGGeometryExt = "TGGeometry"
 
 [compat]
+AdaptivePredicates = "1.2"
 CoordinateTransformations = "0.5, 0.6"
 DataAPI = "1"
 DelaunayTriangulation = "1.0.4"

--- a/src/methods/clipping/predicates.jl
+++ b/src/methods/clipping/predicates.jl
@@ -4,15 +4,17 @@ module Predicates
     import ExactPredicates.Codegen: group!, @genpredicate
     import GeometryOps: False, True, booltype, _tuple_point
     import GeoInterface as GI
+    import AdaptivePredicates
 
     #= Determine the orientation of c with regards to the oriented segment (a, b).
     Return 1 if c is to the left of (a, b).
     Return -1 if c is to the right of (a, b).
     Return 0 if c is on (a, b) or if a == b. =#
-    orient(a, b, c; exact) = _orient(booltype(exact), a, b, c)
+    orient(a, b, c; exact) = _orient(booltype(exact), _tuple_point(a, Float64), _tuple_point(b, Float64), _tuple_point(c, Float64))
     
     # If `exact` is `true`, use `ExactPredicates` to calculate the orientation.
-    _orient(::True, a, b, c) = ExactPredicates.orient(_tuple_point(a, Float64), _tuple_point(b, Float64), _tuple_point(c, Float64))
+    _orient(::True, a, b, c) = AdaptivePredicates.orient2p(_tuple_point(a, Float64), _tuple_point(b, Float64), _tuple_point(c, Float64))
+    # _orient(::True, a, b, c) = ExactPredicates.orient(_tuple_point(a, Float64), _tuple_point(b, Float64), _tuple_point(c, Float64))
     # If `exact` is `false`, calculate the orientation without using `ExactPredicates`.
     function _orient(exact::False, a, b, c)
         a = a .- c

--- a/src/methods/geom_relations/geom_geom_processors.jl
+++ b/src/methods/geom_relations/geom_geom_processors.jl
@@ -505,7 +505,7 @@ function _point_filled_curve_orientation(
         v2 = GI.y(p_end) - y
         if !((v1 < 0 && v2 < 0) || (v1 > 0 && v2 > 0)) # if not cases 11 or 26
             u1, u2 = GI.x(p_start) - x, GI.x(p_end) - x
-            f = Predicates.cross((u1, u2), (v1, v2); exact)
+            f = Predicates.orient(p_start, p_end, (x, y); exact)
             if v2 > 0 && v1 ≤ 0                # Case 3, 9, 16, 21, 13, or 24
                 f == 0 && return on         # Case 16 or 21
                 f > 0 && (k += 1)              # Case 3 or 9


### PR DESCRIPTION
Spun out from #259

- Add AdaptivePredicates as the exact backend for orient.  At some point we should switch to an ecosystem wide (DelaunayTriangulation + GeometryOps + ...) representation for predicate kernels (Exact, Adaptive, Auto (choose adaptive if available and exact if not), and Fast).
- Fix touches for multi geometries