### PR TITLE
TEST — DocumenterVitepress#359 deploy_url fix (do not merge)

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -51,6 +51,7 @@ WellKnownGeometry = "0f680547-7be7-4555-8820-bb198eeb646b"
 [sources]
 GeometryOps = {path = ".."}
 GeometryOpsCore = {path = "../GeometryOpsCore"}
+DocumenterVitepress = {url = "https://github.com/LuxDL/DocumenterVitepress.jl", rev = "as/deploy-url-fixes"}
 
 [compat]
 DocumenterVitepress = ">=0.2.1"


### PR DESCRIPTION
## Purpose

This is a **test build only** — it points `DocumenterVitepress` at the `as/deploy-url-fixes` branch (LuxDL/DocumenterVitepress.jl#359) via a `[sources]` override in `docs/Project.toml`, to verify that GeometryOps's docs build correctly with that PR's fix to how `MarkdownVitepress` derives the VitePress `base` path from `repo`/`deploy_url`.

PR #359 fixes:
- the URL-scheme regex (`^https?://` instead of the old `r"http[s?]://"`, which never matched plain `http://`)
- trailing slashes are now stripped from `repo`/`deploy_url`
- custom-domain deploy URLs with subpaths are now handled correctly

GeometryOps's `docs/make.jl` calls `MarkdownVitepress(repo = "github.com/JuliaGeo/GeometryOps.jl")` (no explicit `deploy_url`), so this build exercises the `repo`-derived base-path logic, including for PR preview deploys (`push_preview = true` in `deploydocs`).

## Change

Only `docs/Project.toml` was touched, adding one line to the existing `[sources]` table:

\`\`\`toml
DocumenterVitepress = {url = "https://github.com/LuxDL/DocumenterVitepress.jl", rev = "as/deploy-url-fixes"}
\`\`\`

No source, docs content, or CI changes.

## This PR MUST NOT be merged

It exists solely to trigger a docs CI build against an unreleased branch of a dependency. Once the build/preview is verified, this PR should be closed (not merged) and the branch deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)