### PR TITLE
Add allocation cache for `ConvexConvexSutherlandHodgman` clipping

### DIFF
--- a/src/methods/clipping/sutherland_hodgman.jl
+++ b/src/methods/clipping/sutherland_hodgman.jl
@@ -1,5 +1,5 @@
 # # Sutherland-Hodgman Convex-Convex Clipping
-export ConvexConvexSutherlandHodgman
+export ConvexConvexSutherlandHodgman, SutherlandHodgmanCache
 
 """
     ConvexConvexSutherlandHodgman{M <: Manifold} <: GeometryOpsCore.Algorithm{M}
@@ -10,6 +10,9 @@ Both input polygons MUST be convex. If either polygon is non-convex, results are
 
 This is simpler and faster than Foster-Hormann for small convex polygons, with O(n*m)
 complexity where n and m are vertex counts.
+
+When intersecting many polygon pairs in a hot loop, pass a [`SutherlandHodgmanCache`](@ref)
+via the `cache` keyword argument to `intersection` to avoid intermediate allocations.
 
 ## Spherical manifold
 
@@ -37,18 +40,78 @@ end
 # Default constructor uses Planar
 ConvexConvexSutherlandHodgman() = ConvexConvexSutherlandHodgman(Planar())
 
+"""
+    SutherlandHodgmanCache{P}()
+    SutherlandHodgmanCache(manifold::Manifold, [T = Float64])
+    SutherlandHodgmanCache(alg::ConvexConvexSutherlandHodgman, [T = Float64])
+
+Preallocated buffers for [`ConvexConvexSutherlandHodgman`](@ref) clipping.
+
+Pass this as the `cache` keyword argument to `intersection` to avoid allocating
+intermediate vectors on every call - useful when intersecting many polygon pairs
+in a hot loop. The returned polygon never aliases the cache, so results remain
+valid after the cache is reused.
+
+The point type `P` must match the algorithm's manifold and float type:
+`Tuple{T,T}` for `Planar()`, `UnitSpherical.UnitSphericalPoint{T}` for
+`Spherical()`. The manifold/algorithm constructors take care of this.
+
+!!! warning "Thread safety"
+    A cache must not be shared across concurrent tasks or threads. Create one
+    cache per task. The default (`cache = nothing`) allocates fresh buffers on
+    each call and is always safe.
+
+# Example
+
+```julia
+import GeometryOps as GO
+
+alg = GO.ConvexConvexSutherlandHodgman()
+cache = GO.SutherlandHodgmanCache(alg)
+for (a, b) in polygon_pairs
+    result = GO.intersection(alg, a, b; cache)
+end
+```
+"""
+struct SutherlandHodgmanCache{P}
+    input::Vector{P}    # ping buffer
+    output::Vector{P}   # pong buffer
+    clip::Vector{P}     # spherical only: clip polygon vertices
+    subject::Vector{P}  # spherical only: copy of original subject for containment check
+end
+SutherlandHodgmanCache{P}() where P = SutherlandHodgmanCache{P}(P[], P[], P[], P[])
+
+SutherlandHodgmanCache(::Planar, ::Type{T} = Float64) where {T} =
+    SutherlandHodgmanCache{Tuple{T,T}}()
+SutherlandHodgmanCache(::Spherical, ::Type{T} = Float64) where {T} =
+    SutherlandHodgmanCache{UnitSpherical.UnitSphericalPoint{T}}()
+SutherlandHodgmanCache(alg::ConvexConvexSutherlandHodgman, ::Type{T} = Float64) where {T} =
+    SutherlandHodgmanCache(alg.manifold, T)
+
+# Validate that a user-supplied cache has the point type the manifold/float combination needs
+function _sh_check_cache(cache::SutherlandHodgmanCache{P}, ::Type{PT}) where {P, PT}
+    P === PT || throw(ArgumentError(
+        "SutherlandHodgmanCache point type mismatch: this intersection requires " *
+        "SutherlandHodgmanCache{$PT}, got SutherlandHodgmanCache{$P}. " *
+        "Construct the cache with `SutherlandHodgmanCache(alg, T)` to match the algorithm."
+    ))
+    return cache
+end
+
 # Main entry point - algorithm dispatch
 function intersection(
     alg::ConvexConvexSutherlandHodgman,
     geom_a,
     geom_b,
     ::Type{T}=Float64;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing,
     kwargs...
 ) where {T<:AbstractFloat}
     return _intersection_sutherland_hodgman(
         alg, T,
         GI.trait(geom_a), geom_a,
-        GI.trait(geom_b), geom_b
+        GI.trait(geom_b), geom_b;
+        cache
     )
 end
 
@@ -57,51 +120,60 @@ function _intersection_sutherland_hodgman(
     alg::ConvexConvexSutherlandHodgman{Planar},
     ::Type{T},
     ::GI.PolygonTrait, poly_a,
-    ::GI.PolygonTrait, poly_b
+    ::GI.PolygonTrait, poly_b;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
 ) where {T}
+    cache = isnothing(cache) ? SutherlandHodgmanCache(Planar(), T) : _sh_check_cache(cache, Tuple{T,T})
+
     # Get exterior rings (convex polygons have no holes)
     ring_a = GI.getexterior(poly_a)
     ring_b = GI.getexterior(poly_b)
 
-    # Start with vertices of poly_a as the output list (excluding closing point)
-    output = Tuple{T,T}[]
+    # Start with vertices of poly_a as the subject list (excluding closing point),
+    # ping-ponging between the two cache buffers as we clip
+    buf_in, buf_out = cache.input, cache.output
+    empty!(buf_in)
     for point in GI.getpoint(ring_a)
         pt = _tuple_point(point, T)
         # Skip the closing point (same as first)
-        if !isempty(output) && pt == output[1]
+        if !isempty(buf_in) && pt == buf_in[1]
             continue
         end
-        push!(output, pt)
+        push!(buf_in, pt)
     end
 
     # Clip against each edge of poly_b
     for (edge_start, edge_end) in eachedge(ring_b, T)
-        isempty(output) && break
-        output = _sh_clip_to_edge(output, edge_start, edge_end, T)
+        isempty(buf_in) && break
+        _sh_clip_to_edge!(buf_out, buf_in, edge_start, edge_end, T)
+        buf_in, buf_out = buf_out, buf_in
     end
 
     # Handle empty result (no intersection) - return degenerate polygon with zero area
-    if isempty(output)
+    if isempty(buf_in)
         zero_pt = (zero(T), zero(T))
         return GI.Polygon([[zero_pt, zero_pt, zero_pt]])
     end
 
-    # Close the ring
-    push!(output, output[1])
+    # Copy into a fresh closed ring so the result doesn't alias the cache
+    result = Vector{Tuple{T,T}}(undef, length(buf_in) + 1)
+    copyto!(result, buf_in)
+    result[end] = buf_in[1]
 
     # Return polygon
-    return GI.Polygon([output])
+    return GI.Polygon([result])
 end
 
-# Clip polygon against a single edge using Sutherland-Hodgman rules
-function _sh_clip_to_edge(polygon_points::Vector{Tuple{T,T}}, edge_start, edge_end, ::Type{T}) where T
-    output = Tuple{T,T}[]
-    n = length(polygon_points)
+# Clip polygon (read from `input`) against a single edge using Sutherland-Hodgman
+# rules, writing the surviving points into `output`
+function _sh_clip_to_edge!(output::Vector{Tuple{T,T}}, input::Vector{Tuple{T,T}}, edge_start, edge_end, ::Type{T}) where T
+    empty!(output)
+    n = length(input)
     n == 0 && return output
 
     for i in 1:n
-        current = polygon_points[i]
-        next_pt = polygon_points[mod1(i + 1, n)]
+        current = input[i]
+        next_pt = input[mod1(i + 1, n)]
 
         # Determine if points are inside (left of or on the edge)
         # orient > 0 means left (inside for CCW polygon), == 0 means on edge, < 0 means right (outside)
@@ -213,24 +285,26 @@ function _sh_spherical_intersection(
     return cand1 ⋅ p1 + cand1 ⋅ p2 ≥ 0 ? cand1 : cand2
 end
 
-# Clip polygon against a single edge using Sutherland-Hodgman rules (spherical version)
-function _sh_clip_to_edge_spherical(
-    polygon_points::Vector{UnitSpherical.UnitSphericalPoint{T}},
+# Clip polygon (read from `input`) against a single edge using Sutherland-Hodgman
+# rules, writing the surviving points into `output` (spherical version)
+function _sh_clip_to_edge_spherical!(
+    output::Vector{UnitSpherical.UnitSphericalPoint{T}},
+    input::Vector{UnitSpherical.UnitSphericalPoint{T}},
     edge_start::UnitSpherical.UnitSphericalPoint,
     edge_end::UnitSpherical.UnitSphericalPoint,
     ::Type{T}
 ) where T
-    output = UnitSpherical.UnitSphericalPoint{T}[]
-    n = length(polygon_points)
+    empty!(output)
+    n = length(input)
     n == 0 && return output
 
     # Track actual orient values to handle edge cases (orient=0 means exactly on the edge)
-    current_orient = UnitSpherical.spherical_orient(edge_start, edge_end, polygon_points[1])
+    current_orient = UnitSpherical.spherical_orient(edge_start, edge_end, input[1])
 
     for i in 1:n
-        current = polygon_points[i]
+        current = input[i]
         next_idx = mod1(i + 1, n)
-        next_pt = polygon_points[next_idx]
+        next_pt = input[next_idx]
 
         next_orient = UnitSpherical.spherical_orient(edge_start, edge_end, next_pt)
         current_inside = current_orient >= 0
@@ -268,8 +342,11 @@ function _intersection_sutherland_hodgman(
     alg::ConvexConvexSutherlandHodgman{Spherical{F}},
     ::Type{T},
     ::GI.PolygonTrait, poly_a,
-    ::GI.PolygonTrait, poly_b
+    ::GI.PolygonTrait, poly_b;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
 ) where {F, T}
+    cache = isnothing(cache) ? SutherlandHodgmanCache(alg.manifold, T) : _sh_check_cache(cache, UnitSpherical.UnitSphericalPoint{T})
+
     ring_a = GI.getexterior(poly_a)
     ring_b = GI.getexterior(poly_b)
 
@@ -283,7 +360,8 @@ function _intersection_sutherland_hodgman(
     end
 
     # Collect clip polygon points (excluding closing point)
-    clip_points = UnitSpherical.UnitSphericalPoint{T}[]
+    clip_points = cache.clip
+    empty!(clip_points)
     for point in GI.getpoint(ring_b)
         if !isempty(clip_points) && point ≈ clip_points[1]
             continue
@@ -291,33 +369,38 @@ function _intersection_sutherland_hodgman(
         push!(clip_points, UnitSpherical.UnitSphericalPoint{T}(point))
     end
 
-    # Build initial output list from poly_a (excluding closing point)
-    output = UnitSpherical.UnitSphericalPoint{T}[]
+    # Build initial subject list from poly_a (excluding closing point),
+    # ping-ponging between the two cache buffers as we clip
+    buf_in, buf_out = cache.input, cache.output
+    empty!(buf_in)
     for point in GI.getpoint(ring_a)
-        if !isempty(output) && point == output[1]
+        if !isempty(buf_in) && point == buf_in[1]
             continue
         end
-        push!(output, UnitSpherical.UnitSphericalPoint{T}(point))
+        push!(buf_in, UnitSpherical.UnitSphericalPoint{T}(point))
     end
 
     # Save original subject for containment check
-    original_subject = copy(output)
+    original_subject = cache.subject
+    empty!(original_subject)
+    append!(original_subject, buf_in)
 
     # Clip against each edge of poly_b
     n_clip = length(clip_points)
     for i in 1:n_clip
-        isempty(output) && break
+        isempty(buf_in) && break
         edge_start = clip_points[i]
         edge_end = clip_points[mod1(i + 1, n_clip)]
         # Skip degenerate edges (duplicate vertices)
         edge_start == edge_end && continue
-        output = _sh_clip_to_edge_spherical(output, edge_start, edge_end, T)
+        _sh_clip_to_edge_spherical!(buf_out, buf_in, edge_start, edge_end, T)
+        buf_in, buf_out = buf_out, buf_in
     end
 
     # Handle empty result - check if clip polygon is fully inside the original subject
-    if isempty(output)
+    if isempty(buf_in)
         if !isempty(clip_points) && _point_in_convex_spherical_polygon(clip_points[1], original_subject)
-            # Subject contains clip - return clip polygon
+            # Subject contains clip - return clip polygon (copied, so it doesn't alias the cache)
             result = copy(clip_points)
             push!(result, result[1])
             return GI.Polygon([result])
@@ -329,14 +412,16 @@ function _intersection_sutherland_hodgman(
 
     # Handle degenerate result (1-2 points can't form a valid ring)
     # This happens for adjacent polygons that share only an edge or corner
-    if length(output) < 3
+    if length(buf_in) < 3
         north_pole = UnitSpherical.UnitSphericalPoint{T}(0, 0, 1)
         return GI.Polygon([[north_pole, north_pole, north_pole]])
     end
 
-    # Close the ring and return
-    push!(output, output[1])
-    return GI.Polygon([output])
+    # Copy into a fresh closed ring so the result doesn't alias the cache
+    result = Vector{UnitSpherical.UnitSphericalPoint{T}}(undef, length(buf_in) + 1)
+    copyto!(result, buf_in)
+    result[end] = buf_in[1]
+    return GI.Polygon([result])
 end
 
 # Fallback for unsupported geometry combinations
@@ -344,7 +429,8 @@ function _intersection_sutherland_hodgman(
     alg::ConvexConvexSutherlandHodgman,
     ::Type{T},
     trait_a, geom_a,
-    trait_b, geom_b
+    trait_b, geom_b;
+    kwargs...
 ) where {T}
     throw(ArgumentError(
         "ConvexConvexSutherlandHodgman only supports Polygon-Polygon intersection, " *

--- a/test/methods/clipping/sutherland_hodgman.jl
+++ b/test/methods/clipping/sutherland_hodgman.jl
@@ -181,6 +181,78 @@ import GeoInterface as GI
         @test GO.area(result3) ≈ 0.0 atol=1e-10
     end
 
+    @testset "Cache" begin
+        alg = GO.ConvexConvexSutherlandHodgman()
+        square1 = GI.Polygon([[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)]])
+        square2 = GI.Polygon([[(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0), (1.0, 1.0)]])
+        tri1 = GI.Polygon([[(0.0, 0.0), (4.0, 0.0), (2.0, 4.0), (0.0, 0.0)]])
+        tri2 = GI.Polygon([[(0.0, 2.0), (2.0, -2.0), (4.0, 2.0), (0.0, 2.0)]])
+
+        @testset "Same results with and without cache" begin
+            cache = GO.SutherlandHodgmanCache(alg)
+            for (a, b) in [(square1, square2), (tri1, tri2), (square1, tri1)]
+                uncached = GO.intersection(alg, a, b)
+                cached = GO.intersection(alg, a, b; cache)
+                @test collect(GI.getpoint(GI.getexterior(cached))) ==
+                      collect(GI.getpoint(GI.getexterior(uncached)))
+            end
+        end
+
+        @testset "Result does not alias the cache" begin
+            cache = GO.SutherlandHodgmanCache(alg)
+            first_result = GO.intersection(alg, square1, square2; cache)
+            first_points = collect(GI.getpoint(GI.getexterior(first_result)))
+            # Reuse the cache - this must not corrupt the previously returned polygon
+            GO.intersection(alg, tri1, tri2; cache)
+            @test collect(GI.getpoint(GI.getexterior(first_result))) == first_points
+        end
+
+        @testset "Wrong cache point type throws" begin
+            f32_cache = GO.SutherlandHodgmanCache(GO.Planar(), Float32)
+            @test_throws ArgumentError GO.intersection(alg, square1, square2; cache=f32_cache)
+
+            spherical_cache = GO.SutherlandHodgmanCache(GO.Spherical())
+            @test_throws ArgumentError GO.intersection(alg, square1, square2; cache=spherical_cache)
+        end
+
+        @testset "No intermediate allocations after warm-up" begin
+            cache = GO.SutherlandHodgmanCache(alg)
+            GO.intersection(alg, square1, square2; cache)  # warm up buffers and compilation
+            allocated = @allocated GO.intersection(alg, square1, square2; cache)
+            # Only the returned polygon should allocate; loose bound to avoid version flakiness
+            @test allocated <= 512
+        end
+
+        @testset "Spherical cache" begin
+            using GeometryOps.UnitSpherical: UnitSphereFromGeographic
+
+            function spherical_polygon(coords)
+                transform = UnitSphereFromGeographic()
+                points = [transform((lon, lat)) for (lon, lat) in coords]
+                push!(points, points[1])
+                return GI.Polygon([points])
+            end
+
+            salg = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+            scache = GO.SutherlandHodgmanCache(salg)
+            sq1 = spherical_polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)])
+            sq2 = spherical_polygon([(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0)])
+            large = spherical_polygon([(-5.0, -5.0), (5.0, -5.0), (5.0, 5.0), (-5.0, 5.0)])
+
+            for (a, b) in [(sq1, sq2), (large, sq1), (sq1, large)]
+                uncached = GO.intersection(salg, a, b)
+                cached = GO.intersection(salg, a, b; cache=scache)
+                @test GO.area(GO.Spherical(), cached) ≈ GO.area(GO.Spherical(), uncached)
+            end
+
+            # Aliasing check on the spherical path too
+            first_result = GO.intersection(salg, sq1, sq2; cache=scache)
+            first_points = collect(GI.getpoint(GI.getexterior(first_result)))
+            GO.intersection(salg, large, sq1; cache=scache)
+            @test collect(GI.getpoint(GI.getexterior(first_result))) == first_points
+        end
+    end
+
     @testset "Spherical helpers" begin
         using GeometryOps.UnitSpherical: UnitSphericalPoint, UnitSphereFromGeographic
 

--- a/test/methods/clipping/sutherland_hodgman.jl
+++ b/test/methods/clipping/sutherland_hodgman.jl
@@ -1,6 +1,24 @@
 using Test
 import GeometryOps as GO
 import GeoInterface as GI
+using GeometryOps.UnitSpherical: UnitSphereFromGeographic, UnitSphericalPoint
+
+# Probes for the cache allocation tests.  These have to be top-level functions: measuring
+# `@allocated` directly on testset-local variables boxes them into the keyword `NamedTuple`
+# and charges the algorithm ~112 bytes that it never actually allocates.
+_clip_bytes(alg, a, b, cache) = @allocated GO.intersection(alg, a, b; cache)
+_clip_bytes(alg, a, b) = @allocated GO.intersection(alg, a, b)
+
+# Cost of the result on its own: a closed ring of `n` points wrapped in a polygon.  Measuring
+# it rather than hardcoding a byte count keeps the test honest across Julia/GeoInterface versions.
+_ring_polygon_bytes(::Type{P}, n) where {P} = @allocated GI.Polygon([Vector{P}(undef, n)])
+
+function _spherical_polygon(coords)
+    transform = UnitSphereFromGeographic()
+    points = [transform((lon, lat)) for (lon, lat) in coords]
+    push!(points, points[1])
+    return GI.Polygon([points])
+end
 
 @testset "ConvexConvexSutherlandHodgman" begin
     @testset "Basic intersection" begin
@@ -215,12 +233,35 @@ import GeoInterface as GI
             @test_throws ArgumentError GO.intersection(alg, square1, square2; cache=spherical_cache)
         end
 
-        @testset "No intermediate allocations after warm-up" begin
-            cache = GO.SutherlandHodgmanCache(alg)
-            GO.intersection(alg, square1, square2; cache)  # warm up buffers and compilation
-            allocated = @allocated GO.intersection(alg, square1, square2; cache)
-            # Only the returned polygon should allocate; loose bound to avoid version flakiness
-            @test allocated <= 512
+        @testset "Cached clipping allocates only the returned polygon" begin
+            @testset "Planar" begin
+                cache = GO.SutherlandHodgmanCache(alg)
+                n = GI.npoint(GI.getexterior(GO.intersection(alg, square1, square2; cache)))
+                output = _ring_polygon_bytes(Tuple{Float64,Float64}, n)
+
+                _clip_bytes(alg, square1, square2, cache)  # warm up compilation and buffer growth
+                @test _clip_bytes(alg, square1, square2, cache) == output
+                # Reusing the cache must not grow the buffers again on later calls
+                @test all(==(output), (_clip_bytes(alg, square1, square2, cache) for _ in 1:5))
+                # Guard against passing vacuously: without a cache this must allocate strictly more
+                _clip_bytes(alg, square1, square2)
+                @test _clip_bytes(alg, square1, square2) > output
+            end
+
+            @testset "Spherical" begin
+                salg = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+                scache = GO.SutherlandHodgmanCache(salg)
+                sq_a = _spherical_polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)])
+                sq_b = _spherical_polygon([(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0)])
+                n = GI.npoint(GI.getexterior(GO.intersection(salg, sq_a, sq_b; cache=scache)))
+                output = _ring_polygon_bytes(UnitSphericalPoint{Float64}, n)
+
+                _clip_bytes(salg, sq_a, sq_b, scache)
+                @test _clip_bytes(salg, sq_a, sq_b, scache) == output
+                @test all(==(output), (_clip_bytes(salg, sq_a, sq_b, scache) for _ in 1:5))
+                _clip_bytes(salg, sq_a, sq_b)
+                @test _clip_bytes(salg, sq_a, sq_b) > output
+            end
         end
 
         @testset "Spherical cache" begin

--- a/test/methods/clipping/sutherland_hodgman.jl
+++ b/test/methods/clipping/sutherland_hodgman.jl
@@ -256,11 +256,24 @@ end
                 n = GI.npoint(GI.getexterior(GO.intersection(salg, sq_a, sq_b; cache=scache)))
                 output = _ring_polygon_bytes(UnitSphericalPoint{Float64}, n)
 
-                _clip_bytes(salg, sq_a, sq_b, scache)
-                @test _clip_bytes(salg, sq_a, sq_b, scache) == output
-                @test all(==(output), (_clip_bytes(salg, sq_a, sq_b, scache) for _ in 1:5))
+                _clip_bytes(salg, sq_a, sq_b, scache)  # warm up compilation and buffer growth
+                cached = _clip_bytes(salg, sq_a, sq_b, scache)
+                # Reusing the cache must not grow the buffers again, whatever the baseline is
+                @test all(==(cached), (_clip_bytes(salg, sq_a, sq_b, scache) for _ in 1:5))
+                # Guard against passing vacuously: without a cache this must allocate strictly more
                 _clip_bytes(salg, sq_a, sq_b)
-                @test _clip_bytes(salg, sq_a, sq_b) > output
+                @test _clip_bytes(salg, sq_a, sq_b) > cached
+
+                if VERSION >= v"1.12"
+                    @test cached == output
+                else
+                    # On Julia 1.11 `dot`/`norm`/`cross` over `UnitSphericalPoint` are called
+                    # through function pointers rather than devirtualized, so the clip loop boxes
+                    # every intermediate point (~3.7kB here) whether or not a cache is supplied —
+                    # the uncached path pays it too.  The cache still removes the buffer
+                    # allocations it is responsible for, which the assertions above cover.
+                    @test_broken cached == output
+                end
             end
         end
 


### PR DESCRIPTION
## Summary

`ConvexConvexSutherlandHodgman` is the fast path for convex-convex polygon intersection, the kind of routine that gets called in a hot loop (e.g. coverage/regridding over many cells). Previously every call allocated a fresh vector per clip edge — m+1 vector allocations plus growth reallocations for an m-gon clip polygon. Since the algorithm is purely iterative (one pass per clip edge), all intermediate state can live in reusable buffers.

This PR adds an exported `SutherlandHodgmanCache{P}` with two ping-pong buffers (shared by both manifolds) plus `clip`/`subject` buffers for the spherical path. It is threaded through as a keyword argument:

```julia
alg = GO.ConvexConvexSutherlandHodgman()
cache = GO.SutherlandHodgmanCache(alg)
for (a, b) in polygon_pairs
    result = GO.intersection(alg, a, b; cache)
end
```

- `cache = nothing` (the default) allocates fresh buffers per call — identical behavior to before, always thread-safe.
- The returned polygon is copied into a fresh, exactly-sized ring, so results never alias the cache and remain valid after the cache is reused.
- A cache with the wrong point type for the manifold/float combination throws a descriptive `ArgumentError` (constructors `SutherlandHodgmanCache(alg, T)` / `SutherlandHodgmanCache(manifold, T)` get this right automatically).
- **Thread safety**: deliberately left to the caller — one cache per task. This is documented in the docstring; a task-local convenience could be layered on later.

## Allocations

With a cache supplied, the clip allocates **exactly** the returned polygon and nothing else — checked against a freshly built polygon of the same shape rather than a hardcoded bound.

On Julia 1.12:

| case | uncached | cached | output alone | |
|---|---|---|---|---|
| planar octagon ∩ octagon | 928 B | 352 B | 352 B | 2.6× |
| planar square ∩ square | 848 B | 272 B | 272 B | 3.1× |
| spherical square ∩ square | 1568 B | 304 B | 304 B | 5.2× |

On Julia 1.11 the planar path is likewise exact (352 B / 272 B), but the spherical path bottoms out at 4016 B against a 304 B output:

| case (Julia 1.11) | uncached | cached | output alone | |
|---|---|---|---|---|
| planar octagon ∩ octagon | 2208 B | 352 B | 352 B | 6.3× |
| spherical square ∩ square | 5040 B | 4016 B | 304 B | 1.25× |

That residue is not the cache's doing: on 1.11 `dot`/`norm`/`cross` over `UnitSphericalPoint` are called through function pointers instead of being devirtualized, so the clip loop boxes every intermediate point — the uncached path pays the same ~3.7 kB. The cache still removes the buffer allocations it owns (5040 → 4016). It disappears on 1.12, so this is worth revisiting only if 1.11 stays supported for long.

Measure this behind a function barrier — calling `@allocated GO.intersection(alg, a, b; cache)` on non-local variables boxes them into the keyword `NamedTuple` and charges the algorithm ~112 bytes it never allocates.

## Test plan

- [x] Existing `ConvexConvexSutherlandHodgman` tests pass unchanged
- [x] New `Cache` testset: cached vs uncached result equality (planar + spherical), aliasing regression (reusing a cache must not corrupt previously returned polygons), and wrong-cache-type `ArgumentError`
- [x] Exact allocation test on both manifolds: a cached clip must allocate exactly the returned polygon, repeated cache reuse must not grow it, and the uncached path must allocate strictly more (so the test cannot pass vacuously). Confirmed to fail — `848 == 272` planar, `1568 == 304` spherical — when the cached path is made to ignore the supplied cache.
- [x] Spherical exactness is `@test_broken` below Julia 1.12 for the codegen reason above, so it reports if it ever starts holding. Verified locally on 1.11.9 (71 pass, 1 broken) and 1.12.6 (72 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
