### PR TITLE
Fix type constraint in _smooth function

### DIFF
--- a/src/transformations/smooth.jl
+++ b/src/transformations/smooth.jl
@@ -94,7 +94,7 @@ end
 _smooth(alg, ::GI.PointTrait, geom) = geom
 _smooth(alg, ::GI.MultiPointTrait, geom) = geom
 
-function _smooth(alg::Chaikin{<: Planar}, trait::Trait, geom) where {M, Trait <: Union{GI.LineStringTrait,GI.LinearRingTrait}}
+function _smooth(alg::Chaikin{<: Planar}, trait::Trait, geom) where {Trait <: Union{GI.LineStringTrait,GI.LinearRingTrait}}
     isring = Trait <: GI.LinearRingTrait
     points = tuple_points(geom)
     if isring && first(points) != last(points)


### PR DESCRIPTION
Got this warning

```julia
Precompiling project...
  110 dependencies successfully precompiled in 189 seconds. 420 already precompiled.
  1 dependency had output during precompilation:
┌ GeometryOps
│  WARNING: method definition for _smooth at /Users/milan/.julia/packages/GeometryOps/6jExF/src/transformations/smooth.jl:97 declares type variable M but does not use it.
└
```