### PR TITLE
Fix off-by-one indexing bug in DouglasPeucker simplify

### DIFF
--- a/src/transformations/simplify.jl
+++ b/src/transformations/simplify.jl
@@ -301,7 +301,7 @@ function _simplify(alg::DouglasPeucker, points::Vector, preserve_endpoint)
     i = 2  # already have first and last point added
     start_idx, end_idx = 1, npoints
     max_idx, max_dist = _find_max_squared_dist(points, start_idx, end_idx)
-    while i ≤ min(MIN_POINTS + 1, max_points) || (i < max_points && max_dist > max_tol)
+    while i < min(MIN_POINTS + 1, max_points) || (i < max_points && max_dist > max_tol)
         # Add next point to results
         i += 1
         results[i] = max_idx

--- a/test/transformations/simplify.jl
+++ b/test/transformations/simplify.jl
@@ -21,6 +21,18 @@ datadir = realpath(joinpath(dirname(pathof(GO)), "../test/data"))
 end
 
 @testset "DouglasPeucker" begin
+    # Test for issue #386: BoundsError when simplifying small geometries with low number/ratio
+    @testset "small geometry simplification (issue #386)" begin
+        # This would cause a BoundsError before the fix due to indexing bug in the while loop
+        line = GI.LineString([(rand(), rand()) for _ in 1:4])
+        @test_nowarn GO.simplify(line; ratio=0.1)
+        @test_nowarn GO.simplify(line; tol=0.1)
+        @test_nowarn GO.simplify(line; number=3)
+        # Verify the output is valid
+        result = GO.simplify(line; number=3)
+        @test GI.npoint(result) == 3
+    end
+
     poly_coords = JLD2.jldopen(joinpath(datadir, "complex_polygons.jld2"))["verts"][1:4]
     for c in poly_coords
         npoints = length(c[1])

--- a/test/transformations/simplify.jl
+++ b/test/transformations/simplify.jl
@@ -23,12 +23,10 @@ end
 @testset "DouglasPeucker" begin
     # Test for issue #386: BoundsError when simplifying small geometries with low number/ratio
     @testset "small geometry simplification (issue #386)" begin
-        # This would cause a BoundsError before the fix due to indexing bug in the while loop
-        line = GI.LineString([(rand(), rand()) for _ in 1:4])
-        @test_nowarn GO.simplify(line; ratio=0.1)
-        @test_nowarn GO.simplify(line; tol=0.1)
-        @test_nowarn GO.simplify(line; number=3)
-        # Verify the output is valid
+        # Fixed coords to ensure deterministic test; these would cause a BoundsError before the fix
+        line = GI.LineString([(0.0, 0.0), (1.0, 0.5), (2.0, 0.0), (3.0, 1.0)])
+        @test GI.npoint(GO.simplify(line; ratio=0.1)) >= 3
+        @test GI.npoint(GO.simplify(line; tol=0.1)) >= 3
         result = GO.simplify(line; number=3)
         @test GI.npoint(result) == 3
     end

--- a/test/transformations/simplify.jl
+++ b/test/transformations/simplify.jl
@@ -23,10 +23,11 @@ end
 @testset "DouglasPeucker" begin
     # Test for issue #386: BoundsError when simplifying small geometries with low number/ratio
     @testset "small geometry simplification (issue #386)" begin
-        # Fixed coords to ensure deterministic test; these would cause a BoundsError before the fix
         line = GI.LineString([(0.0, 0.0), (1.0, 0.5), (2.0, 0.0), (3.0, 1.0)])
-        @test GI.npoint(GO.simplify(line; ratio=0.1)) >= 3
-        @test GI.npoint(GO.simplify(line; tol=0.1)) >= 3
+        @test_nowarn GO.simplify(line; ratio=0.1)
+        @test_nowarn GO.simplify(line; tol=0.1)
+        @test_nowarn GO.simplify(line; number=3)
+        # Verify the output is valid
         result = GO.simplify(line; number=3)
         @test GI.npoint(result) == 3
     end


### PR DESCRIPTION
## Summary

- Fix BoundsError when simplifying small geometries with low `number` or `ratio` values
- Add regression test for issue #386

## Problem

In the DouglasPeucker `_simplify` function, the while loop condition:
```julia
while i ≤ min(MIN_POINTS + 1, max_points) || (i < max_points && max_dist > max_tol)
```
allowed `i` to equal `max_points` and enter the loop. Then `i += 1` would make `i = max_points + 1`, causing `results[i]` to be out of bounds since the array is sized for exactly `max_points` elements.

## Fix

Changed `i ≤` to `i <` in the first part of the condition:
```julia
while i < min(MIN_POINTS + 1, max_points) || (i < max_points && max_dist > max_tol)
```

## Test plan

- [x] Added test case that reproduces the bug with small geometries
- [x] All existing simplify tests pass

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)