### PR TITLE
Fix spherical Sutherland-Hodgman dropping thin grazing slivers

### DIFF
--- a/src/methods/clipping/sutherland_hodgman.jl
+++ b/src/methods/clipping/sutherland_hodgman.jl
@@ -206,19 +206,11 @@ function _sh_spherical_intersection(
 
     intersection_dir = intersection_dir / dir_norm
 
-    # Two candidate intersection points (antipodal)
+    # The two great circles meet at an antipodal pair; keep the crossing on the
+    # subject arc p1→p2, i.e. the one in the same hemisphere as the midpoint p1+p2.
     cand1 = UnitSpherical.UnitSphericalPoint{T}(intersection_dir)
     cand2 = UnitSpherical.UnitSphericalPoint{T}(-intersection_dir)
-
-    # Return the candidate that lies on the subject arc
-    if UnitSpherical.point_on_spherical_arc(cand1, p1, p2)
-        return cand1
-    elseif UnitSpherical.point_on_spherical_arc(cand2, p1, p2)
-        return cand2
-    end
-
-    # Fallback: neither candidate is on the arc (shouldn't happen if orient detected a crossing)
-    return UnitSpherical.UnitSphericalPoint{T}(p1)
+    return cand1 ⋅ p1 + cand1 ⋅ p2 ≥ 0 ? cand1 : cand2
 end
 
 # Clip polygon against a single edge using Sutherland-Hodgman rules (spherical version)

--- a/test/methods/clipping/sutherland_hodgman.jl
+++ b/test/methods/clipping/sutherland_hodgman.jl
@@ -357,6 +357,28 @@ import GeoInterface as GI
             )
             @test spherical_area(result) == 0.0
         end
+
+        @testset "Grazing sliver overlap is symmetric" begin
+            # Two real grid cells (OctaHEALPix × HEALPix) overlapping in a thin sliver
+            # where one corner grazes the other's edge: area must be symmetric.
+            octa = spherical_polygon([
+                (-75.59999999999997, -22.93262592760755),
+                (-76.15384615384615, -19.86735476489602),
+                (-79.2, -22.93262592760755),
+                (-78.75, -25.944479772370016),
+            ])
+            healpix = spherical_polygon([
+                (-77.34375, -24.624318352164078),
+                (-78.04687500000003, -25.282603043311997),
+                (-77.34375, -25.94447977237001),
+                (-76.64062500000003, -25.282603043311997),
+            ])
+            alg = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+            a_oh = spherical_area(GO.intersection(alg, octa, healpix))
+            a_ho = spherical_area(GO.intersection(alg, healpix, octa))
+            @test a_oh ≈ a_ho rtol = 1e-6
+            @test 0 < a_oh < 0.1 * spherical_area(healpix)   # sliver, not the whole cell
+        end
     end
 end
 


### PR DESCRIPTION
`area(intersection(A, B))` for two convex spherical polygons could depend on argument order. When a subject edge grazes the great-circle extension of a clip edge, two overlapping cells returned the **whole clip polygon** one way and the correct thin sliver the other — breaking conservative regridding between HEALPix-family grids (some cells got ~2× their area).

`_sh_spherical_intersection` selected the arc crossing with `point_on_spherical_arc`, whose `spherical_orient(p1, p2, cand) == 0` gate rejects the cross-product candidate (round-off pushes it just off the great circle). Both antipodal candidates get rejected → fall back to an arc endpoint → sliver collapses to zero → the containment fallback returns the whole clip cell.

The two candidates are antipodal, so just keep the one on the subject arc (same hemisphere as the midpoint). Regression test uses the real grid cells that triggered it; the OctaHEALPix↔HEALPix area-agreement error drops from ~1.0 to ~1e-12.

Independent of #414 (which touches the same file); based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)