### PR TITLE
Get the right version of ArchGDAL in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,6 +36,7 @@ GeometryOpsProjExt = "Proj"
 GeometryOpsTGGeometryExt = "TGGeometry"
 
 [compat]
+ArchGDAL = "0.10.10"
 AbstractTrees = "0.4"
 AdaptivePredicates = "1.2"
 CoordinateTransformations = "0.5, 0.6"


### PR DESCRIPTION
For some reason the test resolver gets old versions of AG that pull in GeoInterfaceRecipes and GeoInterfaceMakie.  We don't want to change the GI compat but we can change the AG compat to force a version that doesn't have those