### PR TITLE
Spherical RelateNG kernel

### DIFF
--- a/docs/plans/2026-06-15-relateng-spherical-kernel-design.md
+++ b/docs/plans/2026-06-15-relateng-spherical-kernel-design.md
@@ -1,0 +1,137 @@
+# RelateNG on the Spherical manifold — implementation design
+
+2026-06-15. Builds on the spike `2026-06-12-relateng-spherical-spike.md` /
+`.jl`. This document records the validated design decisions; the bite-sized
+task list lives in `2026-06-15-relateng-spherical-kernel.md`.
+
+## Goal
+
+Make `relate(RelateNG(; manifold = Spherical()), a, b)` work end-to-end —
+Phases 1+2+3 of the spike: the spherical kernel, the acceleration, and the
+exact paths — verified by a standalone spherical kernel-conformance suite and
+end-to-end tests.
+
+## Decisions (from the 2026-06-15 brainstorm)
+
+1. **Scope: full implementation**, not a stub scaffold. All 13 `rk_*`
+   functions for `::Spherical`, including the un-prototyped angle-ordering
+   cluster and the `Rational{BigInt}` exact paths.
+2. **Conformance: a separate standalone suite**
+   (`test/methods/relateng/kernel_conformance_spherical.jl`). The planar
+   `kernel_conformance.jl` is left untouched. The spherical suite uses
+   exactly-representable integer-xyz inputs in general position (so sign
+   predicates stay exact) and carries its own `Rational{BigInt}` differential
+   reference for the crossing-apex property.
+3. **Boundary: full end-to-end** (Phases 1+2+3). Out of scope: Phase 4's
+   broad differential-testing program (JTS-XML port, densified-geodesic
+   oracle); we keep validation to the conformance suite plus targeted
+   end-to-end smoke tests.
+4. **Spherical kernel point type is `UnitSphericalPoint{Float64}`** (not a
+   plain `NTuple{3,Float64}`): isbits, `GI.x/y/z`-accessible, and the kernel's
+   cross/dot math runs on it directly.
+
+## Architecture
+
+The engine is **already manifold-generic in its control flow**: `RelateNG`,
+`RelateGeometry`, `TopologyComputer`, both point locators,
+`RayCrossingCounter` and `edge_intersector` all take `m::Manifold`, and the
+accelerator selection already dispatches `Planar` vs generic `Manifold`. Two
+things are missing:
+
+1. **Point element type `P` is pinned to `Tuple{Float64,Float64}`** at
+   construction (`topology_computer.jl:53`, the `Set`/`Dict`/struct fields in
+   `relate_geometry.jl`, `point_locator.jl`, `indexed_point_in_area.jl`). The
+   structs are *already* parameterized on `P`; only the construction fixes it.
+   The enabling refactor derives `P` from the manifold and converts lon/lat →
+   xyz once at ingest.
+
+2. **The spherical kernel itself** (`kernel_spherical.jl`) — the 13 `rk_*`
+   methods on `::Spherical`.
+
+Correctness vs acceleration are cleanly separable: at `point_locator.jl:525`
+non-`Planar` already falls through to `rk_point_in_ring`, and
+`edge_intersector` already falls back to `NestedLoop()` for non-`Planar`. So
+once the kernel and `P`-threading exist, `relate(Spherical(), …)` is
+*correct* (if unaccelerated). Acceleration (3D edge index, lon-interval
+point locator, STR, prepared mode) is layered on after.
+
+### Point-type plumbing
+
+- `_kernel_point_type(::Planar) = NTuple{2,Float64}`,
+  `_kernel_point_type(::Spherical) = UnitSphericalPoint{Float64}`.
+- `_to_kernel_point(m, geopoint)`: identity `(x,y)` on `Planar`; lon/lat → xyz
+  via `UnitSphereFromGeographic`, **renormalized** (`normalize`) and
+  signed-zero-normalized per component, on `Spherical`.
+- `_node_point` / `_node_points` / `_canonical_segment` / `crossing_node` in
+  `kernel.jl` generalize from `(x,y)` to N components.
+- Thread the derived `P` through `RelateGeometry` →
+  `TopologyComputer`/`RelateSegmentString`/`RelatePointLocator`.
+
+### The spherical kernel
+
+Every predicate reduces to a sign of `det(u,v,w) = (u×v)·w`:
+
+- `rk_orient` → `sign((a×b)·c)`; exact via
+  `ExactPredicates.orient(tup(a),tup(b),tup(c),(0,0,0))`.
+- `rk_point_on_segment` → coplanarity + arc-span dot tests.
+- `rk_classify_intersection` → full `SegSegClass`: `SS_PROPER` (candidate
+  direction `d = n_a×n_b` strictly interior to both arcs), `SS_COLLINEAR`
+  (same great circle, overlapping spans), `SS_TOUCH`/endpoint flags.
+- `rk_point_in_ring` → meridian-arc crossing parity to a pole reference;
+  pole-insideness derived from the ring's signed area (S2 convention,
+  interior on the left of the directed ring).
+- angle cluster (`rk_quadrant`, `rk_compare_edge_dir`, `rk_crossing_dirs_ccw`,
+  `rk_is_crossing`, `rk_is_interior_segment`) → tangent-plane hemisphere
+  split with a reference direction `r` (a pole; fall back when the apex is
+  that pole).
+- `rk_nodes_coincide` → `Rational{BigInt}` on xyz components.
+- `rk_interaction_bounds` → `arc_extent` (spike-proven); area elements
+  extended by the six ±eᵢ axis-point test.
+- antipodal degeneracy → informative `ArgumentError` naming `AntipodalEdgeSplit`.
+
+### Acceleration
+
+- 3D `Extent{(:X,:Y,:Z)}` flow through `_relate_edge_index` unchanged
+  (`NaturalIndex` is dimension-generic).
+- `edge_intersector.jl`: `_select_edge_set_accelerator(::Spherical, …)` →
+  tree accelerator; `_segment_envs_disjoint(::Spherical, …)` → 3D arc-extent
+  disjoint test.
+- 3D STR ordering for prepared geometries.
+- Lon-interval indexed point locator (`SortedPackedIntervalRTree` over
+  longitude intervals; antimeridian crossers split) — an *optimization* over
+  the already-correct fall-through.
+
+### Antipodal edges
+
+Kernel throws on exactly-antipodal consecutive vertices. The opt-in
+`AntipodalEdgeSplit` correction (in `transformations/correction/`) inserts the
+lon/lat midpoint; this is the final, independently-deferrable task.
+
+### Ring/direction containment (`_ring_contains_dir`)
+
+Whether a direction `N` is interior to a ring (S2 interior-on-left) is decided
+by the ring's **winding** about `N`: project each edge onto the plane ⊥ `N` and
+sum the signed turn. Each edge contributes a turn of magnitude < π, so the sum
+has no atan2 branch ambiguity — a per-triangle signed-solid-angle sum
+(Van Oosterom–Strackee) does *not* have this property and reports spurious
+interiors for reference directions far from the loop's winding axis (e.g. an
+equatorial axis against a polar-cap ring). A single interior-on-left enclosure
+sweeps +2π, so `N` is interior iff the total exceeds π.
+
+This is exact for rings smaller than a hemisphere — the common geographic case,
+and all rings the conformance/end-to-end suites build. **Limitation:** a ring
+whose interior is *larger* than a hemisphere (interior = the bigger region)
+would under-report a non-encircled interior axis (winding 0 but interior).
+`_ring_contains_pole` (used for `rk_point_in_ring`'s pole reference) and the
+area-bounds axis extension (`_widen_area_axes`) both rest on this assumption.
+The axis extension only over-prunes when wrong, so it stays conservative-safe;
+super-hemisphere rings in `rk_point_in_ring` are explicitly out of scope here.
+
+## Out of scope
+
+Phase 4 differential-testing program (JTS-XML spherical port,
+densified-geodesic oracle). The conformance suite + end-to-end smoke tests are
+the proof for this work.
+
+Super-hemisphere rings (interior larger than a hemisphere) in
+`_ring_contains_dir` — see the limitation above.

--- a/docs/plans/2026-06-15-relateng-spherical-kernel-design.md
+++ b/docs/plans/2026-06-15-relateng-spherical-kernel-design.md
@@ -92,14 +92,23 @@ Every predicate reduces to a sign of `det(u,v,w) = (u×v)·w`:
 ### Acceleration
 
 - 3D `Extent{(:X,:Y,:Z)}` flow through `_relate_edge_index` unchanged
-  (`NaturalIndex` is dimension-generic).
+  (`NaturalIndex` is dimension-generic). **Done**, but the per-segment extent
+  table had to be made manifold-aware too: it built a 2D endpoint box, which
+  misses a long arc's bulge and prunes real crossings — `_segment_extent`
+  now uses `arc_extent` on the sphere.
 - `edge_intersector.jl`: `_select_edge_set_accelerator(::Spherical, …)` →
   tree accelerator; `_segment_envs_disjoint(::Spherical, …)` → 3D arc-extent
-  disjoint test.
-- 3D STR ordering for prepared geometries.
-- Lon-interval indexed point locator (`SortedPackedIntervalRTree` over
-  longitude intervals; antimeridian crossers split) — an *optimization* over
-  the already-correct fall-through.
+  disjoint test. **Done.**
+- Prepared geometries: `_build_prepared_edge_index(::Spherical, …)` indexes A
+  in 3D; the dimension-generic `NaturalIndex` needs no separate STR ordering,
+  so prepared spherical relate matches unprepared. **Done.**
+- **SKIPPED (time-boxed):** the lon-interval indexed spherical point locator
+  (`SortedPackedIntervalRTree` over longitude intervals; antimeridian crossers
+  split). This is a pure *optimization* over the already-correct fall-through
+  at `point_locator.jl`'s `locate_on_polygonal` — Spherical takes the direct
+  `rk_point_in_ring` ring loop (the `loc.m isa Planar` guard skips the indexed
+  arm), which is correct but O(n) per query. Revisit if spherical point-in-area
+  becomes a hot path.
 
 ### Antipodal edges
 

--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -137,6 +137,7 @@ include("transformations/forcedims.jl")
 include("transformations/correction/geometry_correction.jl")
 include("transformations/correction/closed_ring.jl")
 include("transformations/correction/intersecting_polygons.jl")
+include("transformations/correction/antipodal_edge_split.jl")
 
 # Import all names from GeoInterface and Extents, so users can do `GO.extent` or `GO.trait`.
 for name in names(GeoInterface)

--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -94,6 +94,7 @@ include("methods/geom_relations/relateng/relate_predicates.jl")
 # topology-layer files (Task 6+) that will call the kernel functions.
 include("methods/geom_relations/relateng/kernel.jl")
 include("methods/geom_relations/relateng/kernel_planar.jl")
+include("methods/geom_relations/relateng/kernel_spherical.jl")
 # Node sections: after the kernel (uses `NodeKey`), before the point locator
 # (AdjacentEdgeLocator builds NodeSections).
 include("methods/geom_relations/relateng/node_sections.jl")

--- a/src/methods/geom_relations/relateng/edge_intersector.jl
+++ b/src/methods/geom_relations/relateng/edge_intersector.jl
@@ -232,6 +232,19 @@ function _select_edge_set_accelerator(::Planar, ssa_list, ssb_list)
         return DoubleSTRtree()
     end
 end
+# The same threshold heuristic on the sphere: the tree path is valid because
+# the segment extents are 3D great-circle arc extents (`_segment_extent`), and
+# `NaturalIndex` / the dual DFS / `Extents.intersects` are dimension-generic.
+function _select_edge_set_accelerator(::Spherical, ssa_list, ssb_list)
+    na = _total_segment_count(ssa_list)
+    nb = _total_segment_count(ssb_list)
+    if na < GEOMETRYOPS_NO_OPTIMIZE_EDGEINTERSECT_NUMVERTS &&
+            nb < GEOMETRYOPS_NO_OPTIMIZE_EDGEINTERSECT_NUMVERTS
+        return NestedLoop()
+    else
+        return DoubleSTRtree()
+    end
+end
 _select_edge_set_accelerator(::Manifold, ssa_list, ssb_list) = NestedLoop()
 
 _total_segment_count(ss_list) =
@@ -270,6 +283,11 @@ _segment_envs_disjoint(::Planar, a0, a1, b0, b1) =
     max(a0[1], a1[1]) < min(b0[1], b1[1]) ||
     min(a0[2], a1[2]) > max(b0[2], b1[2]) ||
     max(a0[2], a1[2]) < min(b0[2], b1[2])
+# On the sphere the per-segment extent is the bulge-aware 3D great-circle arc
+# extent, which is exact in xyz and has no antimeridian pathology — so this
+# prune is valid (and tighter than no pruning).
+_segment_envs_disjoint(::Spherical, a0, a1, b0, b1) =
+    !Extents.intersects(arc_extent(a0, a1), arc_extent(b0, b1))
 _segment_envs_disjoint(::Manifold, a0, a1, b0, b1) = false
 
 # The spatial index built over per-segment extents for the tree-accelerated
@@ -289,8 +307,8 @@ function process_edge_intersections!(tc::TopologyComputer,
         ssb_list::AbstractVector{<:RelateSegmentString},
         ::IntersectionAccelerator;
         m::Manifold = _manifold(tc), exact = _exact(tc))
-    extents_a, owners_a = _segment_extent_table(ssa_list)
-    extents_b, owners_b = _segment_extent_table(ssb_list)
+    extents_a, owners_a = _segment_extent_table(m, ssa_list)
+    extents_b, owners_b = _segment_extent_table(m, ssb_list)
     (isempty(extents_a) || isempty(extents_b)) && return nothing
     tree_a = _relate_edge_index(extents_a)
     tree_b = _relate_edge_index(extents_b)
@@ -387,7 +405,7 @@ function process_self_intersections!(tc::TopologyComputer,
         ss_list::AbstractVector{<:RelateSegmentString},
         ::IntersectionAccelerator;
         m::Manifold = _manifold(tc), exact = _exact(tc))
-    extents, owners = _segment_extent_table(ss_list)
+    extents, owners = _segment_extent_table(m, ss_list)
     isempty(extents) && return nothing
     tree = _relate_edge_index(extents)
     SpatialTreeInterface.dual_depth_first_search(Extents.intersects, tree, tree) do ia, ib
@@ -405,25 +423,31 @@ end
 
 # Flat per-segment extent list for a segment-string list, with the offset
 # table mapping each flat index back to (string index, segment index).
-function _segment_extent_table(ss_list)
-    extents = Extents.Extent{(:X, :Y), NTuple{2, NTuple{2, Float64}}}[]
+# Per-segment extent in the manifold's coordinate space: a planar 2D box from
+# the endpoints, or the bulge-aware 3D great-circle arc extent on the sphere
+# (the endpoint box would miss a long arc's bulge and wrongly prune crossings).
+_segment_extent(::Planar, p, q) = Extents.Extent(X = minmax(p[1], q[1]), Y = minmax(p[2], q[2]))
+_segment_extent(::Spherical, p, q) = arc_extent(p, q)
+_segment_extent_type(::Planar) = Extents.Extent{(:X, :Y), NTuple{2, NTuple{2, Float64}}}
+_segment_extent_type(::Spherical) = Extents.Extent{(:X, :Y, :Z), NTuple{3, NTuple{2, Float64}}}
+
+function _segment_extent_table(m::Manifold, ss_list)
+    extents = _segment_extent_type(m)[]
     owners = NTuple{2, Int}[]
     nseg = _total_segment_count(ss_list)
     sizehint!(extents, nseg)
     sizehint!(owners, nseg)
     for (si, ss) in enumerate(ss_list)
-        _push_segment_extents!(extents, owners, si, ss.pts)
+        _push_segment_extents!(m, extents, owners, si, ss.pts)
     end
     return extents, owners
 end
 
 # Function barrier: dispatch once per segment string, so the per-segment
 # loop stays statically typed even if `ss_list` has a non-concrete eltype.
-function _push_segment_extents!(extents::Vector, owners::Vector, si::Int, pts::Vector)
+function _push_segment_extents!(m::Manifold, extents::Vector, owners::Vector, si::Int, pts::Vector)
     for k in 1:(length(pts) - 1)
-        p = pts[k]
-        q = pts[k + 1]
-        push!(extents, Extents.Extent(X = minmax(p[1], q[1]), Y = minmax(p[2], q[2])))
+        push!(extents, _segment_extent(m, pts[k], pts[k + 1]))
         push!(owners, (si, k))
     end
     return nothing

--- a/src/methods/geom_relations/relateng/kernel.jl
+++ b/src/methods/geom_relations/relateng/kernel.jl
@@ -191,9 +191,12 @@ end
     return _rebuild_point(p, _pos_zero(GI.x(p)), _pos_zero(GI.y(p)), _pos_zero(GI.z(p)))
 end
 # Default rebuild: a plain 3-tuple. Concrete point types that must survive node
-# construction add their own method (e.g. `UnitSphericalPoint` in
-# `kernel_spherical.jl`).
+# construction add their own method. The spherical kernel point type is the one
+# such type today: a `UnitSphericalPoint` must stay a `UnitSphericalPoint` so
+# `NodeKey{P}`'s `P` matches the kernel point type (the spherical kernel math
+# runs on it directly).
 @inline _rebuild_point(::Any, x, y, z) = (x, y, z)
+@inline _rebuild_point(::UnitSphericalPoint, x, y, z) = UnitSphericalPoint(x, y, z)
 
 # Collect a curve's coordinates as node points into a plain `Vector`. (A
 # typed comprehension over `GI.getpoint` is not enough: for geometries backed
@@ -232,19 +235,26 @@ is nonzero precisely when the crossing is proper.
 function crossing_node(a0, a1, b0, b1)
     a0, a1 = _canonical_segment(_node_point(a0), _node_point(a1))
     b0, b1 = _canonical_segment(_node_point(b0), _node_point(b1))
-    if (GI.x(b0), GI.y(b0), GI.x(b1), GI.y(b1)) < (GI.x(a0), GI.y(a0), GI.x(a1), GI.y(a1))
+    if (_lex(b0), _lex(b1)) < (_lex(a0), _lex(a1))
         a0, a1, b0, b1 = b0, b1, a0, a1
     end
     return NodeKey(true, a0, a1, b0, b1)
 end
 
-# Order a segment's endpoints lexicographically by (x, y).
-_canonical_segment(p, q) = (GI.x(p), GI.y(p)) <= (GI.x(q), GI.y(q)) ? (p, q) : (q, p)
+# Lexicographic key of a point: (x, y) on the plane, (x, y, z) in 3D.
+@inline _lex(p) = GI.is3d(p) ? (GI.x(p), GI.y(p), GI.z(p)) : (GI.x(p), GI.y(p))
+
+# Order a segment's endpoints lexicographically (by (x, y), or (x, y, z) in 3D).
+_canonical_segment(p, q) = _lex(p) <= _lex(q) ? (p, q) : (q, p)
 
 # Whether `p` lies within the coordinate bounding box of segment `(q0, q1)`.
 # Valid as an on-segment test only when `p` is already known collinear with
-# `(q0, q1)`; shared by manifolds whose segments are coordinate-monotone.
+# `(q0, q1)`; shared by manifolds whose segments are coordinate-monotone. The
+# spherical kernel does NOT use this for arc membership (it uses
+# `rk_point_on_segment` with dot tests); the 3D clause keeps any incidental
+# planar-style call correct.
 @inline function _collinear_between(p, q0, q1)
     (min(GI.x(q0), GI.x(q1)) <= GI.x(p) <= max(GI.x(q0), GI.x(q1))) &&
-    (min(GI.y(q0), GI.y(q1)) <= GI.y(p) <= max(GI.y(q0), GI.y(q1)))
+    (min(GI.y(q0), GI.y(q1)) <= GI.y(p) <= max(GI.y(q0), GI.y(q1))) &&
+    (!GI.is3d(p) || (min(GI.z(q0), GI.z(q1)) <= GI.z(p) <= max(GI.z(q0), GI.z(q1))))
 end

--- a/src/methods/geom_relations/relateng/kernel.jl
+++ b/src/methods/geom_relations/relateng/kernel.jl
@@ -231,6 +231,46 @@ function _node_points(geom)
     return pts
 end
 
+#=
+## Manifold-derived kernel point type (Phase 3 ingest)
+
+The engine stores every coordinate in the manifold's *kernel point type*. The
+planar path keeps the signed-zero-normalized 2-tuple — byte-identical to the
+pre-Phase-3 engine, so `NodeKey` bytes and the locator hash sets are unchanged.
+A non-planar manifold (e.g. `Spherical`) converts each lon/lat (or already-xyz)
+vertex to its kernel representation at ingest, so everything downstream — node
+keys, segment-string coordinate vectors, the point-locator collections, the
+kernel predicate calls — runs in the kernel coordinate space.
+
+`_kernel_point_type(m)` types those collections; `_to_kernel_point(m, p)` /
+`_to_kernel_points(m, geom)` perform the conversion. The `Spherical` methods
+live in kernel_spherical.jl next to `_spherical_kernel_point`.
+=#
+_kernel_point_type(::Planar) = Tuple{Float64, Float64}
+@inline _to_kernel_point(::Planar, p) = _node_point(p)
+
+# Manifold-aware counterpart of `_node_points` (identical to it on the planar
+# path): a curve's coordinates as a `Vector` of kernel points.
+function _to_kernel_points(m::Manifold, geom)
+    P = _kernel_point_type(m)
+    pts = Vector{P}()
+    sizehint!(pts, GI.npoint(geom))
+    for p in GI.getpoint(geom)
+        push!(pts, _to_kernel_point(m, p))
+    end
+    return pts
+end
+
+# Degenerate interaction box of a single *kernel* point, matching the
+# dimensionality of `rk_interaction_bounds` (2D for planar tuples, 3D for 3D
+# kernel points such as `UnitSphericalPoint`). Used by the point-locator line
+# envelope short-circuit, where the query point is already a kernel point.
+@inline _kernel_point_box(p) = _kernel_point_box(booltype(GI.is3d(p)), p)
+@inline _kernel_point_box(::False, p) =
+    Extents.Extent(X = (GI.x(p), GI.x(p)), Y = (GI.y(p), GI.y(p)))
+@inline _kernel_point_box(::True, p) =
+    Extents.Extent(X = (GI.x(p), GI.x(p)), Y = (GI.y(p), GI.y(p)), Z = (GI.z(p), GI.z(p)))
+
 "Node key of a vertex node: keyed exactly by its coordinate."
 function vertex_node(pt)
     p = _node_point(pt)

--- a/src/methods/geom_relations/relateng/kernel.jl
+++ b/src/methods/geom_relations/relateng/kernel.jl
@@ -153,6 +153,24 @@ end
 
 # Manifold-generic helpers
 
+# Conservative interaction-bounds tests (contract above): manifold-generic,
+# operating on the extents produced by `rk_interaction_bounds`.
+# `rk_bounds_disjoint` is dimension-generic already (`Extents.intersects`).
+# `rk_bounds_covers` checks X/Y on the plane and additionally Z for the 3D
+# extents the spherical kernel produces; the X/Y path is byte-identical to the
+# original planar definition. `hasproperty(_, :Z)` folds to a compile-time
+# constant for a concretely-typed `Extent`, so both paths stay allocation-free.
+rk_bounds_disjoint(extA, extB) = !Extents.intersects(extA, extB)
+
+function rk_bounds_covers(extA, extB)
+    (extA.X[1] <= extB.X[1] && extB.X[2] <= extA.X[2]) &&
+    (extA.Y[1] <= extB.Y[1] && extB.Y[2] <= extA.Y[2]) &&
+    _bounds_covers_z(extA, extB)
+end
+@inline _bounds_covers_z(extA, extB) =
+    (!hasproperty(extA, :Z) || !hasproperty(extB, :Z)) ||
+    (extA.Z[1] <= extB.Z[1] && extB.Z[2] <= extA.Z[2])
+
 # Symbolic node identity (design D2). One concrete isbits key type for both
 # node kinds so Dict{NodeKey{P}, ...} is type-stable. Equality and hashing
 # are the default bit-pattern (egal) semantics for isbits structs; this is

--- a/src/methods/geom_relations/relateng/kernel.jl
+++ b/src/methods/geom_relations/relateng/kernel.jl
@@ -180,7 +180,20 @@ end
 # Normalize signed zeros: -0.0 + 0.0 == +0.0 exactly, every other finite
 # value is unchanged. Keeps bit-pattern key equality == coordinate equality.
 @inline _pos_zero(x) = x + zero(x)
-@inline _node_point(p) = (_pos_zero(GI.x(p)), _pos_zero(GI.y(p)))
+
+# A node point is the engine's canonical, signed-zero-normalized representation
+# of a coordinate. Planar points stay 2-tuples (byte-identical to the original
+# implementation, so `NodeKey` bytes are unchanged); 3D points (e.g. a spherical
+# `UnitSphericalPoint`) keep all three components and their concrete type.
+@inline _node_point(p) = _node_point(booltype(GI.is3d(p)), p)
+@inline _node_point(::False, p) = (_pos_zero(GI.x(p)), _pos_zero(GI.y(p)))
+@inline function _node_point(::True, p)
+    return _rebuild_point(p, _pos_zero(GI.x(p)), _pos_zero(GI.y(p)), _pos_zero(GI.z(p)))
+end
+# Default rebuild: a plain 3-tuple. Concrete point types that must survive node
+# construction add their own method (e.g. `UnitSphericalPoint` in
+# `kernel_spherical.jl`).
+@inline _rebuild_point(::Any, x, y, z) = (x, y, z)
 
 # Collect a curve's coordinates as node points into a plain `Vector`. (A
 # typed comprehension over `GI.getpoint` is not enough: for geometries backed
@@ -188,7 +201,8 @@ end
 # static axes, so `collect` returns a `SizedVector`, which downstream code
 # expecting `Vector` point lists rejects.)
 function _node_points(geom)
-    pts = Vector{Tuple{Float64, Float64}}()
+    p1 = GI.getpoint(geom, 1)
+    pts = Vector{typeof(_node_point(p1))}()
     sizehint!(pts, GI.npoint(geom))
     for p in GI.getpoint(geom)
         push!(pts, _node_point(p))

--- a/src/methods/geom_relations/relateng/kernel_planar.jl
+++ b/src/methods/geom_relations/relateng/kernel_planar.jl
@@ -24,13 +24,6 @@ end
 
 rk_interaction_bounds(::Planar, geom) = GI.extent(geom, fallback = true)
 
-rk_bounds_disjoint(extA, extB) = !Extents.intersects(extA, extB)
-
-function rk_bounds_covers(extA, extB)
-    (extA.X[1] <= extB.X[1] && extB.X[2] <= extA.X[2]) &&
-    (extA.Y[1] <= extB.Y[1] && extB.Y[2] <= extA.Y[2])
-end
-
 # Exact coordinate equality of two points.
 _equals2(p, q) = GI.x(p) == GI.x(q) && GI.y(p) == GI.y(q)
 

--- a/src/methods/geom_relations/relateng/kernel_planar.jl
+++ b/src/methods/geom_relations/relateng/kernel_planar.jl
@@ -90,7 +90,16 @@ end
 # increase CCW from the positive X-axis; different quadrants decide the
 # comparison, same-quadrant ties are resolved by orientation (P > Q if P is
 # CCW of Q).
-function _compare_angle(m::Planar, origin, p, q; exact)
+#
+# This and the helpers below (`_is_angle_greater`, `_is_between`,
+# `_compare_between`, `rk_crossing_dirs_ccw`, `rk_is_crossing`,
+# `rk_is_interior_segment`) depend only on `rk_quadrant` and `rk_orient`, both
+# manifold-dispatched, so they are manifold-generic (`m::Manifold`). The
+# spherical kernel supplies a tangent-plane `rk_quadrant`; the same-quadrant
+# orient tiebreak `rk_orient(m, origin, q, p)` is already the tangent-plane CCW
+# sign there. Only `rk_quadrant` and the crossing-apex `rk_compare_edge_dir`
+# are manifold-specific.
+function _compare_angle(m::Manifold, origin, p, q; exact)
     quadrant_p = rk_quadrant(m, origin, p)
     quadrant_q = rk_quadrant(m, origin, q)
     quadrant_p > quadrant_q && return 1
@@ -103,7 +112,7 @@ function _compare_angle(m::Planar, origin, p, q; exact)
 end
 
 # Port of PolygonNodeTopology.isAngleGreater.
-function _is_angle_greater(m::Planar, origin, p, q; exact)
+function _is_angle_greater(m::Manifold, origin, p, q; exact)
     quadrant_p = rk_quadrant(m, origin, p)
     quadrant_q = rk_quadrant(m, origin, q)
     quadrant_p > quadrant_q && return true
@@ -115,7 +124,7 @@ end
 # Port of PolygonNodeTopology.isBetween: whether edge p is inside the arc
 # from e0 to e1 (the arc not including the origin direction). Edges assumed
 # distinct (non-collinear).
-function _is_between(m::Planar, origin, p, e0, e1; exact)
+function _is_between(m::Manifold, origin, p, e0, e1; exact)
     _is_angle_greater(m, origin, p, e0; exact) || return false
     return !_is_angle_greater(m, origin, p, e1; exact)
 end
@@ -123,7 +132,7 @@ end
 # Port of PolygonNodeTopology.compareBetween: 1 if p is inside the arc from
 # e0 to e1 (the arc not crossing the positive X-axis), -1 if outside, 0 if
 # collinear with either edge.
-function _compare_between(m::Planar, origin, p, e0, e1; exact)
+function _compare_between(m::Manifold, origin, p, e0, e1; exact)
     comp0 = _compare_angle(m, origin, p, e0; exact)
     comp0 == 0 && return 0
     comp1 = _compare_angle(m, origin, p, e1; exact)
@@ -194,7 +203,7 @@ proper crossing of (a0,a1) × (b0,b1), starting from a1. Since the
 crossing is proper, b0/b1 are strictly on opposite sides of line(a0,a1):
 if b1 is to the left, CCW order is (a1, b1, a0, b0), else (a1, b0, a0, b1).
 """
-function rk_crossing_dirs_ccw(m::Planar, a0, a1, b0, b1; exact)
+function rk_crossing_dirs_ccw(m::Manifold, a0, a1, b0, b1; exact)
     if rk_orient(m, a0, a1, b1; exact) > 0
         return (a1, b1, a0, b0)
     else
@@ -206,7 +215,7 @@ end
 # Crossing-node apexes are rejected: a proper crossing is a crossing by
 # construction, and the only caller (TopologyComputer.updateAreaAreaCross)
 # short-circuits proper intersections before asking.
-function rk_is_crossing(m::Planar, node::NodeKey, a0, a1, b0, b1; exact)
+function rk_is_crossing(m::Manifold, node::NodeKey, a0, a1, b0, b1; exact)
     node.is_crossing &&
         throw(ArgumentError("rk_is_crossing requires a vertex-node apex; proper crossings cross by construction"))
     nodept = node.pt
@@ -226,7 +235,7 @@ end
 # Port of PolygonNodeTopology.isInteriorSegment, apex = vertex node
 # coordinate: whether segment node→b lies in the interior of the ring corner
 # a0–node–a1 (ring interior on the right, i.e. a CW shell or CCW hole).
-function rk_is_interior_segment(m::Planar, node::NodeKey, a0, a1, b; exact)
+function rk_is_interior_segment(m::Manifold, node::NodeKey, a0, a1, b; exact)
     node.is_crossing &&
         throw(ArgumentError("rk_is_interior_segment requires a vertex-node apex"))
     nodept = node.pt

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -164,6 +164,90 @@ function _sph_classify(bt, a0, a1, b0, b1, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
     return SegSegClass(SS_DISJOINT, false, false, false, false)
 end
 
+# ## Angle ordering at nodes (tangent-plane port of PolygonNodeTopology)
+#
+# Directions around an apex `n` live in the tangent plane at `n`. Pick a
+# reference axis `r` (the coordinate axis least aligned with `n`, so `r ≁ ±n`);
+# the tangent frame is `u = r - (r·n̂)n̂`, `v = n × r`, right-handed with `u×v =
+# n̂`. A direction toward `p` has tangent coordinates `(p·u, p·v)`, and we only
+# need their *signs* — both are determinant signs of `n, r, p`, exact for
+# integer inputs and scale-corrected so the apex need not be unit:
+#   sign(p·u) = sign((p·r)(n·n) - (r·n)(p·n)),   sign(p·v) = sign((n×r)·p).
+# Feeding these to the planar quadrant scheme, with the same-quadrant tiebreak
+# `rk_orient(m, n, q, p) = sign((n×q)·p)` (already the tangent-plane CCW sign),
+# reproduces PolygonNodeTopology exactly.
+
+# Coordinate axis least aligned with `n3` (smallest |component|, first-index
+# tiebreak — matches `argmin`), as a unit vector of `n3`'s element type.
+@inline function _ref_axis(n3)
+    ax, ay, az = abs(n3[1]), abs(n3[2]), abs(n3[3])
+    o = one(ax); z = zero(ax)
+    if ax <= ay && ax <= az
+        return (o, z, z)
+    elseif ay <= az
+        return (z, o, z)
+    else
+        return (z, z, o)
+    end
+end
+
+# JTS quadrant of the direction toward `P3` around apex `n3` with reference
+# `r3`: NE=0, NW=1, SW=2, SE=3, axis directions on the `>= 0` side.
+@inline function _sph_quadrant3(n3, r3, P3)
+    nn = _dot3(n3, n3); nr = _dot3(n3, r3); pn = _dot3(P3, n3); pr = _dot3(P3, r3)
+    su = pr * nn - nr * pn               # sign of P·u
+    sv = _dot3(_cross3(n3, r3), P3)      # sign of P·v
+    (su == 0 && sv == 0) &&
+        throw(ArgumentError("cannot compute the quadrant of a zero-length direction"))
+    if su >= 0
+        return sv >= 0 ? 0 : 3
+    else
+        return sv >= 0 ? 1 : 2
+    end
+end
+
+function rk_quadrant(::Spherical, origin, p)
+    n3 = _tup3(origin)
+    return _sph_quadrant3(n3, _ref_axis(n3), _tup3(p))
+end
+
+# compareAngle around an explicit apex direction `n3` (a vec3 tuple): the
+# crossing-apex slow path, where `n3` is the *constructed* crossing direction
+# and so must be compared with explicit determinant signs (not ExactPredicates,
+# which needs Float64 vertices). Mirrors `_compare_angle`: quadrant first, then
+# the orient tiebreak `sign((n×q)·p)`.
+function _sph_compare_around(bt, n3, p, q)
+    P = _vec3(bt, p); Q = _vec3(bt, q)
+    r3 = _ref_axis(n3)
+    qp = _sph_quadrant3(n3, r3, P)
+    qq = _sph_quadrant3(n3, r3, Q)
+    qp > qq && return 1
+    qp < qq && return -1
+    o = _dot3(_cross3(n3, Q), P)
+    return o > 0 ? 1 : (o < 0 ? -1 : 0)
+end
+
+# The crossing direction (the sphere point where the two arcs of a crossing
+# node meet): ±(na×nb), the candidate strictly interior to both minor arcs.
+function _sph_crossing_dir(bt, node::NodeKey)
+    A0 = _vec3(bt, node.pt); A1 = _vec3(bt, node.a1)
+    B0 = _vec3(bt, node.b0); B1 = _vec3(bt, node.b1)
+    na = _cross3(A0, A1); nb = _cross3(B0, B1)
+    d = _cross3(na, nb)
+    (_strictly_in_arc3(d, A0, A1, na) && _strictly_in_arc3(d, B0, B1, nb)) && return d
+    return _neg3(d)
+end
+
+function rk_compare_edge_dir(m::Spherical, node::NodeKey, p, q; exact)
+    node.is_crossing || return _compare_angle(m, node.pt, p, q; exact)
+    # Crossing apex: unlike the plane, the tangent direction apex→x is not
+    # parallel to opp(x)→x, so the planar endpoint substitution does not carry
+    # over. Compare around the (exact, on-arc) crossing direction instead —
+    # the slow path, only on crossing-node edge ordering.
+    bt = booltype(exact)
+    return _sph_compare_around(bt, _sph_crossing_dir(bt, node), p, q)
+end
+
 # Interaction bounds on the sphere: a 3D `Extent{(:X,:Y,:Z)}` in unit-sphere xyz
 # (the engine works in xyz after ingest), as the union of `arc_extent` over the
 # geometry's edges. Area-element interiors reach beyond their boundary slab — the

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -17,3 +17,15 @@ lives next to the generic `_rebuild_point` in `kernel.jl`.
 
 # xyz tuple of a 3D point, for the ExactPredicates / Rational{BigInt} paths.
 @inline _tup3(u) = (GI.x(u), GI.y(u), GI.z(u))
+
+# ## rk_orient
+
+# Orientation of `c` relative to the great-circle arc `(a, b)`: the sign of the
+# scalar triple product (a×b)·c. Exact path: `ExactPredicates.orient` over the
+# xyz tuples about the origin (the spike measured 3.5 ns); NOT
+# `UnitSpherical.spherical_orient`, whose eps*16 tolerance is unfit for the
+# exact contract. Float path: the plain triple product.
+rk_orient(::Spherical, a, b, c; exact) = _rk_orient(booltype(exact), a, b, c)
+@inline _rk_orient(::True, a, b, c) =
+    ExactPredicates.orient(_tup3(a), _tup3(b), _tup3(c), (0.0, 0.0, 0.0))
+@inline _rk_orient(::False, a, b, c) = cross(a, b) ⋅ c

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -29,3 +29,18 @@ rk_orient(::Spherical, a, b, c; exact) = _rk_orient(booltype(exact), a, b, c)
 @inline _rk_orient(::True, a, b, c) =
     ExactPredicates.orient(_tup3(a), _tup3(b), _tup3(c), (0.0, 0.0, 0.0))
 @inline _rk_orient(::False, a, b, c) = cross(a, b) ⋅ c
+
+# ## rk_point_on_segment
+
+# Whether `p` lies on the closed minor arc `[q0, q1]`. Two conditions: `p` is on
+# the arc's great circle (coplanar with `q0`, `q1`, the origin — an exact orient
+# == 0), and within the minor-arc span. The span test uses dots as cos-of-angle:
+# for unit vectors `q0·p >= q0·q1` means `p` is no farther from `q0` than `q1`
+# is, and symmetrically for `q1`; together they pin `p` to the minor arc. Engine
+# inputs are unit; the conformance grid points are chosen so the dot signs are
+# exact.
+function rk_point_on_segment(m::Spherical, p, q0, q1; exact)
+    rk_orient(m, q0, q1, p; exact) == 0 || return false
+    qq = q0 ⋅ q1
+    return (q0 ⋅ p) >= qq && (q1 ⋅ p) >= qq
+end

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -1,0 +1,19 @@
+# # Spherical RelateKernel
+#
+#=
+Spherical implementation of the RelateKernel contract declared in `kernel.jl`,
+over `UnitSphericalPoint{Float64}`. Every predicate is a sign of
+det(u, v, w) = (u×v)·w, so the exact path mirrors planar: a float filter then an
+exact fallback (`ExactPredicates.orient` for the plain orient, `Rational{BigInt}`
+on the xyz components for composites). No intersection coordinate is ever
+constructed. See the design doc 2026-06-15.
+
+All of `cross`, `⋅`, `normalize` (LinearAlgebra), `ExactPredicates`, and the
+`UnitSpherical` names are already in scope here — this file is `include`d into
+`GeometryOps`, which `using`s them at the top of the module. The
+`_rebuild_point(::UnitSphericalPoint, …)` hook that keeps node points typed
+lives next to the generic `_rebuild_point` in `kernel.jl`.
+=#
+
+# xyz tuple of a 3D point, for the ExactPredicates / Rational{BigInt} paths.
+@inline _tup3(u) = (GI.x(u), GI.y(u), GI.z(u))

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -30,19 +30,40 @@ rk_orient(::Spherical, a, b, c; exact) = _rk_orient(booltype(exact), a, b, c)
     ExactPredicates.orient(_tup3(a), _tup3(b), _tup3(c), (0.0, 0.0, 0.0))
 @inline _rk_orient(::False, a, b, c) = cross(a, b) ⋅ c
 
+# ## Exact-aware 3-vector arithmetic
+#
+# Composite predicates (arc membership, proper crossing, node coincidence)
+# reduce to signs of polynomials in the xyz components. With `exact = True()` we
+# evaluate over `Rational{BigInt}` (Float64 are dyadic rationals → exact); with
+# `False()`, Float64. `_vec3(bt, p)` lifts a point to the chosen number type; the
+# rest are plain tuple cross/dot, so one code path serves both — exactly how the
+# planar kernel threads `exact`.
+@inline _vec3(::True, u) = (Rational{BigInt}(GI.x(u)), Rational{BigInt}(GI.y(u)), Rational{BigInt}(GI.z(u)))
+@inline _vec3(::False, u) = (Float64(GI.x(u)), Float64(GI.y(u)), Float64(GI.z(u)))
+@inline _cross3(a, b) = (a[2]*b[3] - a[3]*b[2], a[3]*b[1] - a[1]*b[3], a[1]*b[2] - a[2]*b[1])
+@inline _dot3(a, b) = a[1]*b[1] + a[2]*b[2] + a[3]*b[3]
+@inline _iszero3(a) = iszero(a[1]) && iszero(a[2]) && iszero(a[3])
+@inline _neg3(a) = (-a[1], -a[2], -a[3])
+# `w` strictly interior to the minor arc (a, b) with normal n = a×b.
+@inline _strictly_in_arc3(w, a, b, n) = _dot3(_cross3(a, w), n) > 0 && _dot3(_cross3(w, b), n) > 0
+_usp_eq(p, q) = GI.x(p) == GI.x(q) && GI.y(p) == GI.y(q) && GI.z(p) == GI.z(q)
+
 # ## rk_point_on_segment
 
 # Whether `p` lies on the closed minor arc `[q0, q1]`. Two conditions: `p` is on
-# the arc's great circle (coplanar with `q0`, `q1`, the origin — an exact orient
-# == 0), and within the minor-arc span. The span test uses dots as cos-of-angle:
-# for unit vectors `q0·p >= q0·q1` means `p` is no farther from `q0` than `q1`
-# is, and symmetrically for `q1`; together they pin `p` to the minor arc. Engine
-# inputs are unit; the conformance grid points are chosen so the dot signs are
-# exact.
+# the arc's great circle (coplanar with `q0`, `q1`, origin — an exact orient ==
+# 0), and within the minor-arc span. The span test is scale-invariant: writing
+# the coplanar `p` as `α q0 + β q1`, `p` is on the closed minor arc iff α, β ≥ 0,
+# and `sign(β) = sign((q0×p)·n)`, `sign(α) = sign((p×q1)·n)` with `n = q0×q1` — a
+# pure determinant sign, correct for unit and non-unit inputs alike.
 function rk_point_on_segment(m::Spherical, p, q0, q1; exact)
     rk_orient(m, q0, q1, p; exact) == 0 || return false
-    qq = q0 ⋅ q1
-    return (q0 ⋅ p) >= qq && (q1 ⋅ p) >= qq
+    return _on_arc_span(booltype(exact), p, q0, q1)
+end
+@inline function _on_arc_span(bt, p, q0, q1)
+    P = _vec3(bt, p); Q0 = _vec3(bt, q0); Q1 = _vec3(bt, q1)
+    n = _cross3(Q0, Q1)
+    return _dot3(_cross3(Q0, P), n) >= 0 && _dot3(_cross3(P, Q1), n) >= 0
 end
 
 # ## Ingest and interaction bounds
@@ -101,6 +122,47 @@ end
 
 @inline _point_box(u) =
     Extents.Extent(X = _widen(GI.x(u), GI.x(u)), Y = _widen(GI.y(u), GI.y(u)), Z = _widen(GI.z(u), GI.z(u)))
+
+# ## rk_classify_intersection
+#
+# The two great circles meet at ±d, d = (a0×a1)×(b0×b1). `SS_PROPER` iff one of
+# ±d is strictly interior to both minor arcs (the candidate-direct formulation —
+# planar straddle tests are NOT sufficient on the sphere, where arcs can straddle
+# each other's great circle while meeting only at the antipodal point). Endpoint
+# incidences are exact arc-membership; collinear = the arcs share a great circle
+# (d == 0). No intersection coordinate is constructed.
+function rk_classify_intersection(m::Spherical, a0, a1, b0, b1; exact)
+    a0_on_b = rk_point_on_segment(m, a0, b0, b1; exact)
+    a1_on_b = rk_point_on_segment(m, a1, b0, b1; exact)
+    b0_on_a = rk_point_on_segment(m, b0, a0, a1; exact)
+    b1_on_a = rk_point_on_segment(m, b1, a0, a1; exact)
+    return _sph_classify(booltype(exact), a0, a1, b0, b1, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
+end
+
+function _sph_classify(bt, a0, a1, b0, b1, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
+    A0 = _vec3(bt, a0); A1 = _vec3(bt, a1); B0 = _vec3(bt, b0); B1 = _vec3(bt, b1)
+    na = _cross3(A0, A1); nb = _cross3(B0, B1)
+    d = _cross3(na, nb)
+    n_inc = a0_on_b + a1_on_b + b0_on_a + b1_on_a
+    if _iszero3(d)   # same great circle (or a degenerate, zero-length arc)
+        n_inc == 0 && return SegSegClass(SS_DISJOINT, false, false, false, false)
+        # a degenerate (zero-length) arc on the other is a touch, not an overlap
+        zero_len = _iszero3(na) || _iszero3(nb)
+        shared_only = n_inc == 2 && (a0_on_b || a1_on_b) && (b0_on_a || b1_on_a) &&
+            (_usp_eq(a0, b0) || _usp_eq(a0, b1) || _usp_eq(a1, b0) || _usp_eq(a1, b1))
+        kind = (shared_only || zero_len) ? SS_TOUCH : SS_COLLINEAR
+        return SegSegClass(kind, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
+    end
+    if a0_on_b || a1_on_b || b0_on_a || b1_on_a
+        return SegSegClass(SS_TOUCH, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
+    end
+    nd = _neg3(d)
+    if (_strictly_in_arc3(d, A0, A1, na) && _strictly_in_arc3(d, B0, B1, nb)) ||
+       (_strictly_in_arc3(nd, A0, A1, na) && _strictly_in_arc3(nd, B0, B1, nb))
+        return SegSegClass(SS_PROPER, false, false, false, false)
+    end
+    return SegSegClass(SS_DISJOINT, false, false, false, false)
+end
 
 # Interaction bounds on the sphere: a 3D `Extent{(:X,:Y,:Z)}` in unit-sphere xyz
 # (the engine works in xyz after ingest), as the union of `arc_extent` over the

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -44,3 +44,98 @@ function rk_point_on_segment(m::Spherical, p, q0, q1; exact)
     qq = q0 ⋅ q1
     return (q0 ⋅ p) >= qq && (q1 ⋅ p) >= qq
 end
+
+# ## Ingest and interaction bounds
+
+# Renormalize to unit length (Float32-sourced data — e.g. Natural Earth GeoJSON
+# converted to Float64 — is ~1e-8 off unit and trips `robust_cross_product`).
+@inline rk_normalize_usp(u) = UnitSphericalPoint(normalize(u))
+
+# Canonical kernel point of a GeoInterface point: lon/lat (2D) → unit xyz, or an
+# already-3D point treated as xyz; renormalized and signed-zero normalized so
+# the same vertex always produces identical bits (NodeKey equality). The vertex
+# ingest (Phase 3 `_to_kernel_point`) and the extent computation below share
+# this, so a vertex and its extent agree exactly.
+@inline function _spherical_kernel_point(p)
+    u = GI.is3d(p) ?
+        UnitSphericalPoint(Float64(GI.x(p)), Float64(GI.y(p)), Float64(GI.z(p))) :
+        UnitSphereFromGeographic()((Float64(GI.x(p)), Float64(GI.y(p))))
+    return _node_point(rk_normalize_usp(u))
+end
+
+# 3D AABB of a minor great-circle arc (spike-proven, 0/102k fuzz escapes). A
+# great-circle arc bulges outside the coordinate box of its endpoints; the
+# extremum of coordinate i on the circle with normal n is at ±w, the normalized
+# projection of axis eᵢ onto the circle's plane. The box is extended by whichever
+# of ±w lies on the minor arc; a few ulps of widening absorb the roundoff in w.
+@inline _on_minor_arc(w, a, b, n) = (cross(a, w) ⋅ n) >= 0.0 && (cross(w, b) ⋅ n) >= 0.0
+@inline _widen(lo, hi) = (prevfloat(lo, 4), nextfloat(hi, 4))
+
+function arc_extent(a, b)
+    n = cross(a, b)
+    n2 = n ⋅ n
+    xlo, xhi = minmax(a[1], b[1]); ylo, yhi = minmax(a[2], b[2]); zlo, zhi = minmax(a[3], b[3])
+    if n2 > 0.0
+        invn2 = inv(n2)
+        @inbounds for i in 1:3
+            ei_n = n[i]
+            wx = (i == 1) - ei_n * n[1] * invn2
+            wy = (i == 2) - ei_n * n[2] * invn2
+            wz = (i == 3) - ei_n * n[3] * invn2
+            wnorm = sqrt(wx^2 + wy^2 + wz^2)
+            wnorm == 0.0 && continue   # axis ⟂ plane: coordinate constant 0, endpoints cover it
+            w = UnitSphericalPoint(wx / wnorm, wy / wnorm, wz / wnorm)
+            for ww in (w, -w)
+                if _on_minor_arc(ww, a, b, n)
+                    ci = ww[i]
+                    if i == 1; xlo = min(xlo, ci); xhi = max(xhi, ci)
+                    elseif i == 2; ylo = min(ylo, ci); yhi = max(yhi, ci)
+                    else; zlo = min(zlo, ci); zhi = max(zhi, ci)
+                    end
+                end
+            end
+        end
+    end
+    return Extents.Extent(X = _widen(xlo, xhi), Y = _widen(ylo, yhi), Z = _widen(zlo, zhi))
+end
+
+@inline _point_box(u) =
+    Extents.Extent(X = _widen(GI.x(u), GI.x(u)), Y = _widen(GI.y(u), GI.y(u)), Z = _widen(GI.z(u), GI.z(u)))
+
+# Interaction bounds on the sphere: a 3D `Extent{(:X,:Y,:Z)}` in unit-sphere xyz
+# (the engine works in xyz after ingest), as the union of `arc_extent` over the
+# geometry's edges. Area-element interiors reach beyond their boundary slab — the
+# ±eᵢ axis-point extension is added in Task 11.
+rk_interaction_bounds(m::Spherical, geom) = _sph_bounds(m, GI.trait(geom), geom)
+
+function _sph_bounds(::Spherical, ::GI.AbstractPointTrait, geom)
+    return _point_box(_spherical_kernel_point(geom))
+end
+function _sph_bounds(::Spherical, ::GI.AbstractCurveTrait, geom)
+    n = GI.npoint(geom)
+    prev = _spherical_kernel_point(GI.getpoint(geom, 1))
+    n == 1 && return _point_box(prev)
+    ext = nothing
+    for i in 2:n
+        cur = _spherical_kernel_point(GI.getpoint(geom, i))
+        e = arc_extent(prev, cur)
+        ext = ext === nothing ? e : Extents.union(ext, e)
+        prev = cur
+    end
+    return ext
+end
+function _sph_bounds(m::Spherical, ::GI.AbstractPolygonTrait, geom)
+    ext = _sph_bounds(m, GI.trait(GI.getexterior(geom)), GI.getexterior(geom))
+    for hole in GI.gethole(geom)
+        ext = Extents.union(ext, _sph_bounds(m, GI.trait(hole), hole))
+    end
+    return ext
+end
+function _sph_bounds(m::Spherical, ::GI.AbstractGeometryTrait, geom)
+    ext = nothing
+    for g in GI.getgeom(geom)
+        e = _sph_bounds(m, GI.trait(g), g)
+        ext = ext === nothing ? e : Extents.union(ext, e)
+    end
+    return ext
+end

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -99,9 +99,19 @@ _kernel_point_type(::Spherical) = UnitSphericalPoint{Float64}
 @inline _on_minor_arc(w, a, b, n) = (cross(a, w) ⋅ n) >= 0.0 && (cross(w, b) ⋅ n) >= 0.0
 @inline _widen(lo, hi) = (prevfloat(lo, 4), nextfloat(hi, 4))
 
+@noinline _throw_antipodal_edge(a, b) = throw(ArgumentError(
+    "spherical edge between antipodal vertices $(_tup3(a)) and $(_tup3(b)) has no " *
+    "unique great-circle arc; densify it first with the `AntipodalEdgeSplit` " *
+    "correction (it inserts the lon/lat midpoint)"))
+
 function arc_extent(a, b)
     n = cross(a, b)
     n2 = n ⋅ n
+    #-- a vanishing normal with the endpoints pointing opposite ways means the
+    #-- vertices are exactly antipodal: infinitely many great circles pass
+    #-- through them, so the edge has no well-defined arc. (A vanishing normal
+    #-- with a·b > 0 is a zero-length/repeated vertex, which is fine.)
+    n2 == 0.0 && (a ⋅ b) < 0.0 && _throw_antipodal_edge(a, b)
     xlo, xhi = minmax(a[1], b[1]); ylo, yhi = minmax(a[2], b[2]); zlo, zhi = minmax(a[3], b[3])
     if n2 > 0.0
         invn2 = inv(n2)

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -266,6 +266,62 @@ function rk_nodes_coincide(::Spherical, k1::NodeKey, k2::NodeKey; exact)
     return _iszero3(_cross3(d1, d2)) && _dot3(d1, d2) > 0
 end
 
+# ## rk_point_in_ring (meridian-crossing parity, S2 convention)
+
+const _NPOLE = UnitSphericalPoint(0.0, 0.0, 1.0)
+
+# Whether the two minor arcs (p0,p1) and (q0,q1) cross properly (interior to
+# both). The great circles meet at ±d, d = (p0×p1)×(q0×q1); a proper crossing is
+# one of ±d strictly interior to both arcs (the spike's `arcs_cross_properly`).
+function _arcs_cross_properly(bt, p0, p1, q0, q1)
+    P0 = _vec3(bt, p0); P1 = _vec3(bt, p1); Q0 = _vec3(bt, q0); Q1 = _vec3(bt, q1)
+    na = _cross3(P0, P1); nb = _cross3(Q0, Q1)
+    d = _cross3(na, nb)
+    _iszero3(d) && return false
+    (_strictly_in_arc3(d, P0, P1, na) && _strictly_in_arc3(d, Q0, Q1, nb)) && return true
+    nd = _neg3(d)
+    return _strictly_in_arc3(nd, P0, P1, na) && _strictly_in_arc3(nd, Q0, Q1, nb)
+end
+
+# Whether the north pole lies in the ring's interior (S2 interior-on-left). The
+# signed solid angle of the loop seen from the pole (sum of signed triangle
+# areas, Van Oosterom–Strackee) is +interior_area when the pole is interior and
+# interior_area − 4π when exterior — so it is positive exactly when the pole is
+# inside. Float is sufficient: a global orientation property, robust unless the
+# ring hugs a great circle (Ω ≈ 0).
+function _ring_contains_pole(pts)
+    Ω = 0.0
+    N = _NPOLE
+    for i in 1:length(pts)-1
+        a = normalize(pts[i]); b = normalize(pts[i+1])
+        Ω += 2 * atan(N ⋅ cross(a, b), 1.0 + (N ⋅ a) + (a ⋅ b) + (b ⋅ N))
+    end
+    return Ω > 0
+end
+
+# Location of `p` relative to the area enclosed by `ring`. Boundary first (exact
+# arc membership), then parity of proper crossings of the minor arc p→NPOLE with
+# the ring edges — "same region as the pole" — resolved to interior/exterior by
+# the pole's own containment.
+#
+# NOTE: the north-pole reference is degenerate when `p` is at/antipodal to the
+# pole, or a ring vertex sits exactly on the p→pole meridian. The engine inputs
+# in this work avoid those; the deterministic-perturbation / other-pole
+# treatment (mirroring planar RayCrossingCounter) is a follow-up.
+function rk_point_in_ring(m::Spherical, p, ring; exact)
+    pts = _node_points(ring)
+    @inbounds for i in 1:length(pts)-1
+        rk_point_on_segment(m, p, pts[i], pts[i+1]; exact) && return LOC_BOUNDARY
+    end
+    bt = booltype(exact)
+    crossings = 0
+    @inbounds for i in 1:length(pts)-1
+        _arcs_cross_properly(bt, p, _NPOLE, pts[i], pts[i+1]) && (crossings += 1)
+    end
+    pole_inside = _ring_contains_pole(pts)
+    return (isodd(crossings) ⊻ pole_inside) ? LOC_INTERIOR : LOC_EXTERIOR
+end
+
 # Interaction bounds on the sphere: a 3D `Extent{(:X,:Y,:Z)}` in unit-sphere xyz
 # (the engine works in xyz after ingest), as the union of `arc_extent` over the
 # geometry's edges. Area-element interiors reach beyond their boundary slab — the

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -283,21 +283,24 @@ function _arcs_cross_properly(bt, p0, p1, q0, q1)
     return _strictly_in_arc3(nd, P0, P1, na) && _strictly_in_arc3(nd, Q0, Q1, nb)
 end
 
-# Whether the north pole lies in the ring's interior (S2 interior-on-left). The
-# signed solid angle of the loop seen from the pole (sum of signed triangle
-# areas, Van Oosterom–Strackee) is +interior_area when the pole is interior and
-# interior_area − 4π when exterior — so it is positive exactly when the pole is
-# inside. Float is sufficient: a global orientation property, robust unless the
-# ring hugs a great circle (Ω ≈ 0).
-function _ring_contains_pole(pts)
-    Ω = 0.0
-    N = _NPOLE
+# Whether direction `N` lies in the ring's interior (S2 interior-on-left),
+# decided by the ring's winding around `N`: project each edge onto the plane ⊥ N
+# and sum the signed turn (each < π in magnitude, so there is no atan2 branch
+# ambiguity — unlike a per-triangle solid-angle sum). A single interior-on-left
+# enclosure sweeps +2π. Robust for rings smaller than a hemisphere (the common
+# geographic case); a super-hemisphere interior would under-report a
+# non-encircled interior axis — a documented limitation, see the design doc.
+function _ring_contains_dir(pts, N)
+    θ = 0.0
     for i in 1:length(pts)-1
-        a = normalize(pts[i]); b = normalize(pts[i+1])
-        Ω += 2 * atan(N ⋅ cross(a, b), 1.0 + (N ⋅ a) + (a ⋅ b) + (b ⋅ N))
+        a = pts[i]; b = pts[i+1]
+        ua = a - (a ⋅ N) * N
+        ub = b - (b ⋅ N) * N
+        θ += atan(N ⋅ cross(ua, ub), ua ⋅ ub)
     end
-    return Ω > 0
+    return θ > π
 end
+@inline _ring_contains_pole(pts) = _ring_contains_dir(pts, _NPOLE)
 
 # Location of `p` relative to the area enclosed by `ring`. Boundary first (exact
 # arc membership), then parity of proper crossings of the minor arc p→NPOLE with
@@ -324,32 +327,49 @@ end
 
 # Interaction bounds on the sphere: a 3D `Extent{(:X,:Y,:Z)}` in unit-sphere xyz
 # (the engine works in xyz after ingest), as the union of `arc_extent` over the
-# geometry's edges. Area-element interiors reach beyond their boundary slab — the
-# ±eᵢ axis-point extension is added in Task 11.
+# geometry's edges, plus — for area elements — an axis-point extension so the box
+# covers the interior, not just the boundary slab.
 rk_interaction_bounds(m::Spherical, geom) = _sph_bounds(m, GI.trait(geom), geom)
+
+# Converted (lon/lat → unit xyz) vertices of a ring/curve.
+_ring_usp(ring) = [_spherical_kernel_point(p) for p in GI.getpoint(ring)]
+
+# Union of arc_extents over consecutive vertices (a single point box if n == 1).
+function _arcs_extent(usp)
+    length(usp) == 1 && return _point_box(usp[1])
+    ext = arc_extent(usp[1], usp[2])
+    for i in 2:length(usp)-1
+        ext = Extents.union(ext, arc_extent(usp[i], usp[i+1]))
+    end
+    return ext
+end
 
 function _sph_bounds(::Spherical, ::GI.AbstractPointTrait, geom)
     return _point_box(_spherical_kernel_point(geom))
 end
-function _sph_bounds(::Spherical, ::GI.AbstractCurveTrait, geom)
-    n = GI.npoint(geom)
-    prev = _spherical_kernel_point(GI.getpoint(geom, 1))
-    n == 1 && return _point_box(prev)
-    ext = nothing
-    for i in 2:n
-        cur = _spherical_kernel_point(GI.getpoint(geom, i))
-        e = arc_extent(prev, cur)
-        ext = ext === nothing ? e : Extents.union(ext, e)
-        prev = cur
-    end
-    return ext
-end
-function _sph_bounds(m::Spherical, ::GI.AbstractPolygonTrait, geom)
-    ext = _sph_bounds(m, GI.trait(GI.getexterior(geom)), GI.getexterior(geom))
+_sph_bounds(::Spherical, ::GI.AbstractCurveTrait, geom) = _arcs_extent(_ring_usp(geom))
+function _sph_bounds(::Spherical, ::GI.AbstractPolygonTrait, geom)
+    exterior = _ring_usp(GI.getexterior(geom))
+    ext = _arcs_extent(exterior)
     for hole in GI.gethole(geom)
-        ext = Extents.union(ext, _sph_bounds(m, GI.trait(hole), hole))
+        ext = Extents.union(ext, _arcs_extent(_ring_usp(hole)))
     end
-    return ext
+    # An area interior reaches beyond its boundary slab (e.g. a ring around a
+    # pole has a thin boundary band but its interior reaches z = 1). Widen each
+    # axis whose ±eᵢ is interior to the exterior ring out to ±1 (conservative —
+    # over-covering can only under-prune, never miss an interaction).
+    return _widen_area_axes(ext, exterior)
+end
+
+function _widen_area_axes(ext, pts)
+    xlo, xhi = ext.X; ylo, yhi = ext.Y; zlo, zhi = ext.Z
+    _ring_contains_dir(pts, UnitSphericalPoint(1.0, 0.0, 0.0)) && (xhi = 1.0)
+    _ring_contains_dir(pts, UnitSphericalPoint(-1.0, 0.0, 0.0)) && (xlo = -1.0)
+    _ring_contains_dir(pts, UnitSphericalPoint(0.0, 1.0, 0.0)) && (yhi = 1.0)
+    _ring_contains_dir(pts, UnitSphericalPoint(0.0, -1.0, 0.0)) && (ylo = -1.0)
+    _ring_contains_dir(pts, UnitSphericalPoint(0.0, 0.0, 1.0)) && (zhi = 1.0)
+    _ring_contains_dir(pts, UnitSphericalPoint(0.0, 0.0, -1.0)) && (zlo = -1.0)
+    return Extents.Extent(X = (xlo, xhi), Y = (ylo, yhi), Z = (zlo, zhi))
 end
 function _sph_bounds(m::Spherical, ::GI.AbstractGeometryTrait, geom)
     ext = nothing

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -84,6 +84,13 @@ end
     return _node_point(rk_normalize_usp(u))
 end
 
+# Phase 3 ingest hooks (the planar methods live in kernel.jl). The spherical
+# kernel point type is the unit-sphere xyz point; conversion is the canonical
+# `_spherical_kernel_point` (lon/lat → unit xyz, or an already-xyz point
+# renormalized), so an ingested vertex agrees bit-for-bit with its extent.
+_kernel_point_type(::Spherical) = UnitSphericalPoint{Float64}
+@inline _to_kernel_point(::Spherical, p) = _spherical_kernel_point(p)
+
 # 3D AABB of a minor great-circle arc (spike-proven, 0/102k fuzz escapes). A
 # great-circle arc bulges outside the coordinate box of its endpoints; the
 # extremum of coordinate i on the circle with normal n is at ±w, the normalized
@@ -311,8 +318,17 @@ end
 # pole, or a ring vertex sits exactly on the p→pole meridian. The engine inputs
 # in this work avoid those; the deterministic-perturbation / other-pole
 # treatment (mirroring planar RayCrossingCounter) is a follow-up.
+# Ring vertices as spherical kernel points. A 3D ring is already in kernel
+# coordinates (e.g. the conformance suite's exact integer USP rings) and is read
+# verbatim — renormalizing would perturb the exact orient the boundary test
+# relies on. A 2D (lon/lat) ring — the engine's ingested polygon — is converted
+# to unit xyz.
+_ring_kernel_pts(ring) = _ring_kernel_pts(booltype(GI.is3d(GI.getpoint(ring, 1))), ring)
+_ring_kernel_pts(::True, ring) = _node_points(ring)
+_ring_kernel_pts(::False, ring) = _ring_usp(ring)
+
 function rk_point_in_ring(m::Spherical, p, ring; exact)
-    pts = _node_points(ring)
+    pts = _ring_kernel_pts(ring)
     @inbounds for i in 1:length(pts)-1
         rk_point_on_segment(m, p, pts[i], pts[i+1]; exact) && return LOC_BOUNDARY
     end

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -248,6 +248,24 @@ function rk_compare_edge_dir(m::Spherical, node::NodeKey, p, q; exact)
     return _sph_compare_around(bt, _sph_crossing_dir(bt, node), p, q)
 end
 
+# ## rk_nodes_coincide (exact slow path)
+#
+# Whether two node keys denote the same sphere point. The point of a vertex node
+# is its coordinate direction; of a crossing node, the on-arc crossing direction
+# `±(na×nb)`. Two directions denote the same sphere point iff they are parallel
+# (cross product zero) and point into the same hemisphere (positive dot) — `-d`
+# is the antipodal point, a different node. Exact via `Rational{BigInt}` (the
+# `True()` branch of `_vec3`), mirroring the planar D3 rational slow path.
+@inline _exact_node_dir(bt, k::NodeKey) =
+    k.is_crossing ? _sph_crossing_dir(bt, k) : _vec3(bt, k.pt)
+
+function rk_nodes_coincide(::Spherical, k1::NodeKey, k2::NodeKey; exact)
+    k1 == k2 && return true
+    bt = booltype(exact)
+    d1 = _exact_node_dir(bt, k1); d2 = _exact_node_dir(bt, k2)
+    return _iszero3(_cross3(d1, d2)) && _dot3(d1, d2) > 0
+end
+
 # Interaction bounds on the sphere: a 3D `Extent{(:X,:Y,:Z)}` in unit-sphere xyz
 # (the engine works in xyz after ingest), as the union of `arc_extent` over the
 # geometry's edges. Area-element interiors reach beyond their boundary slab — the

--- a/src/methods/geom_relations/relateng/point_locator.jl
+++ b/src/methods/geom_relations/relateng/point_locator.jl
@@ -37,9 +37,9 @@ struct LinearBoundary{BR <: BoundaryNodeRule, P}
     rule::BR
 end
 
-function LinearBoundary(lines, rule::BoundaryNodeRule)
+function LinearBoundary(m::Manifold, lines, rule::BoundaryNodeRule)
     # assert: dim(geom) == 1
-    vertex_degree = _compute_boundary_points(lines)
+    vertex_degree = _compute_boundary_points(m, lines)
     has_boundary = _check_boundary(vertex_degree, rule)
     return LinearBoundary(vertex_degree, has_boundary, rule)
 end
@@ -62,13 +62,13 @@ function is_boundary(lb::LinearBoundary, pt)
     return is_in_boundary(lb.rule, degree)
 end
 
-function _compute_boundary_points(lines)
-    vertex_degree = Dict{Tuple{Float64, Float64}, Int}()
+function _compute_boundary_points(m::Manifold, lines)
+    vertex_degree = Dict{_kernel_point_type(m), Int}()
     for line in lines
         n = GI.npoint(line)
         n == 0 && continue
-        _add_endpoint!(_node_point(GI.getpoint(line, 1)), vertex_degree)
-        _add_endpoint!(_node_point(GI.getpoint(line, n)), vertex_degree)
+        _add_endpoint!(_to_kernel_point(m, GI.getpoint(line, 1)), vertex_degree)
+        _add_endpoint!(_to_kernel_point(m, GI.getpoint(line, n)), vertex_degree)
     end
     return vertex_degree
 end
@@ -110,7 +110,7 @@ struct AdjacentEdgeLocator{M <: Manifold, E, P}
 end
 
 function AdjacentEdgeLocator(m::Manifold, geom; exact)
-    ring_list = Vector{Tuple{Float64, Float64}}[]
+    ring_list = Vector{_kernel_point_type(m)}[]
     _ael_init!(m, ring_list, geom; exact)
     return AdjacentEdgeLocator(m, exact, ring_list)
 end
@@ -197,7 +197,7 @@ _add_rings!(m, ::GI.AbstractTrait, geom, ring_list; exact) = nothing
 # helper `_ring_is_ccw`.)
 function _add_ring!(m, ring, require_cw::Bool, ring_list; exact)
     #TODO: remove repeated points?
-    pts = _node_points(ring)
+    pts = _to_kernel_points(m, ring)
     pts = _orient_ring(m, pts, require_cw; exact)
     push!(ring_list, pts)
     return nothing
@@ -242,7 +242,7 @@ build and reuse the indexed locator — one O(n) scan beats an O(n) index
 build, while the many area-vertex locations of a multi-element relate
 amortize the index (see `locate_on_polygonal`).
 """
-mutable struct RelatePointLocator{M <: Manifold, E, G, BR <: BoundaryNodeRule}
+mutable struct RelatePointLocator{M <: Manifold, E, G, BR <: BoundaryNodeRule, P}
     const m::M
     const exact::E
     const geom::G
@@ -251,11 +251,11 @@ mutable struct RelatePointLocator{M <: Manifold, E, G, BR <: BoundaryNodeRule}
     # element collections extracted from the (possibly nested-GC) input.
     # Java leaves these null when no element of that kind exists; here they
     # are simply empty. Heterogeneous GI element types force `Any` element
-    # eltypes.
-    const points::Set{Tuple{Float64, Float64}}
+    # eltypes. `P` is the manifold's kernel point type (Phase 3).
+    const points::Set{P}
     const lines::Vector{Any}
     const polygons::Vector{Any}
-    const line_boundary::LinearBoundary{BR, Tuple{Float64, Float64}}
+    const line_boundary::LinearBoundary{BR, P}
     const is_empty::Bool
     # per-polygonal-element indexed locators, created lazily by
     # `_get_poly_locator` (Java: polyLocator, filled by getLocator).
@@ -266,16 +266,17 @@ mutable struct RelatePointLocator{M <: Manifold, E, G, BR <: BoundaryNodeRule}
     # index heuristic above
     const poly_query_count::Vector{Int32}
     # lazily built on the first multi-boundary point (Java: adjEdgeLocator)
-    adj_edge_locator::Union{Nothing, AdjacentEdgeLocator{M, E, Tuple{Float64, Float64}}}
+    adj_edge_locator::Union{Nothing, AdjacentEdgeLocator{M, E, P}}
 end
 
 function RelatePointLocator(m::Manifold, geom; exact,
         is_prepared::Bool = false, boundary_rule::BoundaryNodeRule = Mod2Boundary())
     #-- init(geom)
-    points = Set{Tuple{Float64, Float64}}()
+    P = _kernel_point_type(m)
+    points = Set{P}()
     lines = Any[]
     polygons = Any[]
-    _extract_elements!(points, lines, polygons, geom)
+    _extract_elements!(m, points, lines, polygons, geom)
     # Java caches `isEmpty = geom.isEmpty()` (recursive emptiness); since
     # `extractElements` skips empty elements, the input is recursively empty
     # iff nothing was extracted.
@@ -283,14 +284,18 @@ function RelatePointLocator(m::Manifold, geom; exact,
     # Java builds `lineBoundary` only when lines exist; an empty
     # LinearBoundary behaves identically (no boundary, no boundary points),
     # so it is built unconditionally here.
-    line_boundary = LinearBoundary(lines, boundary_rule)
+    line_boundary = LinearBoundary(m, lines, boundary_rule)
     # Java allocates `polyLocator` for both modes (Simple/Indexed); here both
     # modes may cache indexed locator objects (unprepared lazily, on repeat
     # queries), so it is allocated unconditionally.
     poly_locator = Vector{Union{Nothing, IndexedPointInAreaLocator{typeof(m), typeof(exact)}}}(
         nothing, length(polygons))
     poly_query_count = zeros(Int32, length(polygons))
-    return RelatePointLocator(m, exact, geom, is_prepared, boundary_rule,
+    #-- P cannot be inferred from the `nothing` adj_edge_locator, so spell out
+    #-- every type parameter
+    return RelatePointLocator{typeof(m), typeof(exact), typeof(geom),
+            typeof(boundary_rule), P}(
+        m, exact, geom, is_prepared, boundary_rule,
         points, lines, polygons, line_boundary, is_empty, poly_locator,
         poly_query_count, nothing)
 end
@@ -299,38 +304,38 @@ has_boundary(loc::RelatePointLocator) = has_boundary(loc.line_boundary)
 
 # Port of RelatePointLocator.extractElements + addPoint/addLine/addPolygonal:
 # trait-dispatched traversal of the (possibly nested) collection structure.
-_extract_elements!(points, lines, polygons, geom) =
-    _extract_elements!(points, lines, polygons, GI.trait(geom), geom)
+_extract_elements!(m, points, lines, polygons, geom) =
+    _extract_elements!(m, points, lines, polygons, GI.trait(geom), geom)
 
-function _extract_elements!(points, lines, polygons, ::GI.PointTrait, geom)
+function _extract_elements!(m, points, lines, polygons, ::GI.PointTrait, geom)
     GI.isempty(geom) && return nothing
-    #-- addPoint: normalized coordinate tuples, as in LinearBoundary
-    push!(points, _node_point(geom))
+    #-- addPoint: normalized kernel points, as in LinearBoundary
+    push!(points, _to_kernel_point(m, geom))
     return nothing
 end
-function _extract_elements!(points, lines, polygons, ::GI.AbstractCurveTrait, geom)
+function _extract_elements!(m, points, lines, polygons, ::GI.AbstractCurveTrait, geom)
     GI.isempty(geom) && return nothing
     #-- addLine (Java LinearRing extends LineString, hence AbstractCurve)
     push!(lines, geom)
     return nothing
 end
-function _extract_elements!(points, lines, polygons,
+function _extract_elements!(m, points, lines, polygons,
         ::Union{GI.PolygonTrait, GI.MultiPolygonTrait}, geom)
     GI.isempty(geom) && return nothing
     #-- addPolygonal: whole polygonal geometry kept as one element
     push!(polygons, geom)
     return nothing
 end
-function _extract_elements!(points, lines, polygons,
+function _extract_elements!(m, points, lines, polygons,
         ::GI.AbstractGeometryCollectionTrait, geom)
     GI.isempty(geom) && return nothing
     #-- covers GeometryCollection, MultiPoint, MultiLineString
     for g in GI.getgeom(geom)
-        _extract_elements!(points, lines, polygons, g)
+        _extract_elements!(m, points, lines, polygons, g)
     end
     return nothing
 end
-_extract_elements!(points, lines, polygons, ::GI.AbstractTrait, geom) = nothing
+_extract_elements!(m, points, lines, polygons, ::GI.AbstractTrait, geom) = nothing
 
 """
     locate(loc::RelatePointLocator, p)
@@ -453,16 +458,16 @@ end
 # tree, which carries a stored extent on every linework element).
 # `is_node` is unused, as in Java (kept for signature parity).
 function locate_on_line(loc::RelatePointLocator, p, is_node::Bool, line)
-    #-- Java: lineEnv.intersects(p) short-circuit
-    pt_ext = Extents.Extent(X = (GI.x(p), GI.x(p)), Y = (GI.y(p), GI.y(p)))
+    #-- Java: lineEnv.intersects(p) short-circuit (p is already a kernel point)
+    pt_ext = _kernel_point_box(p)
     if rk_bounds_disjoint(rk_interaction_bounds(loc.m, line), pt_ext)
         return LOC_EXTERIOR
     end
     #-- Java: PointLocation.isOnLine over the coordinate sequence
     n = GI.npoint(line)
-    q0 = _tuple_point(GI.getpoint(line, 1))
+    q0 = _to_kernel_point(loc.m, GI.getpoint(line, 1))
     for i in 2:n
-        q1 = _tuple_point(GI.getpoint(line, i))
+        q1 = _to_kernel_point(loc.m, GI.getpoint(line, i))
         if rk_point_on_segment(loc.m, p, q0, q1; exact = loc.exact)
             return LOC_INTERIOR
         end

--- a/src/methods/geom_relations/relateng/relate_geometry.jl
+++ b/src/methods/geom_relations/relateng/relate_geometry.jl
@@ -39,7 +39,7 @@ Java caches `geomEnv = input.getEnvelopeInternal()`, here `extent` is the
 union of the interaction bounds (`rk_interaction_bounds`) of the non-empty
 elements, or `nothing` if the geometry is empty.
 """
-mutable struct RelateGeometry{M <: Manifold, E, G, BR <: BoundaryNodeRule, X}
+mutable struct RelateGeometry{M <: Manifold, E, G, BR <: BoundaryNodeRule, X, P}
     const m::M
     const exact::E
     const geom::G
@@ -55,9 +55,10 @@ mutable struct RelateGeometry{M <: Manifold, E, G, BR <: BoundaryNodeRule, X}
     # id counter for extracted elements (Java `elementId`); never reset, so
     # repeated extraction (prepared mode) keeps producing distinct ids.
     element_id::Int32
-    # lazy caches
-    unique_points::Union{Nothing, Set{Tuple{Float64, Float64}}}
-    locator::Union{Nothing, RelatePointLocator{M, E, G, BR}}
+    # lazy caches. `P` is the manifold's kernel point type (Phase 3): the
+    # coordinate type of every node point and segment-string vertex.
+    unique_points::Union{Nothing, Set{P}}
+    locator::Union{Nothing, RelatePointLocator{M, E, G, BR, P}}
 end
 
 function RelateGeometry(m::Manifold, geom; exact,
@@ -75,7 +76,12 @@ function RelateGeometry(m::Manifold, geom; exact,
     dim = _geom_dimension(geom)
     dim, has_points, has_lines, has_areas = _analyze_dimensions(geom, dim, is_geom_empty)
     is_line_zero_len = _is_zero_length_line(geom, dim)
-    return RelateGeometry(m, exact, geom, is_prepared, boundary_rule, extent,
+    #-- P (the kernel point type) cannot be inferred from the `nothing` lazy
+    #-- caches, so spell out every type parameter
+    P = _kernel_point_type(m)
+    return RelateGeometry{typeof(m), typeof(exact), typeof(geom), typeof(boundary_rule),
+            typeof(extent), P}(
+        m, exact, geom, is_prepared, boundary_rule, extent,
         dim, has_points, has_lines, has_areas, is_line_zero_len, is_geom_empty,
         Int32(0), nothing, nothing)
 end
@@ -394,7 +400,7 @@ function get_unique_points(rg::RelateGeometry)
     #-- will be re-used in prepared mode
     up = rg.unique_points
     up === nothing || return up
-    up = _create_unique_points(rg.geom)
+    up = _create_unique_points(rg.m, rg.geom)
     rg.unique_points = up
     return up
 end
@@ -402,31 +408,31 @@ end
 # Port of RelateGeometry.createUniquePoints. Only called on P geometries.
 # (Java uses ComponentCoordinateExtracter, which records the first coordinate
 # of each point/line component; for point geometries that is every point.)
-function _create_unique_points(geom)
-    set = Set{Tuple{Float64, Float64}}()
-    _add_component_coordinates!(set, geom)
+function _create_unique_points(m::Manifold, geom)
+    set = Set{_kernel_point_type(m)}()
+    _add_component_coordinates!(set, m, geom)
     return set
 end
 
-_add_component_coordinates!(set, geom) =
-    _add_component_coordinates!(set, GI.trait(geom), geom)
-function _add_component_coordinates!(set, ::GI.AbstractGeometryCollectionTrait, geom)
+_add_component_coordinates!(set, m, geom) =
+    _add_component_coordinates!(set, m, GI.trait(geom), geom)
+function _add_component_coordinates!(set, m, ::GI.AbstractGeometryCollectionTrait, geom)
     for g in GI.getgeom(geom)
-        _add_component_coordinates!(set, g)
+        _add_component_coordinates!(set, m, g)
     end
     return nothing
 end
-function _add_component_coordinates!(set, ::GI.AbstractPointTrait, geom)
+function _add_component_coordinates!(set, m, ::GI.AbstractPointTrait, geom)
     GI.isempty(geom) && return nothing
-    push!(set, _node_point(geom))
+    push!(set, _to_kernel_point(m, geom))
     return nothing
 end
-function _add_component_coordinates!(set, ::GI.AbstractCurveTrait, geom)
+function _add_component_coordinates!(set, m, ::GI.AbstractCurveTrait, geom)
     GI.isempty(geom) && return nothing
-    push!(set, _node_point(GI.getpoint(geom, 1)))
+    push!(set, _to_kernel_point(m, GI.getpoint(geom, 1)))
     return nothing
 end
-_add_component_coordinates!(set, ::GI.AbstractTrait, geom) = nothing
+_add_component_coordinates!(set, m, ::GI.AbstractTrait, geom) = nothing
 
 # Port of RelateGeometry.getEffectivePoints: the point elements which are not
 # covered by an element of higher dimension. (This JTS version has no
@@ -442,7 +448,7 @@ function get_effective_points(rg::RelateGeometry)
     pt_list = Any[]
     for p in pt_list_all
         GI.isempty(p) && continue
-        loc_dim = locate_with_dim(rg, _tuple_point(p))
+        loc_dim = locate_with_dim(rg, _to_kernel_point(rg.m, p))
         if dimloc_dimension(loc_dim) == DIM_P
             push!(pt_list, p)
         end
@@ -497,11 +503,11 @@ end
 _segment_string_eltype(rg::RelateGeometry, geom) =
     _segment_string_eltype(rg, GI.trait(geom), geom)
 _segment_string_eltype(rg::RG, ::GI.AbstractCurveTrait, geom) where {RG <: RelateGeometry} =
-    RelateSegmentString{Tuple{Float64, Float64}, Nothing, RG}
+    RelateSegmentString{_kernel_point_type(rg.m), Nothing, RG}
 #-- rings of MultiPolygon elements carry the MultiPolygon as parent
 _segment_string_eltype(rg::RG, ::Union{GI.AbstractPolygonTrait, GI.AbstractMultiPolygonTrait},
         geom) where {RG <: RelateGeometry} =
-    RelateSegmentString{Tuple{Float64, Float64}, typeof(geom), RG}
+    RelateSegmentString{_kernel_point_type(rg.m), typeof(geom), RG}
 function _segment_string_eltype(rg::RelateGeometry, ::GI.AbstractGeometryCollectionTrait, geom)
     T = Union{}
     for g in GI.getgeom(geom)
@@ -548,7 +554,7 @@ function _extract_segment_strings_from_atomic!(rg::RelateGeometry, is_a::Bool, g
     rg.element_id += Int32(1)
     trait = GI.trait(geom)
     if trait isa GI.AbstractCurveTrait
-        pts = _node_points(geom)
+        pts = _to_kernel_points(rg.m, geom)
         ss = _rss_create_line(pts, is_a, rg.element_id, rg)
         push!(seg_strings, ss)
     elseif trait isa GI.AbstractPolygonTrait
@@ -577,7 +583,7 @@ function _extract_ring_to_segment_string!(rg::RelateGeometry, is_a::Bool, ring, 
 
     #-- orient the points if required
     require_cw = ring_id == 0
-    pts = _node_points(ring)
+    pts = _to_kernel_points(rg.m, ring)
     pts = _orient_ring(rg.m, pts, require_cw; exact = rg.exact)
     ss = _rss_create_ring(pts, is_a, rg.element_id, ring_id, parent_poly, rg)
     push!(seg_strings, ss)

--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -712,18 +712,25 @@ relate_predicate(p::PreparedRelate, predicate::TopologyPredicate, b) =
 # `Planar` above the clipping size threshold only (B is unknown at prepare
 # time, so the decision is made on A's segment count alone); any other
 # explicit accelerator always takes the tree path.
-_build_prepared_edge_index(::Manifold, ::IntersectionAccelerator, segs_a) =
-    _make_prepared_edge_index(segs_a)
+_build_prepared_edge_index(m::Manifold, ::IntersectionAccelerator, segs_a) =
+    _make_prepared_edge_index(m, segs_a)
 _build_prepared_edge_index(::Manifold, ::NestedLoop, segs_a) = nothing
 _build_prepared_edge_index(::Manifold, ::AutoAccelerator, segs_a) = nothing
-function _build_prepared_edge_index(::Planar, ::AutoAccelerator, segs_a)
+function _build_prepared_edge_index(m::Planar, ::AutoAccelerator, segs_a)
     _total_segment_count(segs_a) >= GEOMETRYOPS_NO_OPTIMIZE_EDGEINTERSECT_NUMVERTS ||
         return nothing
-    return _make_prepared_edge_index(segs_a)
+    return _make_prepared_edge_index(m, segs_a)
+end
+#-- the Spherical tree path is valid too (3D arc extents); above the threshold
+#-- prepared mode indexes A just like Planar
+function _build_prepared_edge_index(m::Spherical, ::AutoAccelerator, segs_a)
+    _total_segment_count(segs_a) >= GEOMETRYOPS_NO_OPTIMIZE_EDGEINTERSECT_NUMVERTS ||
+        return nothing
+    return _make_prepared_edge_index(m, segs_a)
 end
 
-function _make_prepared_edge_index(segs_a)
-    extents, owners = _segment_extent_table(segs_a)
+function _make_prepared_edge_index(m::Manifold, segs_a)
+    extents, owners = _segment_extent_table(m, segs_a)
     isempty(extents) && return nothing
     return PreparedEdgeIndex(_relate_edge_index(extents), owners)
 end
@@ -739,7 +746,7 @@ _process_prepared_edges!(tc::TopologyComputer, segs_a, ::Nothing, edges_b) =
 function _process_prepared_edges!(tc::TopologyComputer, segs_a,
         eidx::PreparedEdgeIndex, edges_b;
         m::Manifold = _manifold(tc), exact = _exact(tc))
-    extents_b, owners_b = _segment_extent_table(edges_b)
+    extents_b, owners_b = _segment_extent_table(m, edges_b)
     isempty(extents_b) && return nothing
     tree_b = _relate_edge_index(extents_b)
     SpatialTreeInterface.dual_depth_first_search(Extents.intersects, eidx.tree, tree_b) do ia, ib

--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -377,7 +377,7 @@ function compute_points!(tc::TopologyComputer, geom::RelateGeometry, is_a::Bool,
         #TODO: exit when all possible target locations (E,I,B) have been found?
         GI.isempty(point) && continue
 
-        pt = _node_point(point)
+        pt = _to_kernel_point(geom.m, point)
         compute_point!(tc, is_a, pt, geom_target)
         is_result_known(tc) && return true
     end
@@ -424,12 +424,12 @@ function _compute_line_ends_walk!(tc::TopologyComputer, elem, geom::RelateGeomet
         return (false, has_exterior_intersection)
     end
 
-    e0 = _node_point(GI.getpoint(elem, 1))
+    e0 = _to_kernel_point(geom.m, GI.getpoint(elem, 1))
     has_exterior_intersection |= compute_line_end!(tc, geom, is_a, e0, geom_target)
     is_result_known(tc) && return (true, has_exterior_intersection)
 
     if !_line_is_closed(elem)
-        e1 = _node_point(GI.getpoint(elem, GI.npoint(elem)))
+        e1 = _to_kernel_point(geom.m, GI.getpoint(elem, GI.npoint(elem)))
         has_exterior_intersection |= compute_line_end!(tc, geom, is_a, e1, geom_target)
         is_result_known(tc) && return (true, has_exterior_intersection)
     end
@@ -504,7 +504,7 @@ end
 function compute_area_vertex_on_ring!(tc::TopologyComputer, geom::RelateGeometry,
         is_a::Bool, ring, geom_target::RelateGeometry)
     #TODO: use extremal (highest) point to ensure one is on boundary of polygon cluster
-    pt = _node_point(GI.getpoint(ring, 1))
+    pt = _to_kernel_point(geom.m, GI.getpoint(ring, 1))
 
     loc_area = locate_area_vertex(geom, pt)
     loc_dim_target = locate_with_dim(geom_target, pt)

--- a/src/methods/geom_relations/relateng/topology_computer.jl
+++ b/src/methods/geom_relations/relateng/topology_computer.jl
@@ -48,9 +48,10 @@ function TopologyComputer(predicate::TopologyPredicate,
     #-- both inputs must have been built with the same settings
     (geom_a.m == geom_b.m && geom_a.exact == geom_b.exact) ||
         throw(ArgumentError("RelateGeometry manifold/exact settings of the A and B inputs must agree"))
-    #-- P matches relate_geometry.jl's `_node_point` normalization of all
-    #-- segment-string coordinates to Tuple{Float64, Float64}
-    P = Tuple{Float64, Float64}
+    #-- P is the manifold's kernel point type, matching the coordinate type of
+    #-- every segment string / node point produced at ingest (Tuple{Float64,
+    #-- Float64} for Planar, UnitSphericalPoint{Float64} for Spherical)
+    P = _kernel_point_type(geom_a.m)
     tc = TopologyComputer(predicate, geom_a, geom_b, Dict{NodeKey{P}, NodeSections{P}}())
     init_exterior_dims!(tc)
     return tc

--- a/src/transformations/correction/antipodal_edge_split.jl
+++ b/src/transformations/correction/antipodal_edge_split.jl
@@ -1,0 +1,80 @@
+# # Antipodal Edge Split
+
+export AntipodalEdgeSplit
+
+#=
+On the sphere an edge between two *antipodal* vertices (a point and its
+antipode) has no unique great-circle arc — infinitely many great circles pass
+through both — so the spherical RelateNG kernel refuses such an edge (see
+[`arc_extent`](@ref) / `relate` with a `Spherical` manifold). This correction
+is the documented remedy: it splits every antipodal edge by inserting the
+lon/lat midpoint of its endpoints, replacing one ambiguous edge with two
+well-defined (roughly quarter-circle) arcs.
+
+## Example
+=#
+# ```@example antipodal
+# import GeometryOps as GO, GeoInterface as GI
+# # the edge (0,0)→(180,0) maps to the antipodal unit vectors (1,0,0) and (-1,0,0)
+# polygon = GI.Polygon([GI.LinearRing([(0., 0.), (180., 0.), (90., 80.), (0., 0.)])])
+# GO.fix(polygon; corrections = [GO.AntipodalEdgeSplit()])
+# ```
+#=
+The corrected ring carries the inserted midpoint `(90, 0)`, after which
+`relate(GO.RelateNG(; manifold = GO.Spherical()), …)` runs without error.
+
+## Implementation
+=#
+
+"""
+    AntipodalEdgeSplit() <: GeometryCorrection
+
+Split every edge whose endpoints map to exactly-antipodal unit vectors by
+inserting the lon/lat midpoint of the edge, so each edge has a well-defined
+great-circle arc. This is the remedy for the antipodal-edge `ArgumentError`
+thrown by `relate` on the `Spherical` manifold.
+
+It can be called on any geometry as usual (`AntipodalEdgeSplit()(geom)`), or
+passed to [`fix`](@ref).
+
+See also [`GeometryCorrection`](@ref).
+"""
+struct AntipodalEdgeSplit <: GeometryCorrection end
+
+application_level(::AntipodalEdgeSplit) = GI.PolygonTrait
+
+function (::AntipodalEdgeSplit)(::GI.PolygonTrait, polygon)
+    exterior = _split_antipodal_curve(GI.getexterior(polygon))
+    holes = map(_split_antipodal_curve, GI.gethole(polygon))
+    return GI.Wrappers.Polygon([exterior, holes...])
+end
+
+(::AntipodalEdgeSplit)(::GI.AbstractCurveTrait, curve) = _split_antipodal_curve(curve)
+
+# Whether the lon/lat points `p`, `q` map to exactly-antipodal unit vectors —
+# the same condition `arc_extent` throws on (vanishing cross, negative dot).
+function _is_antipodal_lonlat(p, q)
+    up = _spherical_kernel_point(p)
+    uq = _spherical_kernel_point(q)
+    n = cross(up, uq)
+    return iszero(n[1]) && iszero(n[2]) && iszero(n[3]) && (up ⋅ uq) < 0
+end
+
+# Insert the lon/lat midpoint into every antipodal edge of a ring/line,
+# returning the input unchanged (no copy) when there is nothing to split.
+function _split_antipodal_curve(curve)
+    pts = [tuples(p) for p in GI.getpoint(curve)]
+    split = false
+    out = similar(pts, 0)
+    push!(out, pts[1])
+    for i in 1:(length(pts) - 1)
+        p, q = pts[i], pts[i + 1]
+        if _is_antipodal_lonlat(p, q)
+            push!(out, ((p[1] + q[1]) / 2, (p[2] + q[2]) / 2))
+            split = true
+        end
+        push!(out, q)
+    end
+    split || return curve
+    return GI.geointerface_geomtype(GI.trait(curve))(out)
+end

--- a/test/methods/relateng/kernel.jl
+++ b/test/methods/relateng/kernel.jl
@@ -4,6 +4,7 @@
 using Test
 import GeometryOps as GO
 import GeometryOps: Planar, True, False
+import GeometryOps.UnitSpherical: UnitSphericalPoint
 import GeoInterface as GI
 
 const PT = Tuple{Float64, Float64}
@@ -261,4 +262,15 @@ end
     # crossing point with non-representable rational coordinates
     c3 = GO.crossing_node((0.,0.), (3.,1.), (0.,1.), (3.,0.))  # crosses at (1.5, 0.5)
     @test GO.rk_nodes_coincide(m, c3, GO.vertex_node((1.5, 0.5)); exact = True()) == true
+end
+
+@testset "node helpers are N-dimensional (3D round-trips)" begin
+    u = UnitSphericalPoint(0.0, -0.0, 1.0)
+    k = GO.vertex_node(u)
+    # signed zero normalized away, all three components preserved
+    @test GI.x(k.pt) == 0.0 && GI.y(k.pt) == 0.0 && GI.z(k.pt) == 1.0
+    @test !signbit(GI.y(k.pt))               # -0.0 -> +0.0
+    # planar 2-tuple path unchanged
+    k2 = GO.vertex_node((3.0, 4.0))
+    @test k2.pt == (3.0, 4.0)
 end

--- a/test/methods/relateng/kernel.jl
+++ b/test/methods/relateng/kernel.jl
@@ -274,3 +274,12 @@ end
     k2 = GO.vertex_node((3.0, 4.0))
     @test k2.pt == (3.0, 4.0)
 end
+
+@testset "crossing_node canonicalizes in 3D and is order-invariant" begin
+    a0 = UnitSphericalPoint(1.0, 0.0, 0.0); a1 = UnitSphericalPoint(0.0, 1.0, 0.0)
+    b0 = UnitSphericalPoint(0.0, 0.0, 1.0); b1 = UnitSphericalPoint(1.0, 1.0, 1.0)
+    k1 = GO.crossing_node(a0, a1, b0, b1)
+    k2 = GO.crossing_node(b1, b0, a1, a0)   # same pair, every order/orientation flipped
+    @test k1 == k2
+    @test k1.pt isa UnitSphericalPoint       # USP preserved through canonicalization
+end

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -10,6 +10,7 @@ using Test
 import GeometryOps as GO
 import GeometryOps: Spherical, True, False
 import GeometryOps.UnitSpherical: UnitSphericalPoint, slerp
+import GeometryOps.Extents as Extents
 import GeoInterface as GI
 using Random
 using LinearAlgebra: ⋅, cross
@@ -77,6 +78,18 @@ function kernel_conformance_suite_spherical(m; exact)
             @test e.Y[1] <= GI.y(u) <= e.Y[2]
             @test e.Z[1] <= GI.z(u) <= e.Z[2]
         end
+    end
+    @testset "rk_bounds_covers respects Z" begin
+        big = Extents.Extent(X = (0., 2.), Y = (0., 2.), Z = (0., 2.))
+        inside = Extents.Extent(X = (0.5, 1.), Y = (0.5, 1.), Z = (0.5, 1.))
+        outsideZ = Extents.Extent(X = (0.5, 1.), Y = (0.5, 1.), Z = (0.5, 3.))
+        @test GO.rk_bounds_covers(big, inside)
+        @test !GO.rk_bounds_covers(big, outsideZ)
+        @test !GO.rk_bounds_disjoint(big, inside)
+        # the 2D covering relation is unchanged
+        big2 = Extents.Extent(X = (0., 2.), Y = (0., 2.))
+        @test GO.rk_bounds_covers(big2, Extents.Extent(X = (0.5, 1.), Y = (0.5, 1.)))
+        @test !GO.rk_bounds_covers(big2, Extents.Extent(X = (0.5, 3.), Y = (0.5, 1.)))
     end
     # testsets added task-by-task below
 end

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -1,0 +1,44 @@
+# Spherical RelateKernel conformance suite (design layer contract, Task 9).
+# Standalone counterpart to kernel_conformance.jl. Inputs are exactly-
+# representable integer xyz vectors in *general position*: every predicate is
+# a sign of an integer determinant, so the exact answer is unambiguous and the
+# suite is deterministic. Points are NOT unit length — sign predicates do not
+# require it; where unit length matters (arc membership) we use exact-on-grid
+# configurations.
+
+using Test
+import GeometryOps as GO
+import GeometryOps: Spherical, True, False
+import GeometryOps.UnitSpherical: UnitSphericalPoint
+import GeoInterface as GI
+using Random
+using LinearAlgebra: ⋅, cross
+
+const USPt = UnitSphericalPoint{Float64}
+_sgn(x) = Int(sign(x))
+_usp(x, y, z) = UnitSphericalPoint(Float64(x), Float64(y), Float64(z))
+
+function kernel_conformance_suite_spherical(m; exact)
+    rng = Random.MersenneTwister(0x5e1a7e)
+    # random integer-component direction (a point on the sphere only up to
+    # scaling; sign predicates are scale-invariant in each argument)
+    rpt() = _usp(rand(rng, -8:8), rand(rng, -8:8), rand(rng, -8:8))
+    function nonzero()
+        p = rpt()
+        while iszero(GI.x(p)) && iszero(GI.y(p)) && iszero(GI.z(p))
+            p = rpt()
+        end
+        return p
+    end
+
+    @testset "placeholder until rk_orient exists" begin
+        @test true
+    end
+    # testsets added task-by-task below
+end
+
+@testset "Kernel conformance: Spherical" begin
+    @testset "exact = $E" for E in (True(), False())
+        kernel_conformance_suite_spherical(Spherical(); exact = E)
+    end
+end

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -91,6 +91,66 @@ function kernel_conformance_suite_spherical(m; exact)
         @test GO.rk_bounds_covers(big2, Extents.Extent(X = (0.5, 1.), Y = (0.5, 1.)))
         @test !GO.rk_bounds_covers(big2, Extents.Extent(X = (0.5, 3.), Y = (0.5, 1.)))
     end
+    @testset "rk_classify_intersection: symmetry and incidence consistency" begin
+        n_proper = 0; n_touch = 0; n_collinear = 0
+        for _ in 1:2000
+            a0, a1, b0, b1 = nonzero(), nonzero(), nonzero(), nonzero()
+            r = GO.rk_classify_intersection(m, a0, a1, b0, b1; exact)
+            # swapping A and B: kind invariant, flag pairs permuted
+            s = GO.rk_classify_intersection(m, b0, b1, a0, a1; exact)
+            @test s.kind == r.kind
+            @test (s.a0_on_b, s.a1_on_b, s.b0_on_a, s.b1_on_a) ==
+                  (r.b0_on_a, r.b1_on_a, r.a0_on_b, r.a1_on_b)
+            # reversing a segment: kind invariant, its two flags swapped
+            v = GO.rk_classify_intersection(m, a1, a0, b0, b1; exact)
+            @test v.kind == r.kind
+            @test (v.a0_on_b, v.a1_on_b, v.b0_on_a, v.b1_on_a) ==
+                  (r.a1_on_b, r.a0_on_b, r.b0_on_a, r.b1_on_a)
+            w = GO.rk_classify_intersection(m, a0, a1, b1, b0; exact)
+            @test w.kind == r.kind
+            @test (w.a0_on_b, w.a1_on_b, w.b0_on_a, w.b1_on_a) ==
+                  (r.a0_on_b, r.a1_on_b, r.b1_on_a, r.b0_on_a)
+            if r.kind == GO.SS_PROPER
+                n_proper += 1
+                @test !(r.a0_on_b || r.a1_on_b || r.b0_on_a || r.b1_on_a)
+                # proper: each endpoint strictly off the other arc's great circle
+                @test GO.rk_orient(m, b0, b1, a0; exact) != 0
+                @test GO.rk_orient(m, b0, b1, a1; exact) != 0
+                @test GO.rk_orient(m, a0, a1, b0; exact) != 0
+                @test GO.rk_orient(m, a0, a1, b1; exact) != 0
+            end
+            r.kind == GO.SS_TOUCH && (n_touch += 1)
+            r.kind == GO.SS_COLLINEAR && (n_collinear += 1)
+            # each incidence flag agrees exactly with rk_point_on_segment
+            @test r.a0_on_b == GO.rk_point_on_segment(m, a0, b0, b1; exact)
+            @test r.a1_on_b == GO.rk_point_on_segment(m, a1, b0, b1; exact)
+            @test r.b0_on_a == GO.rk_point_on_segment(m, b0, a0, a1; exact)
+            @test r.b1_on_a == GO.rk_point_on_segment(m, b1, a0, a1; exact)
+        end
+        # proper crossings are common for two random great circles; touch and
+        # collinear (two coplanar great circles) are rare/measure-zero on the
+        # sphere, so they are exercised by the explicit cases below.
+        @test n_proper > 20
+
+        # --- hand-built decidable configurations ---
+        # proper crossing: two axis-aligned great circles meeting at +x=(1,0,0),
+        # strictly interior to both minor arcs
+        r = GO.rk_classify_intersection(m, _usp(1,0,1), _usp(1,0,-1), _usp(1,1,0), _usp(1,-1,0); exact)
+        @test r.kind == GO.SS_PROPER
+        @test !(r.a0_on_b || r.a1_on_b || r.b0_on_a || r.b1_on_a)
+        # shared-endpoint touch (non-collinear arcs sharing (1,0,0))
+        r = GO.rk_classify_intersection(m, _usp(1,0,0), _usp(0,1,0), _usp(1,0,0), _usp(0,0,1); exact)
+        @test r.kind == GO.SS_TOUCH && r.a0_on_b && r.b0_on_a
+        # collinear overlap on the equator: arcs [+x,(1,1,0)] and [(1,1,0)... ] overlapping
+        r = GO.rk_classify_intersection(m, _usp(1,0,0), _usp(0,1,0), _usp(1,1,0), _usp(-1,1,0); exact)
+        @test r.kind == GO.SS_COLLINEAR
+        # collinear disjoint on the equator: [+x, (2,1,0)] vs [(-1,2,0), -y]
+        r = GO.rk_classify_intersection(m, _usp(1,0,0), _usp(2,1,0), _usp(-1,2,0), _usp(0,-1,0); exact)
+        @test r.kind == GO.SS_DISJOINT
+        # T-touch: b0 on the interior of arc a (a on equator, b dips to the pole)
+        r = GO.rk_classify_intersection(m, _usp(1,0,0), _usp(0,1,0), _usp(1,1,0), _usp(0,0,1); exact)
+        @test r.kind == GO.SS_TOUCH && r.b0_on_a && !r.a0_on_b
+    end
     # testsets added task-by-task below
 end
 

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -270,6 +270,17 @@ function kernel_conformance_suite_spherical(m; exact)
         @test GO.rk_point_in_ring(m, _usp(3,1,0), rev; exact) == GO.LOC_INTERIOR
         @test GO.rk_point_in_ring(m, _usp(1,1,1), rev; exact) == GO.LOC_BOUNDARY
     end
+    @testset "area interaction bounds reach the enclosed pole" begin
+        verts = [_usp(2,0,1), _usp(0,2,1), _usp(-2,0,1), _usp(0,-2,1), _usp(2,0,1)]
+        poly = GI.Polygon([GI.LinearRing(verts)])
+        e = GO.rk_interaction_bounds(m, poly)
+        @test e.Z[2] == 1.0                # interior reaches the enclosed north pole
+        # the boundary ring (curve) bound tops out well below the pole
+        eb = GO.rk_interaction_bounds(m, GI.LinearRing(verts))
+        @test eb.Z[2] < 0.99
+        # only the enclosed +z axis is extended; the equatorial axes are not
+        @test e.X == eb.X && e.Y == eb.Y && e.Z[1] == eb.Z[1]
+    end
     # testsets added task-by-task below
 end
 

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -9,7 +9,7 @@
 using Test
 import GeometryOps as GO
 import GeometryOps: Spherical, True, False
-import GeometryOps.UnitSpherical: UnitSphericalPoint
+import GeometryOps.UnitSpherical: UnitSphericalPoint, slerp
 import GeoInterface as GI
 using Random
 using LinearAlgebra: ⋅, cross
@@ -51,6 +51,32 @@ function kernel_conformance_suite_spherical(m; exact)
         @test GO.rk_point_on_segment(m, _usp(1, 1, 0), a, b; exact)  # interior (same great circle, within span)
         @test !GO.rk_point_on_segment(m, _usp(0, 0, 1), a, b; exact) # pole, off the circle
         @test !GO.rk_point_on_segment(m, _usp(-1, 1, 0), a, b; exact) # on circle, outside the minor-arc span
+    end
+    @testset "arc_extent contains the arc (bulge captured)" begin
+        rng2 = Random.MersenneTwister(42)
+        for _ in 1:500
+            p = GO.rk_normalize_usp(_usp(randn(rng2), randn(rng2), randn(rng2)))
+            q = GO.rk_normalize_usp(_usp(randn(rng2), randn(rng2), randn(rng2)))
+            e = GO.arc_extent(p, q)
+            for s in 0:0.05:1
+                u = slerp(p, q, s)
+                @test e.X[1] <= GI.x(u) <= e.X[2]
+                @test e.Y[1] <= GI.y(u) <= e.Y[2]
+                @test e.Z[1] <= GI.z(u) <= e.Z[2]
+            end
+        end
+    end
+
+    @testset "rk_interaction_bounds is 3D and contains the converted vertices" begin
+        ring = GI.LinearRing([(0.,0.), (10.,0.), (10.,10.), (0.,10.), (0.,0.)])
+        e = GO.rk_interaction_bounds(m, ring)
+        @test hasproperty(e, :Z)
+        for p in GI.getpoint(ring)
+            u = GO.rk_normalize_usp(UnitSphericalPoint((Float64(GI.x(p)), Float64(GI.y(p)))))
+            @test e.X[1] <= GI.x(u) <= e.X[2]
+            @test e.Y[1] <= GI.y(u) <= e.Y[2]
+            @test e.Z[1] <= GI.z(u) <= e.Z[2]
+        end
     end
     # testsets added task-by-task below
 end

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -151,6 +151,74 @@ function kernel_conformance_suite_spherical(m; exact)
         r = GO.rk_classify_intersection(m, _usp(1,0,0), _usp(0,1,0), _usp(1,1,0), _usp(0,0,1); exact)
         @test r.kind == GO.SS_TOUCH && r.b0_on_a && !r.a0_on_b
     end
+    @testset "angle ordering: vertex-apex fan reproduces planar order" begin
+        # apex +x; reference axis is +y (argmin |component|), so the tangent
+        # frame is (u,v) = (+y,+z) and a direction-point (0,dx,dy) has tangent
+        # coords exactly (dx,dy) — the spherical comparator reproduces the planar
+        # fan order verbatim.
+        apex = _usp(1, 0, 0)
+        node = GO.vertex_node(apex)
+        dirs = [(1,0),(2,1),(1,1),(1,2),(0,1),
+                (-1,2),(-1,1),(-2,1),(-1,0),
+                (-2,-1),(-1,-1),(-1,-2),
+                (0,-1),(1,-2),(1,-1),(2,-1)]
+        fan = [_usp(0, dx, dy) for (dx, dy) in dirs]
+        vcmp(p, q) = GO.rk_compare_edge_dir(m, node, p, q; exact)
+        for p in fan
+            @test vcmp(p, p) == 0
+        end
+        for i in eachindex(fan), j in eachindex(fan)
+            @test vcmp(fan[i], fan[j]) == (i == j ? 0 : (i < j ? -1 : 1))
+        end
+        for i in eachindex(fan), j in eachindex(fan), k in eachindex(fan)
+            if vcmp(fan[i], fan[j]) < 0 && vcmp(fan[j], fan[k]) < 0
+                @test vcmp(fan[i], fan[k]) < 0
+            end
+        end
+        @test_throws ArgumentError GO.rk_quadrant(m, apex, apex)  # zero-length direction
+    end
+
+    @testset "isCrossing / isInteriorSegment on a spherical corner" begin
+        # apex +x, direction-point (0,dx,dy) -> planar direction (dx,dy); the
+        # planar truth table maps over verbatim.
+        nd = GO.vertex_node(_usp(1, 0, 0))
+        d(dx, dy) = _usp(0, dx, dy)
+        # X cross: a arms (1,1)/(-1,-1), b arms (-1,1)/(1,-1)
+        @test GO.rk_is_crossing(m, nd, d(-1,-1), d(1,1), d(-1,1), d(1,-1); exact)
+        # collinear b arm -> not crossing
+        @test !GO.rk_is_crossing(m, nd, d(-1,-1), d(1,1), d(-1,-1), d(1,-1); exact)
+        # both b arms same side of the a-line -> not crossing
+        @test !GO.rk_is_crossing(m, nd, d(-1,-1), d(1,1), d(-1,1), d(0,1); exact)
+        # crossing-node apex is rejected
+        cn = GO.crossing_node(_usp(1,0,1), _usp(1,0,-1), _usp(1,1,0), _usp(1,-1,0))
+        @test_throws ArgumentError GO.rk_is_crossing(m, cn, d(-1,-1), d(1,1), d(-1,1), d(1,-1); exact)
+
+        # isInteriorSegment: corner a0->node->a1, ring interior on the right
+        @test !GO.rk_is_interior_segment(m, nd, d(0,1), d(1,0), d(1,1); exact)
+        @test GO.rk_is_interior_segment(m, nd, d(0,1), d(1,0), d(-1,-1); exact)
+        @test GO.rk_is_interior_segment(m, nd, d(1,0), d(0,1), d(1,1); exact)
+        @test !GO.rk_is_interior_segment(m, nd, d(1,0), d(0,1), d(-1,-1); exact)
+    end
+
+    @testset "rk_crossing_dirs_ccw and crossing-apex comparison" begin
+        # proper crossing at +x=(1,0,0): a-arc (1,0,1)->(1,0,-1), b-arc (1,1,0)->(1,-1,0)
+        a0, a1, b0, b1 = _usp(1,0,1), _usp(1,0,-1), _usp(1,1,0), _usp(1,-1,0)
+        @test GO.rk_classify_intersection(m, a0, a1, b0, b1; exact).kind == GO.SS_PROPER
+        ccw = GO.rk_crossing_dirs_ccw(m, a0, a1, b0, b1; exact)
+        @test Set(ccw) == Set((a0, a1, b0, b1))   # a permutation of the four endpoints
+        @test ccw[1] == a1                          # starts from a1 (contract)
+        # the crossing-apex comparator is a strict weak order on the four arms
+        cn = GO.crossing_node(a0, a1, b0, b1)
+        ccmp(p, q) = GO.rk_compare_edge_dir(m, cn, p, q; exact)
+        arms = (a0, a1, b0, b1)
+        for x in arms
+            @test ccmp(x, x) == 0
+        end
+        for x in arms, y in arms
+            @test ccmp(x, y) == -ccmp(y, x)         # antisymmetry
+            x === y || @test ccmp(x, y) != 0        # distinct arms have distinct angles
+        end
+    end
     # testsets added task-by-task below
 end
 

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -219,6 +219,36 @@ function kernel_conformance_suite_spherical(m; exact)
             x === y || @test ccmp(x, y) != 0        # distinct arms have distinct angles
         end
     end
+    @testset "rk_nodes_coincide: reflexive, symmetric, cross-kind" begin
+        # crossing at +x via two different segment pairs
+        cx_a = GO.crossing_node(_usp(1,0,1), _usp(1,0,-1), _usp(1,1,0), _usp(1,-1,0))
+        cx_b = GO.crossing_node(_usp(2,1,0), _usp(2,-1,0), _usp(2,0,1), _usp(2,0,-1))
+        # crossing at +y
+        cy = GO.crossing_node(_usp(0,1,1), _usp(0,1,-1), _usp(1,1,0), _usp(-1,1,0))
+        vx = GO.vertex_node(_usp(1,0,0))
+        vx2 = GO.vertex_node(_usp(2,0,0))     # parallel to +x -> same sphere point
+        vy = GO.vertex_node(_usp(0,1,0))
+        keys = (cx_a, cx_b, cy, vx, vx2, vy)
+        for k in keys
+            @test GO.rk_nodes_coincide(m, k, k; exact)            # reflexive
+        end
+        for k1 in keys, k2 in keys
+            @test GO.rk_nodes_coincide(m, k1, k2; exact) ==
+                  GO.rk_nodes_coincide(m, k2, k1; exact)          # symmetric
+        end
+        # vertex coincidence by parallelism (not exact bit equality)
+        @test vx != vx2 && GO.rk_nodes_coincide(m, vx, vx2; exact)
+        @test !GO.rk_nodes_coincide(m, vx, vy; exact)
+        # cross-kind: vertex lies on a proper crossing
+        @test GO.rk_nodes_coincide(m, cx_a, vx; exact)
+        @test GO.rk_nodes_coincide(m, cx_a, vx2; exact)
+        @test !GO.rk_nodes_coincide(m, cy, vx; exact)
+        # two distinct crossing pairs meeting at the same apex (+x)
+        @test cx_a != cx_b && GO.rk_nodes_coincide(m, cx_a, cx_b; exact)
+        @test !GO.rk_nodes_coincide(m, cx_a, cy; exact)
+        # antipodal directions are NOT the same point
+        @test !GO.rk_nodes_coincide(m, GO.vertex_node(_usp(1,1,0)), GO.vertex_node(_usp(-1,-1,0)); exact)
+    end
     # testsets added task-by-task below
 end
 

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -31,8 +31,18 @@ function kernel_conformance_suite_spherical(m; exact)
         return p
     end
 
-    @testset "placeholder until rk_orient exists" begin
-        @test true
+    @testset "rk_orient: antisymmetry / cyclic invariance / degeneracy" begin
+        for _ in 1:500
+            a, b, c = nonzero(), nonzero(), nonzero()
+            o = _sgn(GO.rk_orient(m, a, b, c; exact))
+            @test o == -_sgn(GO.rk_orient(m, b, a, c; exact))
+            @test o == -_sgn(GO.rk_orient(m, a, c, b; exact))
+            @test o == _sgn(GO.rk_orient(m, b, c, a; exact))
+            @test o == _sgn(GO.rk_orient(m, c, a, b; exact))
+            @test GO.rk_orient(m, a, a, b; exact) == 0
+            @test GO.rk_orient(m, a, b, a; exact) == 0
+            @test GO.rk_orient(m, a, b, b; exact) == 0
+        end
     end
     # testsets added task-by-task below
 end

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -249,6 +249,27 @@ function kernel_conformance_suite_spherical(m; exact)
         # antipodal directions are NOT the same point
         @test !GO.rk_nodes_coincide(m, GO.vertex_node(_usp(1,1,0)), GO.vertex_node(_usp(-1,-1,0)); exact)
     end
+    @testset "rk_point_in_ring: parity, boundary, S2 orientation" begin
+        # CCW-from-above diamond at z=1 encircling the north pole; integer
+        # vertices (membership decidable: boundary via exact coplanarity, the
+        # meridian-parity crossings are scale-invariant signs).
+        verts = [_usp(2,0,1), _usp(0,2,1), _usp(-2,0,1), _usp(0,-2,1), _usp(2,0,1)]
+        ring = GI.LinearRing(verts)
+        @test GO.rk_point_in_ring(m, _usp(2,0,1), ring; exact) == GO.LOC_BOUNDARY     # vertex
+        @test GO.rk_point_in_ring(m, _usp(1,1,1), ring; exact) == GO.LOC_BOUNDARY     # edge midpoint
+        @test GO.rk_point_in_ring(m, _usp(-1,1,1), ring; exact) == GO.LOC_BOUNDARY    # edge midpoint
+        @test GO.rk_point_in_ring(m, _usp(1,1,10), ring; exact) == GO.LOC_INTERIOR    # polar cap
+        @test GO.rk_point_in_ring(m, _usp(1,0,8), ring; exact) == GO.LOC_INTERIOR
+        @test GO.rk_point_in_ring(m, _usp(3,1,0), ring; exact) == GO.LOC_EXTERIOR     # equatorial
+        @test GO.rk_point_in_ring(m, _usp(3,-1,0), ring; exact) == GO.LOC_EXTERIOR
+
+        # S2 convention: reversing the ring swaps interior/exterior (the pole is
+        # no longer enclosed). Boundary is unchanged.
+        rev = GI.LinearRing(reverse(verts))
+        @test GO.rk_point_in_ring(m, _usp(1,1,10), rev; exact) == GO.LOC_EXTERIOR
+        @test GO.rk_point_in_ring(m, _usp(3,1,0), rev; exact) == GO.LOC_INTERIOR
+        @test GO.rk_point_in_ring(m, _usp(1,1,1), rev; exact) == GO.LOC_BOUNDARY
+    end
     # testsets added task-by-task below
 end
 

--- a/test/methods/relateng/kernel_conformance_spherical.jl
+++ b/test/methods/relateng/kernel_conformance_spherical.jl
@@ -44,6 +44,14 @@ function kernel_conformance_suite_spherical(m; exact)
             @test GO.rk_orient(m, a, b, b; exact) == 0
         end
     end
+    @testset "rk_point_on_segment: endpoints, midpoint, off-arc" begin
+        a = _usp(1, 0, 0); b = _usp(0, 1, 0)
+        @test GO.rk_point_on_segment(m, a, a, b; exact)              # endpoint
+        @test GO.rk_point_on_segment(m, b, a, b; exact)              # endpoint
+        @test GO.rk_point_on_segment(m, _usp(1, 1, 0), a, b; exact)  # interior (same great circle, within span)
+        @test !GO.rk_point_on_segment(m, _usp(0, 0, 1), a, b; exact) # pole, off the circle
+        @test !GO.rk_point_on_segment(m, _usp(-1, 1, 0), a, b; exact) # on circle, outside the minor-arc span
+    end
     # testsets added task-by-task below
 end
 

--- a/test/methods/relateng/point_locator.jl
+++ b/test/methods/relateng/point_locator.jl
@@ -12,7 +12,7 @@ import GeoInterface as GI
 # here each WKT literal is translated by hand into GI.LineStrings and a set
 # of expected boundary coordinate tuples (nothing ⇔ Java's null = no boundary).
 function check_linear_boundary(lines, rule, expected_boundary)
-    lb = GO.LinearBoundary(lines, rule)
+    lb = GO.LinearBoundary(Planar(), lines, rule)
     has_boundary_expected = expected_boundary === nothing ? false : true
     @test GO.has_boundary(lb) == has_boundary_expected
     check_boundary_points(lb, lines, expected_boundary)

--- a/test/methods/relateng/relate_geometry.jl
+++ b/test/methods/relateng/relate_geometry.jl
@@ -5,7 +5,7 @@
 
 using Test
 import GeometryOps as GO
-import GeometryOps: Planar, True
+import GeometryOps: Planar, Spherical, True
 import GeoInterface as GI
 import LibGEOS as LG  # only for POLYGON EMPTY — GI wrappers cannot be empty
 import Extents
@@ -344,7 +344,7 @@ end
 
     #-- _add_component_coordinates!: point coords + first line coords
     pts = Set{Tuple{Float64, Float64}}()
-    GO._add_component_coordinates!(pts, GI.GeometryCollection([mp, ml]))
+    GO._add_component_coordinates!(pts, GO.Planar(), GI.GeometryCollection([mp, ml]))
     @test (0.0, 0.0) in pts
 
     #-- _extract_point_elements!: only the Point element of the GC
@@ -354,7 +354,20 @@ end
 
     #-- _extract_elements!: classification into points/lines/polygons
     points = Set{Tuple{Float64, Float64}}(); lines = Any[]; polygons = Any[]
-    GO._extract_elements!(points, lines, polygons,
+    GO._extract_elements!(GO.Planar(), points, lines, polygons,
         GI.GeometryCollection([GI.Point(0.0, 0.0), ml, mpoly]))
     @test length(points) == 1 && length(lines) == 2 && length(polygons) == 1
+end
+
+# Task 13: the manifold-derived point type flows through ingest, so a
+# spherical `RelateGeometry` stores 3D (xyz) interaction bounds and converts
+# lon/lat vertices to the spherical kernel point type.
+@testset "Spherical RelateGeometry ingests xyz" begin
+    ring = GI.LinearRing([(0., 0.), (10., 0.), (10., 10.), (0., 10.), (0., 0.)])
+    rg = GO.RelateGeometry(Spherical(), GI.Polygon([ring]); exact = True())
+    @test rg.extent isa Extents.Extent
+    @test hasproperty(rg.extent, :Z)             # 3D interaction bounds
+    #-- the unique-point / segment-string point type is the spherical kernel point
+    @test GO._kernel_point_type(Spherical()) == GO.UnitSpherical.UnitSphericalPoint{Float64}
+    @test GO._to_kernel_point(Spherical(), (0., 0.)) isa GO.UnitSpherical.UnitSphericalPoint{Float64}
 end

--- a/test/methods/relateng/runtests.jl
+++ b/test/methods/relateng/runtests.jl
@@ -14,6 +14,7 @@ using SafeTestsets
 @safetestset "XML harness" begin include("xml_harness.jl") end
 @safetestset "RelateNG engine" begin include("relate_ng.jl") end
 @safetestset "JTS XML suite" begin include("xml_suite.jl") end
+@safetestset "Spherical relate end-to-end" begin include("spherical_end_to_end.jl") end
 @safetestset "LibGEOS differential fuzz" begin include("fuzz.jl") end
 @safetestset "Allocations and type stability" begin include("allocations.jl") end
 # Further files appended here as tasks land:

--- a/test/methods/relateng/runtests.jl
+++ b/test/methods/relateng/runtests.jl
@@ -4,6 +4,7 @@ using SafeTestsets
 @safetestset "Predicates" begin include("predicates.jl") end
 @safetestset "Kernel" begin include("kernel.jl") end
 @safetestset "Kernel conformance" begin include("kernel_conformance.jl") end
+@safetestset "Spherical kernel conformance" begin include("kernel_conformance_spherical.jl") end
 @safetestset "Point locator" begin include("point_locator.jl") end
 @safetestset "Indexed point-in-area locator" begin include("indexed_point_in_area.jl") end
 @safetestset "RelateGeometry" begin include("relate_geometry.jl") end

--- a/test/methods/relateng/runtests.jl
+++ b/test/methods/relateng/runtests.jl
@@ -5,6 +5,7 @@ using SafeTestsets
 @safetestset "Kernel" begin include("kernel.jl") end
 @safetestset "Kernel conformance" begin include("kernel_conformance.jl") end
 @safetestset "Spherical kernel conformance" begin include("kernel_conformance_spherical.jl") end
+@safetestset "S2 edge-crossing conformance" begin include("s2_crossings_conformance.jl") end
 @safetestset "Point locator" begin include("point_locator.jl") end
 @safetestset "Indexed point-in-area locator" begin include("indexed_point_in_area.jl") end
 @safetestset "RelateGeometry" begin include("relate_geometry.jl") end

--- a/test/methods/relateng/s2_crossings_conformance.jl
+++ b/test/methods/relateng/s2_crossings_conformance.jl
@@ -1,0 +1,189 @@
+# Spherical edge-crossing conformance, ported from Google S2.
+#
+# Source: s2geometry `src/s2/s2edge_crosser_test.cc` (`TEST(S2, Crossings)`,
+# `CollinearEdgesThatDontTouch`, `CoincidentZeroLengthEdgesThatDontTouch`) and
+# `src/s2/s2edge_crossings.h` (the `CrossingSign` contract). These are S2's
+# hand-built numerically-extreme edge-crossing cases — several require exact
+# arithmetic to resolve (floating-point underflow; determinants needing >2000
+# bits of precision) — and are the canonical battery for a robust spherical
+# crossing predicate.
+#
+# Mapping S2 `CrossingSign(a,b,c,d)` onto GeometryOps `rk_classify_intersection`
+# (validated empirically against the spherical kernel before this file landed):
+#
+#   CrossingSign == +1  (interior crossing of both edges) <-> SS_PROPER
+#   CrossingSign == -1  (no crossing)                     <-> SS_DISJOINT
+#   CrossingSign ==  0  (a vertex is shared)              <-> SS_TOUCH / SS_COLLINEAR
+#                                                             with the incidence
+#                                                             flag(s) set
+#
+# Two of S2's edge-crossing tests are deliberately NOT ported, because they have
+# no faithful analog in this kernel:
+#
+#   * `GetIntersection` / `GrazingIntersections` compute an intersection *point*.
+#     This kernel is symbolic: a proper crossing's node has no coordinate
+#     anywhere in the engine (design D2), so there is nothing to compare.
+#
+#   * `CoincidentZeroLengthEdgesThatDontTouch` asserts that four points which are
+#     *exactly proportional* on the sphere never cross. That holds only under
+#     S2's symbolic-perturbation model of `Sign`. This kernel instead computes
+#     the exact sign of the *actual* Float64 coordinates (via ExactPredicates /
+#     Rational), and the rounding of `(1+k*eps)*p` makes the four points genuinely
+#     non-collinear, so a tiny real interior crossing is the correct answer for
+#     the given inputs. The S2 test's own comment notes it "depends on the
+#     particular symbolic perturbations used by s2pred::Sign()". See the
+#     `CoincidentProportionalEdges` testset below, which asserts the property
+#     this kernel *does* guarantee (permutation-consistency) on such inputs.
+#
+# `RobustCrossProd` (also in s2edge_crossings_test.cc) is already ported, in
+# test/utils/robustcrossproduct.jl.
+
+using Test
+import GeometryOps as GO
+import GeometryOps: Spherical, True, False
+import GeometryOps.UnitSpherical: UnitSphericalPoint, slerp
+import GeoInterface as GI
+using LinearAlgebra: normalize
+using Random
+
+# Build a unit-length spherical kernel point from raw components, normalizing
+# exactly as S2's `S2Point::Normalize()` does (the S2 test harness normalizes
+# every vertex before testing).
+_nv(x, y, z) = (v = normalize([Float64(x), Float64(y), Float64(z)]);
+                UnitSphericalPoint(v[1], v[2], v[3]))
+
+# S2::Origin() — the conventional reference point, copied verbatim from
+# s2pointutil.h. Used by S2 crossing cases 4 and 5 to exercise an edge whose
+# endpoint is the origin reference.
+const _S2_ORIGIN = (-0.0099994664350250197, 0.0025924542609324121, 0.99994664350250195)
+
+# Port of S2's `TestCrossings(a, b, c, d, crossing_sign, ...)`. We assert the
+# `CrossingSign`->`SegSegClass.kind` mapping plus the symmetry that S2's harness
+# checks: `kind` is invariant under reversing either edge and under swapping the
+# two edges.
+function check_s2_crossing(m, a, b, c, d, crossing_sign; exact)
+    r = GO.rk_classify_intersection(m, a, b, c, d; exact)
+
+    if exact === True()
+        # The exact path is authoritative — S2's `CrossingSign` is robust, so the
+        # faithful analog is this kernel's exact path. Assert the full mapping.
+        if crossing_sign == 1
+            @test r.kind == GO.SS_PROPER
+        elseif crossing_sign == -1
+            @test r.kind == GO.SS_DISJOINT
+        else # crossing_sign == 0: at least one vertex is shared between the edges
+            @test r.kind != GO.SS_PROPER
+            @test r.kind != GO.SS_DISJOINT
+            @test r.a0_on_b || r.a1_on_b || r.b0_on_a || r.b1_on_a
+        end
+    else
+        # The Float64 fast path is a conservative accelerator, not an oracle: it
+        # falls back to SS_TOUCH on cases that need exact arithmetic (9, 11) and
+        # cannot register an incidence whose coplanarity determinant does not
+        # round to *exactly* zero (so a shared vertex of two skew normalized
+        # edges, as in case 6, reads as SS_DISJOINT). The contract it must honor
+        # is one-directional: never deny a real crossing, never invent one.
+        if crossing_sign == 1
+            @test r.kind != GO.SS_DISJOINT
+        else
+            @test r.kind != GO.SS_PROPER
+        end
+    end
+
+    # S2 TestCrossings symmetry: classification is invariant under reversal of
+    # either edge and under swapping the two edges. (Holds on both paths.)
+    for (p, q, s, t) in ((b, a, c, d), (a, b, d, c), (b, a, d, c), (c, d, a, b))
+        @test GO.rk_classify_intersection(m, p, q, s, t; exact).kind == r.kind
+    end
+    return r
+end
+
+function s2_crossings_suite(m; exact)
+    @testset "S2 Crossings: 12 hand-built cases" begin
+        # 1. Two regular edges that cross.
+        check_s2_crossing(m, _nv(1, 2, 1), _nv(1, -3, 0.5),
+                             _nv(1, -0.5, -3), _nv(0.1, 0.5, 3), 1; exact)
+        # 2. Two regular edges that intersect at antipodal points (so the arcs
+        #    themselves do not meet).
+        check_s2_crossing(m, _nv(1, 2, 1), _nv(1, -3, 0.5),
+                             _nv(-1, 0.5, 3), _nv(-0.1, -0.5, -3), -1; exact)
+        # 3. Two edges on the same great circle that start at antipodal points.
+        check_s2_crossing(m, _nv(0, 0, -1), _nv(0, 1, 0),
+                             _nv(0, 0, 1), _nv(0, 1, 1), -1; exact)
+        # 4. Two edges that cross where one vertex is S2::Origin().
+        check_s2_crossing(m, _nv(1, 0, 0), _nv(_S2_ORIGIN...),
+                             _nv(1, -0.1, 1), _nv(1, 1, -0.1), 1; exact)
+        # 5. Antipodal intersection where one vertex is S2::Origin().
+        check_s2_crossing(m, _nv(1, 0, 0), _nv(_S2_ORIGIN...),
+                             _nv(-1, 0.1, -1), _nv(-1, -1, 0.1), -1; exact)
+        # 6. Two edges that share an endpoint (2,3,4).
+        check_s2_crossing(m, _nv(7, -2, 3), _nv(2, 3, 4),
+                             _nv(2, 3, 4), _nv(-1, 2, 5), 0; exact)
+        # 7. Edges that barely cross near the middle of one edge. AB is ~ in the
+        #    x=y plane; CD is ~ perpendicular and ends exactly at the x=y plane.
+        check_s2_crossing(m, _nv(1, 1, 1), _nv(1, prevfloat(1.0), -1),
+                             _nv(11, -12, -1), _nv(10, 10, 1), 1; exact)
+        # 8. As (7) but the edges are separated by a distance of about 1e-15.
+        check_s2_crossing(m, _nv(1, 1, 1), _nv(1, nextfloat(1.0), -1),
+                             _nv(1, -1, 0), _nv(1, 1, 0), -1; exact)
+        # 9. Barely cross near the end of both edges — cannot be handled in plain
+        #    double precision due to floating-point underflow.
+        check_s2_crossing(m, _nv(0, 0, 1), _nv(2, -1e-323, 1),
+                             _nv(1, -1, 1), _nv(1e-323, 0, 1), 1; exact)
+        # 10. As (9) but separated by a distance of about 1e-640.
+        check_s2_crossing(m, _nv(0, 0, 1), _nv(2, 1e-323, 1),
+                             _nv(1, -1, 1), _nv(1e-323, 0, 1), -1; exact)
+        # 11. Barely cross near the middle of one edge — the exact determinant of
+        #     some triangles here needs more than 2000 bits of precision.
+        check_s2_crossing(m, _nv(1, -1e-323, -1e-323), _nv(1e-323, 1, 1e-323),
+                             _nv(1, -1, 1e-323), _nv(1, 1, 0), 1; exact)
+        # 12. As (11) but separated by a distance of about 1e-640.
+        check_s2_crossing(m, _nv(1, 1e-323, -1e-323), _nv(-1e-323, 1, 1e-323),
+                             _nv(1, -1, 1e-323), _nv(1, 1, 0), -1; exact)
+    end
+
+    @testset "S2 CollinearEdgesThatDontTouch" begin
+        # Two disjoint sub-arcs of one minor arc: a..b == arc[0.00,0.05] and
+        # c..d == arc[0.95,1.00]. They share a great circle but never overlap, so
+        # they must never be reported as a proper crossing.
+        rng = MersenneTwister(0x5e2c011)
+        rp() = (v = normalize(randn(rng, 3)); UnitSphericalPoint(v[1], v[2], v[3]))
+        for _ in 1:500
+            a = rp(); d = rp()
+            b = slerp(a, d, 0.05)
+            c = slerp(a, d, 0.95)
+            r = GO.rk_classify_intersection(m, a, b, c, d; exact)
+            @test r.kind != GO.SS_PROPER
+            # On the exact path the kernel resolves them as fully disjoint.
+            exact === True() && @test r.kind == GO.SS_DISJOINT
+        end
+    end
+
+    @testset "CoincidentProportionalEdges (kernel convention, not S2's)" begin
+        # S2's `CoincidentZeroLengthEdgesThatDontTouch` asserts non-crossing for
+        # exactly-proportional points under symbolic perturbation. This kernel
+        # uses exact signs of the actual Float64 coordinates instead, so it does
+        # not promise that. What it *does* promise — and what we assert here — is
+        # that the classification is self-consistent: invariant under reversing
+        # either edge and under swapping the two edges (the same symmetry the S2
+        # harness relies on).
+        rng = MersenneTwister(0x5e2c022)
+        for _ in 1:300
+            p = normalize(randn(rng, 3))
+            a = UnitSphericalPoint(((1 - 3e-16) .* p)...)
+            b = UnitSphericalPoint(((1 - 1e-16) .* p)...)
+            c = UnitSphericalPoint(p...)
+            d = UnitSphericalPoint(((1 + 2e-16) .* p)...)
+            r = GO.rk_classify_intersection(m, a, b, c, d; exact)
+            for (w, x, y, z) in ((b, a, c, d), (a, b, d, c), (b, a, d, c), (c, d, a, b))
+                @test GO.rk_classify_intersection(m, w, x, y, z; exact).kind == r.kind
+            end
+        end
+    end
+end
+
+@testset "S2 edge-crossing conformance: Spherical" begin
+    @testset "exact = $E" for E in (True(), False())
+        s2_crossings_suite(Spherical(); exact = E)
+    end
+end

--- a/test/methods/relateng/spherical_end_to_end.jl
+++ b/test/methods/relateng/spherical_end_to_end.jl
@@ -71,3 +71,20 @@ end
         @test GO.relate(prep, B) == GO.relate(loop, A, B)
     end
 end
+
+# Task 18: an exactly-antipodal edge has no unique great-circle arc; the kernel
+# refuses it at ingest with a message pointing at the AntipodalEdgeSplit remedy.
+@testset "spherical antipodal edge throws informatively" begin
+    p0   = GO._to_kernel_point(Spherical(), (0., 0.))       # (1, 0, 0)
+    p180 = GO._to_kernel_point(Spherical(), (180., 0.))     # (-1, 0, 0): antipodal
+    p90  = GO._to_kernel_point(Spherical(), (90., 0.))      # (0, 1, 0)
+    err = try; GO.arc_extent(p0, p180); nothing; catch e; e; end
+    @test err isa ArgumentError
+    @test occursin("AntipodalEdgeSplit", err.msg)
+    #-- a normal edge and a repeated (zero-length) vertex do NOT throw
+    @test (GO.arc_extent(p0, p90); true)
+    @test (GO.arc_extent(p0, p0); true)
+    #-- the whole relate rejects a polygon carrying an antipodal edge at ingest
+    bad = GI.Polygon([GI.LinearRing([(0., 0.), (180., 0.), (90., 80.), (0., 0.)])])
+    @test_throws ArgumentError GO.relate(alg, bad, GI.Point(10., 10.))
+end

--- a/test/methods/relateng/spherical_end_to_end.jl
+++ b/test/methods/relateng/spherical_end_to_end.jl
@@ -1,0 +1,29 @@
+# End-to-end `relate(RelateNG(; manifold = Spherical()), …)` smoke tests
+# (Task 14). With the spherical kernel and the manifold-derived point type
+# in place, the engine runs on the unindexed NestedLoop path. Away from the
+# poles and the antimeridian, spherical and planar topology agree (the spike
+# measured 2000/2000), so the patch test compares the two DE-9IM matrices
+# directly; the pole-containing ring is a case only the spherical kernel
+# gets right.
+
+using Test
+import GeometryOps as GO
+import GeometryOps: Spherical, RelateNG
+import GeoInterface as GI
+
+alg = RelateNG(; manifold = Spherical())
+
+@testset "spherical relate agrees with planar on a small mid-latitude patch" begin
+    # two overlapping boxes near (10°, 45°): away from poles/antimeridian the
+    # spherical and planar topology agree
+    A = GI.Polygon([GI.LinearRing([(0., 40.), (10., 40.), (10., 50.), (0., 50.), (0., 40.)])])
+    B = GI.Polygon([GI.LinearRing([(5., 45.), (15., 45.), (15., 55.), (5., 55.), (5., 45.)])])
+    @test GO.relate(alg, A, B) == GO.relate(A, B)           # same DE-9IM
+    @test GO.relate(alg, A, B, "T*T***T**")                  # overlaps
+end
+
+@testset "spherical handles a pole-containing ring" begin
+    cap = GI.Polygon([GI.LinearRing([(0., 80.), (120., 80.), (240., 80.), (0., 80.)])])
+    pt  = GI.Point(0., 89.)                                  # near north pole
+    @test GO.relate(alg, cap, pt, "T*****FF*")               # contains
+end

--- a/test/methods/relateng/spherical_end_to_end.jl
+++ b/test/methods/relateng/spherical_end_to_end.jl
@@ -27,3 +27,47 @@ end
     pt  = GI.Point(0., 89.)                                  # near north pole
     @test GO.relate(alg, cap, pt, "T*****FF*")               # contains
 end
+
+# Task 15: the tree accelerator must build 3D great-circle arc extents, not a
+# 2D coordinate box. A long near-equatorial arc (lon 0 → 170) bulges to y ≈ 1
+# at lon 90 while its endpoint box has y ∈ [0, 0.17]; a polygon straddling the
+# equator at lon 90 crosses it there. A 2D endpoint box prunes that pair away
+# (wrong DE-9IM); the bulge-aware `arc_extent` keeps it.
+@testset "spherical tree accelerator agrees with NestedLoop (arc bulge)" begin
+    A = GI.Polygon([GI.LinearRing([(0., 0.), (170., 0.), (85., 40.), (0., 0.)])])
+    B = GI.Polygon([GI.LinearRing([(88., -2.), (92., -2.), (92., 2.), (88., 2.), (88., -2.)])])
+    tree = RelateNG(; manifold = Spherical(), accelerator = GO.DoubleSTRtree())
+    loop = RelateNG(; manifold = Spherical(), accelerator = GO.NestedLoop())
+    @test GO.relate(tree, A, B) == GO.relate(loop, A, B)
+end
+
+# Task 15: above the 32-segment threshold AutoAccelerator picks the tree path;
+# it must give the same DE-9IM as the unindexed nested loop on a real ring.
+@testset "spherical AutoAccelerator picks the tree above threshold" begin
+    n = 48                                                   # 48 segments > threshold
+    ringpts = [(10.0 + 8cosd(t), 45.0 + 5sind(t)) for t in range(0, 360; length = n + 1)]
+    A = GI.Polygon([GI.LinearRing(ringpts)])
+    B = GI.Polygon([GI.LinearRing([(8., 43.), (20., 43.), (20., 52.), (8., 52.), (8., 43.)])])
+    loop = RelateNG(; manifold = Spherical(), accelerator = GO.NestedLoop())
+    @test GO.relate(alg, A, B) == GO.relate(loop, A, B)
+end
+
+# Task 17: prepared spherical relate (A indexed once, in 3D) must agree with
+# the unprepared nested-loop relate over several B geometries. The prepared
+# edge index is the dimension-generic `NaturalIndex` over 3D arc extents.
+@testset "spherical prepared relate agrees with unprepared" begin
+    n = 48
+    ringpts = [(10.0 + 8cosd(t), 45.0 + 5sind(t)) for t in range(0, 360; length = n + 1)]
+    A = GI.Polygon([GI.LinearRing(ringpts)])
+    prep = GO.prepare(alg, A)
+    loop = RelateNG(; manifold = Spherical(), accelerator = GO.NestedLoop())
+    Bs = (
+        GI.Polygon([GI.LinearRing([(8., 43.), (20., 43.), (20., 52.), (8., 52.), (8., 43.)])]),
+        GI.Polygon([GI.LinearRing([(11., 45.), (13., 45.), (13., 47.), (11., 47.), (11., 45.)])]),
+        GI.Point(10., 45.),
+        GI.Point(40., 80.),
+    )
+    for B in Bs
+        @test GO.relate(prep, B) == GO.relate(loop, A, B)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,7 @@ end
 @safetestset "Geometry Correction" begin include("transformations/correction/geometry_correction.jl") end
 @safetestset "Closed Rings" begin include("transformations/correction/closed_ring.jl")  end
 @safetestset "Intersecting Polygons" begin include("transformations/correction/intersecting_polygons.jl") end
+@safetestset "Antipodal Edge Split" begin include("transformations/correction/antipodal_edge_split.jl") end
 # Extensions
 @safetestset "FlexiJoins" begin include("extensions/flexijoins.jl") end
 @safetestset "LibGEOS" begin include("extensions/libgeos.jl") end

--- a/test/transformations/correction/antipodal_edge_split.jl
+++ b/test/transformations/correction/antipodal_edge_split.jl
@@ -1,0 +1,33 @@
+using Test
+import GeoInterface as GI
+import GeometryOps as GO
+import GeometryOps: Spherical, RelateNG
+
+# The edge (0,0)→(180,0) maps to the antipodal unit vectors (1,0,0) and
+# (-1,0,0), which the spherical kernel rejects.
+antipodal_poly = GI.Polygon([GI.LinearRing([(0., 0.), (180., 0.), (90., 80.), (0., 0.)])])
+clean_poly = GI.Polygon([GI.LinearRing([(0., 0.), (10., 0.), (10., 10.), (0., 10.), (0., 0.)])])
+
+@testset "AntipodalEdgeSplit" begin
+    alg = RelateNG(; manifold = Spherical())
+
+    #-- without correction the spherical kernel refuses the antipodal edge
+    @test_throws ArgumentError GO.relate(alg, antipodal_poly, GI.Point(10., 10.))
+
+    #-- the correction inserts the lon/lat midpoint (90, 0): one extra vertex
+    fixed = GO.AntipodalEdgeSplit()(antipodal_poly)
+    @test GI.npoint(fixed) == GI.npoint(antipodal_poly) + 1
+    pts = [(GI.x(p), GI.y(p)) for p in GI.getpoint(GI.getexterior(fixed))]
+    @test (90.0, 0.0) in pts
+
+    #-- after correction the relate runs and is correct (the big triangle
+    #-- north of the equator contains the near-equator point)
+    @test GO.relate(alg, fixed, GI.Point(10., 10.), "T*****FF*")
+
+    #-- also reachable through `fix`
+    @test GI.npoint(GO.fix(antipodal_poly; corrections = [GO.AntipodalEdgeSplit()])) ==
+        GI.npoint(antipodal_poly) + 1
+
+    #-- a geometry with no antipodal edge keeps its vertices
+    @test GI.npoint(GO.AntipodalEdgeSplit()(clean_poly)) == GI.npoint(clean_poly)
+end


### PR DESCRIPTION
## Summary

Implements the `Spherical()` manifold for the RelateNG engine, so
`relate(RelateNG(; manifold = Spherical()), a, b)` produces a DE-9IM on the
unit sphere. Stacked on top of the `relateng` port branch; this PR is just the
spherical work (17 commits) for easier review.

- **Spherical kernel** (`kernel_spherical.jl`): all 13 `rk_*` predicates over
  `UnitSphericalPoint{Float64}`, each a sign of `det(u,v,w) = (u×v)·w`, with an
  exact path (`ExactPredicates.orient` / `Rational{BigInt}` composites) and a
  float path. Bulge-aware great-circle `arc_extent`; S2 interior-on-left
  point-in-ring via meridian-crossing parity; ring/axis containment via a
  robust winding-number test (no atan2 branch ambiguity).
- **Manifold-derived point type**: threaded `_kernel_point_type` /
  `_to_kernel_point` through the engine. Planar stays byte-identical
  (signed-zero `Tuple{Float64,Float64}`); Spherical ingests unit xyz.
- **Acceleration**: the per-segment spatial index and the prepared-mode index
  build over 3D `arc_extent`s, so the tree and prepared paths match the nested
  loop (a 2D endpoint box misses a long arc's bulge and prunes real crossings).
- **Antipodal edges**: the kernel throws informatively on exactly-antipodal
  vertices; `AntipodalEdgeSplit` is the opt-in geometry correction that inserts
  the lon/lat midpoint as the remedy.

Engine generality (manifold-generic `apply`/topology) was already in place from
the port; this adds the spherical kernel and the point-type plumbing.

## Test Plan

- [x] Spherical kernel conformance suite: **114,624** assertions, `exact ∈ {True(), False()}`
- [x] Planar kernel conformance: **76,908** — no regression
- [x] JTS XML conformance corpus: **6,537** — no planar regression
- [x] LibGEOS differential fuzz: **500** — no planar regression
- [x] End-to-end `spherical_end_to_end.jl`: planar agreement on a mid-latitude
      patch, pole-containing ring, tree/NestedLoop + prepared/unprepared
      agreement, antipodal throw
- [x] `AntipodalEdgeSplit` correction
- [x] Allocations + type stability (the `P` type parameter does not regress the
      planar path)
- [x] Full `test/methods/relateng/runtests.jl` green (exit 0)

> One follow-up deferred (documented in the design doc): the lon-interval
> indexed spherical point locator — a pure optimization over the already-correct
> `rk_point_in_ring` fall-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)