### PR TITLE
Fix type instability in `area` for `NaiveTriangulatedSphericalArea`

### DIFF
--- a/src/methods/area.jl
+++ b/src/methods/area.jl
@@ -255,23 +255,26 @@ function area(m::Spherical, geom, ::Type{T} = Float64; threaded=false, kwargs...
     area(NaiveTriangulatedSphericalArea(m), geom, T; threaded, kwargs...)
 end
 
+# Compute the area of a single polygon (exterior minus holes) on the unit sphere.
+# These must be top-level functions: a multi-method local function captured by a
+# closure gets lowered into a `Core.Box`, making `area` infer as `Any`.
+# See https://github.com/JuliaGeo/GeometryOps.jl/issues/407.
+function _naive_triangulated_spherical_polygon_area(method::SphericalTriangleAreaMethod, ::Type{T}, ::GI.PolygonTrait, poly) where T
+    GI.isempty(poly) && return zero(T)
+    ext = GI.getexterior(poly)
+    ext_area = abs(_naive_triangulated_spherical_ring_area(method, GI.trait(ext), ext, T))
+    for hole in GI.gethole(poly)
+        hole_trait = GI.trait(hole)
+        ext_area -= abs(_naive_triangulated_spherical_ring_area(method, hole_trait, hole, T))
+    end
+    return ext_area
+end
+_naive_triangulated_spherical_polygon_area(::SphericalTriangleAreaMethod, ::Type{T}, ::GI.PointTrait, point) where T = zero(T)
+
 # Main implementation for NaiveTriangulatedSphericalArea
 function area(alg::NaiveTriangulatedSphericalArea, geom, ::Type{T} = Float64; threaded=false, kwargs...) where T <: AbstractFloat
-
-    function _polygon_area(trait::GI.PolygonTrait, alg::SphericalTriangleAreaMethod, poly)
-        GI.isempty(poly) && return zero(T)
-        ext = GI.getexterior(poly)
-        ext_area = abs(_naive_triangulated_spherical_ring_area(alg, GI.trait(ext), ext, T))
-        for hole in GI.gethole(poly)
-            hole_trait = GI.trait(hole)
-            ext_area -= abs(_naive_triangulated_spherical_ring_area(alg, hole_trait, hole, T))
-        end
-        return ext_area
-    end
-    _polygon_area(::GI.PointTrait, alg, geom) = zero(T)
-
     unit_area = applyreduce(
-        WithTrait((trait, g) -> _polygon_area(trait, alg.method, g)),
+        WithTrait((trait, g) -> _naive_triangulated_spherical_polygon_area(alg.method, T, trait, g)),
         +,
         TraitTarget{Union{GI.PolygonTrait, GI.PointTrait}}(),
         geom;

--- a/test/methods/area.jl
+++ b/test/methods/area.jl
@@ -269,4 +269,24 @@ end
 
         @test computed_area ≈ expected_area rtol=1e-10
     end
+
+    @testset "Type stability" begin
+        # https://github.com/JuliaGeo/GeometryOps.jl/issues/407
+        using GeometryOps.UnitSpherical: UnitSphericalPoint
+        octant = GI.Polygon([[(0.0, 0.0), (90.0, 0.0), (0.0, 90.0), (0.0, 0.0)]])
+        usp_octant = GI.Polygon([GI.LinearRing([
+            UnitSphericalPoint(0.0, 0.0, 1.0), UnitSphericalPoint(1.0, 0.0, 0.0),
+            UnitSphericalPoint(0.0, 1.0, 0.0), UnitSphericalPoint(0.0, 0.0, 1.0),
+        ])])
+        R = GO.Spherical().radius
+        expected_area = (π/2) * R^2
+
+        @test only(Base.return_types(GO.area, (GO.Spherical{Float64}, typeof(octant)))) == Float64
+        @test only(Base.return_types(GO.area, (GO.Spherical{Float64}, typeof(usp_octant)))) == Float64
+        @test only(Base.return_types(GO.area, (GO.NaiveTriangulatedSphericalArea{GO.Spherical{Float64}, GO.Eriksson}, typeof(octant)))) == Float64
+        @test only(Base.return_types(GO.area, (GO.Spherical{Float64}, typeof(octant), Type{Float32}))) == Float32
+
+        @test (@inferred GO.area(GO.Spherical(), octant)) ≈ expected_area rtol=1e-10
+        @test (@inferred GO.area(GO.Spherical(), usp_octant)) ≈ expected_area rtol=1e-10
+    end
 end


### PR DESCRIPTION
Fixes #407.

## Problem

`area(::Spherical, geom)` inferred as `Any`: the local helper `_polygon_area` in the `NaiveTriangulatedSphericalArea` method had **two methods** and was **captured by the `(trait, g) -> ...` lambda** passed to `applyreduce`. Julia lowers a multi-method local function that is captured by a closure into a `Core.Box{Any}`, which forces a heap allocation plus dynamic dispatch per call, and leaks `Any` out of `area` whenever the trailing `T(...)` conversion can't re-pin the type.

## Fix

Lift `_polygon_area` to a top-level helper, `_naive_triangulated_spherical_polygon_area(method, ::Type{T}, trait, geom)`, and call it from the closure. The remaining captures (`alg`, `T`) are read-only function arguments, so nothing gets boxed — this is the same pattern the `Planar` method already uses.

Before (issue MWE):
```julia
Base.return_types(GO.area, (GO.Spherical{Float64}, typeof(poly)))
# Any
```

After:
```julia
# Float64, and the numeric result is bit-identical (6.375823512160898e13 for the octant MWE)
```

## Tests

Added a `Type stability` testset covering inference through the `Spherical` manifold entry point (both lon/lat and `UnitSphericalPoint`-backed polygons), the direct `NaiveTriangulatedSphericalArea` algorithm call, and the `Float32` path. It fails on `main` (all infer `Any`) and passes with this change; the full `test/methods/area.jl` suite passes (160/160) with identical numeric output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)