### PR TITLE
Make `_contains(::SphericalCap, ::SphericalCap)` inclusive

### DIFF
--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -104,8 +104,10 @@ _disjoint(x::SphericalCap, y::SphericalCap) = !_intersects(x, y)
 
 function _contains(big::SphericalCap, small::SphericalCap)
     dist = spherical_distance(big.point, small.point)
-    # small circle fits in big circle
-    return dist + small.radius < big.radius 
+    # small circle fits in big circle; `<=` so internally-tangent small
+    # caps count as contained, matching the point overload below and
+    # S2's `S2Cap::Contains(const S2Cap&)` convention.
+    return dist + small.radius <= big.radius
 end
 function _contains(cap::SphericalCap, point::UnitSphericalPoint)
     spherical_distance(cap.point, point) <= cap.radius

--- a/test/utils/unitspherical.jl
+++ b/test/utils/unitspherical.jl
@@ -117,7 +117,7 @@ end
         # Test containment
         big_cap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π/2)
         small_cap = SphericalCap(UnitSphericalPoint(1/√2, 1/√2, 0.0), π/4)
-        @test_broken UnitSpherical._contains(big_cap, small_cap)
+        @test UnitSpherical._contains(big_cap, small_cap)
         @test !UnitSpherical._contains(small_cap, big_cap)
     end
 


### PR DESCRIPTION
## Summary

- Change `_contains(::SphericalCap, ::SphericalCap)` at `src/utils/UnitSpherical/cap.jl:108` from strict `<` to `<=`, so internally-tangent small caps count as contained.
- Matches the convention of the sibling `_contains(::SphericalCap, ::UnitSphericalPoint)` method (`cap.jl:111`) and [S2's `S2Cap::Contains(const S2Cap&)`](https://github.com/google/s2geometry/blob/a4f0cf58a9cfc214585c39de6e3682384fac0917/src/s2/s2cap.cc).
- Flip the pre-existing `@test_broken` in `test/utils/unitspherical.jl` that exercised exactly this boundary case to `@test`.

The broken test had: `big_cap` = hemisphere centered at `(1,0,0)`, `small_cap` centered at `(1/√2, 1/√2, 0)` with radius `π/4`. `dist(centers) = π/4` and `small.radius + dist = π/2 = big.radius` exactly.

## Test plan

- [x] `test/utils/unitspherical.jl`: Spherical caps now 455 pass / 0 broken / 0 fail (was 454 pass / 1 broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)