### PR TITLE
Remove conflicting `simplify()` method definition

### DIFF
--- a/src/transformations/simplify.jl
+++ b/src/transformations/simplify.jl
@@ -161,7 +161,6 @@ GI.npoint(simple)
 ```
 """
 simplify(alg::SimplifyAlg, data; kw...) = _simplify(alg, data; kw...)
-simplify(alg::GEOS, data; kw...) = _simplify(alg, data; kw...)
 
 # Default algorithm is DouglasPeucker
 simplify(


### PR DESCRIPTION
Working on creating custom sysimage for my own package and I think I am blocked by an issue where a GeometryOp extension fails to fully compile due to a clashing method definition.

See below.

```julia-repl
julia> using LibGEOS

julia> using GeometryOps
Precompiling GeometryOps...
  1 dependency successfully precompiled in 3 seconds. 56 already precompiled.
Precompiling GeometryOpsLibGEOSExt...
Info Given GeometryOpsLibGEOSExt was explicitly requested, output will be shown live
WARNING: Method definition simplify(GeometryOps.GEOS, Any) in module GeometryOps at C:\Users\...\projects\GeometryOps.jl\src\transformations\simplify.jl:164 overwritten in module GeometryOpsLibGEOSExt at C:\Users\...\projects\GeometryOps.jl\ext\GeometryOpsLibGEOSExt\simplify.jl:41.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
  ? GeometryOps → GeometryOpsLibGEOSExt
[ Info: Precompiling GeometryOpsLibGEOSExt [86ce28eb-7010-5088-b8ab-bf1ec09961f6] (cache misses: wrong dep version loaded (10), incompatible header (10))
WARNING: Method definition simplify(GeometryOps.GEOS, Any) in module GeometryOps at C:\Users\...\projects\GeometryOps.jl\src\transformations\simplify.jl:164 overwritten in module GeometryOpsLibGEOSExt at C:\Users\...\projects\GeometryOps.jl\ext\GeometryOpsLibGEOSExt\simplify.jl:41.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
┌ Info: Skipping precompilation due to precompilable error. Importing GeometryOpsLibGEOSExt [86ce28eb-7010-5088-b8ab-bf1ec09961f6].
└   exception = Error when precompiling module, potentially caused by a __precompile__(false) declaration in the module.
```

Removing the indicated line resolves the warnings above. I have run tests locally and (those that are not marked as broken) they all pass.

Although a few more warnings get thrown:

```julia-repl
Precompiling project for configuration --code-coverage=none --color=yes --check-bounds=yes --warn-overwrite=yes --depwarn=yes --inline=yes --startup-file=no --track-allocation=none...
  140 dependencies successfully precompiled in 172 seconds. 130 already precompiled.
  1 dependency had output during precompilation:
┌ DimensionalData
│  ┌ Warning: `dimsymbols(x)` is deprecated, use `dimsymbol(x)` instead.
│  │   caller = show(io::IOContext{IOBuffer}, mime::MIME{Symbol("text/plain")}, x::DimensionalData.ShowWith; kw::Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}) at show.jl:282
│  └ @ DimensionalData C:\Users\...\.julia\packages\DimensionalData\KlTtO\src\array\show.jl:282
│  ┌ Warning: `dimsymbols(x)` is deprecated, use `dimsymbol(x)` instead.
│  │   caller = show(io::IOContext{IOBuffer}, mime::MIME{Symbol("text/plain")}, x::DimensionalData.ShowWith; kw::Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}) at show.jl:284
│  └ @ DimensionalData C:\Users\...\.julia\packages\DimensionalData\KlTtO\src\array\show.jl:284
└  
     Testing Running tests...
WARNING: Method definition ncoord(GeoInterface.MultiLineStringTrait, GeometryBasics.MultiLineString{N, T} where T<:Real) where {N} in module GeometryBasics at C:\Users\...\.julia\packages\GeometryBasics\Tr4ca\src\geointerface.jl:68 overwritten at C:\Users\...\projects\GeometryOps.jl\test\helpers.jl:17.
WARNING: Method definition geointerface_geomtype(GeoInterface.LineTrait) in module GeometryBasics at C:\Users\...\.julia\packages\GeometryBasics\Tr4ca\src\geointerface.jl:28 overwritten at C:\Users\...\projects\GeometryOps.jl\test\helpers.jl:25.
WARNING: Method definition convert(Type{GeometryBasics.LineString{Dim, T} where T<:Real where Dim}, GeoInterface.LineStringTrait, GeoInterface.Wrappers.LinearRing{false, false, StaticArraysCore.SArray{Tuple{N}, Tuple{Float64, Float64}, 1, N}, Nothing, Nothing} where N) in module GeometryBasics at C:\Users\...\projects\GeometryOps.jl\test\helpers.jl:37 overwritten at C:\Users\...\projects\GeometryOps.jl\test\helpers.jl:45.
```

