### PR TITLE
Fix missing p_start update in hinge midpoint loop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometryOps"
 uuid = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"
 authors = ["Anshul Singhvi <anshulsinghvi@gmail.com>", "Rafael Schouten <rafaelschouten@gmail.com>", "Skylar Gering <skygering@gmail.com>", "and contributors"]
-version = "0.1.38"
+version = "0.1.39"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/methods/geom_relations/geom_geom_processors.jl
+++ b/src/methods/geom_relations/geom_geom_processors.jl
@@ -627,6 +627,7 @@ function _line_filled_curve_interactions(
                             elseif mid_val == point_out
                                 out_curve = true
                             end
+                            p_start = p_end
                         end
                         # already checked segment against whole filled curve
                         l_start = l_end

--- a/test/methods/geom_relations.jl
+++ b/test/methods/geom_relations.jl
@@ -57,6 +57,9 @@ p10 = LG.Polygon([
     [[0.15, 0.55], [0.15, 0.95], [0.55, 0.95], [0.55, 0.55], [0.15, 0.55]]
 ])
 p11 = LG.Polygon(r3)
+# Polygon with interior notch sharing collinear edges with a rectangle (issue #396)
+p12 = LG.Polygon([[[0.0, 0.0], [0.0, 4.0], [8.0, 4.0], [8.0, 0.0], [0.0, 0.0]]])
+p13 = LG.Polygon([[[0.0, 0.0], [0.0, 2.0], [7.0, 1.0], [7.0, 3.0], [0.0, 3.0], [0.0, 4.0], [8.0, 4.0], [8.0, 0.0], [0.0, 0.0]]])
 
 mpt1 = LG.MultiPoint([pt1, pt2])
 mpt2 = LG.MultiPoint([pt2, pt3])
@@ -157,6 +160,8 @@ test_pairs = [
     (p6, p1, "p6", "p1", "Polygon inside of other polygon's hole"),
     (p7, p1, "p7", "p1", "Polygons overlap"),
     (p10, p1, "p10", "p1", "Polygon's with nested holes"),
+    (p12, p13, "p12", "p13", "Rectangle with polygon with collinear notch (#396)"),
+    (p13, p12, "p13", "p12", "Polygon with collinear notch inside rectangle (#396)"),
     # Multigeometries
     (mpt1, mpt1, "mpt1", "mpt1", "Same set of points for multipoints"),
     (mpt1, mpt2, "mpt1", "mpt2", "Some point matches, others are different"),


### PR DESCRIPTION
## Summary

- Fixes a bug where `_line_filled_curve_interactions` failed to advance `p_start` in the `line_hinge` midpoint-checking loop, causing all midpoints to be computed from the original line start instead of between consecutive intersection points
- This caused `within` (and potentially other DE-9IM predicates) to return incorrect results when polygon edges were collinear with the boundary of another polygon containing a notch/indentation

## Details

The hinge handler splits a line segment at all intersection points with a curve, then checks the midpoint of each sub-segment to determine if it's inside, on, or outside the filled curve. Without advancing `p_start`, the midpoints were wrong — for example, a midpoint that should have been `(0, 2.5)` (outside the polygon) was instead computed as `(0, 3.0)` (on the boundary), so the "outside" flag was never set.

The fix is a single line: `p_start = p_end` at the end of the loop body.

Fixes #396

## Test plan

- [x] All existing tests pass (17,000+ tests)
- [x] Verify the MWE from #396 returns correct results
- [x] Consider adding a regression test for this case

🤖 Generated with [Claude Code](https://claude.com/claude-code)