### PR TITLE
Add `Prepared` geometry with type-indexed preparations

### DIFF
--- a/GeometryOpsCore/Project.toml
+++ b/GeometryOpsCore/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometryOpsCore"
 uuid = "05efe853-fabf-41c8-927e-7063c8b9f013"
 authors = ["Anshul Singhvi <anshulsinghvi@gmail.com>", "Rafael Schouten <rafaelschouten@gmail.com>", "Skylar Gering <skygering@gmail.com>", "and contributors"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/GeometryOpsCore/src/GeometryOpsCore.jl
+++ b/GeometryOpsCore/src/GeometryOpsCore.jl
@@ -22,6 +22,7 @@ include("keyword_docs.jl")
 include("constants.jl")
 
 include("types/manifold.jl")
+include("types/preparations.jl")
 include("types/algorithm.jl")
 include("types/operation.jl")
 include("types/exceptions.jl")

--- a/GeometryOpsCore/src/types/preparations.jl
+++ b/GeometryOpsCore/src/types/preparations.jl
@@ -1,0 +1,119 @@
+#=
+# Prepared geometry
+
+Interface types for prepared geometry: a GeoInterface-compatible wrapper that carries a
+tuple of immutable, eagerly built acceleration structures ("preparations"), retrieved by
+*capability* trait — algorithms only care that a geometry *has* an edge index, not how it
+was built. Design: `docs/plans/2026-07-01-prepared-geometry-design.md` (repo root).
+
+The consumption interface lives here in GeometryOpsCore so third-party packages can
+provide preparations without depending on GeometryOps. The `prepare` builder and the
+concrete preparations live in GeometryOps (extents are manifold-aware).
+=#
+
+export AbstractPreparation, AbstractPreparationTrait,
+    SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike,
+    preptrait, PreparationSpec, Prepared, getprep, prepare
+
+"""
+    AbstractPreparation
+
+Supertype of built, immutable acceleration structures attached to exactly one geometry via
+[`Prepared`](@ref). Concrete subtypes implement [`preptrait`](@ref).
+"""
+abstract type AbstractPreparation end
+
+"""
+    AbstractPreparationTrait
+
+Capability traits for preparations: what a preparation can answer, not what it is.
+Retrieval via `get(prepared, trait)` returns the first preparation with that capability.
+"""
+abstract type AbstractPreparationTrait end
+
+"Capability: an extent tree over child elements (rings of a polygon, polygons of a multi)."
+struct SpatialIndexLike <: AbstractPreparationTrait end
+"Capability: an extent tree over the segments/edges of a curve or geometry."
+struct SpatialEdgeIndexLike <: AbstractPreparationTrait end
+"Capability: a point-in-polygonal-area locator."
+struct PointInAreaLike <: AbstractPreparationTrait end
+
+"""
+    preptrait(prep::AbstractPreparation)::AbstractPreparationTrait
+
+The capability of `prep`. Every concrete preparation implements this.
+"""
+function preptrait end
+
+"""
+    PreparationSpec
+
+Supertype of the *configs* passed to [`prepare`](@ref)'s `preps` tuple. A spec declares
+which GeoInterface trait it attaches to via `appliesto(spec)` and how to build via
+`buildprep(spec, manifold, geom) -> Union{AbstractPreparation, Nothing}` (`nothing` means
+"nothing to index here", e.g. an empty geometry). Both are extended (not exported) via
+`import GeometryOpsCore: appliesto, buildprep`.
+"""
+abstract type PreparationSpec end
+
+function appliesto end
+function buildprep end
+
+"""
+    Prepared(geom, manifold::Manifold, preps::Tuple, extent::Extents.Extent)
+
+A geometry `geom` carrying preparations `preps`. Forwards GeoInterface, so it works
+anywhere a geometry does. `extent` is always cached (manifold-aware: 3D on `Spherical`).
+The wrapper and its preparation set are immutable; a miss on `get` means the caller takes
+its unindexed path. Children of a `Prepared` built by `prepare` are themselves `Prepared`.
+"""
+struct Prepared{T <: GI.AbstractTrait, M <: Manifold, G,
+                P <: Tuple{Vararg{AbstractPreparation}}, E <: Extents.Extent}
+    geom::G
+    manifold::M
+    preps::P
+    extent::E
+    function Prepared(geom::G, m::M, preps::P, extent::E) where
+            {M <: Manifold, G, P <: Tuple{Vararg{AbstractPreparation}}, E <: Extents.Extent}
+        t = GI.trait(geom)
+        t === nothing && throw(ArgumentError("`Prepared` requires a GeoInterface geometry; got $(typeof(geom))"))
+        new{typeof(t), M, G, P, E}(geom, m, preps, extent)
+    end
+end
+
+Base.parent(p::Prepared) = p.geom
+manifold(p::Prepared) = p.manifold
+
+"""
+    get(p::Prepared, t::AbstractPreparationTrait) -> Union{AbstractPreparation, Nothing}
+    get(geom, t::AbstractPreparationTrait) -> nothing
+
+The first preparation on `p` with capability `t`, or `nothing`. Plain geometries always
+return `nothing`, so call sites need no special-casing.
+"""
+Base.get(p::Prepared, t::AbstractPreparationTrait) = _findprep(t, p.preps)
+Base.get(@nospecialize(_), ::AbstractPreparationTrait) = nothing
+
+_findprep(::AbstractPreparationTrait, ::Tuple{}) = nothing
+_findprep(t::AbstractPreparationTrait, preps::Tuple) =
+    preptrait(first(preps)) === t ? first(preps) : _findprep(t, Base.tail(preps))
+
+"""
+    getprep(m::Manifold, geom, t::AbstractPreparationTrait) -> Union{AbstractPreparation, Nothing}
+
+Manifold-checked retrieval: like `get(geom, t)` but a manifold mismatch is a miss —
+preparations bake in manifold-specific state (kernel point types, 3D extents), so a
+`Planar` edge tree must never be served to a `Spherical` algorithm.
+"""
+getprep(m::Manifold, p::Prepared, t::AbstractPreparationTrait) =
+    manifold(p) === m ? get(p, t) : nothing
+getprep(::Manifold, @nospecialize(_), ::AbstractPreparationTrait) = nothing
+
+"""
+    prepare(...)
+
+Generic entry point for prepared-geometry optimizations. GeometryOps implements
+`prepare(geom; preps, manifold)` (the wrapper builder) and `prepare(alg, geom)` methods
+for algorithms (e.g. `RelateNG`).
+"""
+function prepare end

--- a/GeometryOpsCore/src/types/preparations.jl
+++ b/GeometryOpsCore/src/types/preparations.jl
@@ -117,3 +117,38 @@ Generic entry point for prepared-geometry optimizations. GeometryOps implements
 for algorithms (e.g. `RelateNG`).
 """
 function prepare end
+
+#-- GeoInterface forwarding: a Prepared IS-A geometry wherever GI is spoken.
+#-- The extent is served from the cached field, never recomputed.
+GI.isgeometry(::Type{<:Prepared{T, M, G}}) where {T, M, G} = GI.isgeometry(G)
+GI.trait(::Prepared{T}) where {T} = T()
+GI.geomtrait(::Prepared{T}) where {T} = T()
+
+Extents.extent(p::Prepared) = p.extent
+GI.extent(::GI.AbstractTrait, p::Prepared) = p.extent
+GI.crs(t::GI.AbstractTrait, p::Prepared) = GI.crs(t, parent(p))
+
+for f in (:coordnames, :is3d, :ismeasured, :isempty, :coordinates, :ngeom, :getgeom)
+    @eval GI.$f(t::GI.AbstractGeometryTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:npoint, :getpoint, :startpoint, :endpoint, :issimple, :isclosed, :isring)
+    @eval GI.$f(t::GI.AbstractCurveTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:nring, :getring, :getexterior, :nhole, :gethole, :npoint, :getpoint)
+    @eval GI.$f(t::GI.AbstractPolygonTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:nring, :getring, :npoint, :getpoint)
+    @eval GI.$f(t::GI.AbstractMultiPolygonTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:npoint, :getpoint, :issimple)
+    @eval GI.$f(t::GI.AbstractMultiPointTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+    @eval GI.$f(t::GI.AbstractMultiCurveTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+
+#-- disambiguation against GI's trait-specific defaults (e.g. npoint(::LineTrait) = 2)
+for T in (:LineTrait, :TriangleTrait, :PentagonTrait, :HexagonTrait, :RectangleTrait, :QuadTrait)
+    @eval GI.npoint(t::GI.$T, p::Prepared) = GI.npoint(t, parent(p))
+end
+for T in (:TriangleTrait, :RectangleTrait, :QuadTrait, :PentagonTrait, :HexagonTrait)
+    @eval GI.nring(t::GI.$T, p::Prepared) = GI.nring(t, parent(p))
+end

--- a/GeometryOpsCore/src/types/preparations.jl
+++ b/GeometryOpsCore/src/types/preparations.jl
@@ -152,3 +152,10 @@ end
 for T in (:TriangleTrait, :RectangleTrait, :QuadTrait, :PentagonTrait, :HexagonTrait)
     @eval GI.nring(t::GI.$T, p::Prepared) = GI.nring(t, parent(p))
 end
+
+#-- points are never wrapped by `prepare`, but a Prepared point is constructible
+#-- (e.g. by a third-party provider); forward the point-trait accessors that
+#-- collide with the AbstractGeometryTrait loop above
+for f in (:ngeom, :getgeom, :coordinates)
+    @eval GI.$f(t::GI.AbstractPointTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometryOps"
 uuid = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"
 authors = ["Anshul Singhvi <anshulsinghvi@gmail.com>", "Rafael Schouten <rafaelschouten@gmail.com>", "Skylar Gering <skygering@gmail.com>", "and contributors"]
-version = "0.1.40"
+version = "0.1.41"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -52,7 +52,7 @@ Extents = "0.1.5"
 FlexiJoins = "0.1.30"
 GeoFormatTypes = "0.4"
 GeoInterface = "1.6"
-GeometryOpsCore = "=0.1.10"
+GeometryOpsCore = "=0.1.11"
 LibGEOS = "0.9.2"
 LinearAlgebra = "1"
 Proj = "1"

--- a/docs/plans/2026-07-01-prepared-geometry-design.md
+++ b/docs/plans/2026-07-01-prepared-geometry-design.md
@@ -133,7 +133,8 @@ Notes:
    - `RelateGeometry` constructor: if the input is `Prepared`, skip
      `_relate_cache_extents` — extents are already on the wrapper.
    - `_build_prepared_edge_index`: `getprep(m, a, SpatialEdgeIndexLike())` hit ⇒ reuse
-     instead of rebuilding.
+     instead of rebuilding. *(Not built — dropped with `SegmentIndex`, see Amendments;
+     v1 ships two relateng seams: extent trust and `PointInAreaLike` reuse.)*
    - `RelatePointLocator`: a polygonal element that is `Prepared` with `PointInAreaLike`
      ⇒ use it as the indexed locator for that element.
 2. **`NaturallyIndexedRing`** is deleted; its two call sites move to

--- a/docs/plans/2026-07-01-prepared-geometry-design.md
+++ b/docs/plans/2026-07-01-prepared-geometry-design.md
@@ -1,0 +1,194 @@
+# Prepared geometry (F4): `Prepared{Geom, Preparations}` design
+
+**Status: DRAFT — decisions 1–2 ratified by Anshul, 3–8 provisional (made in his absence, listed in §Decisions for ratification).**
+
+This is the design for follow-up **F4** from `2026-06-10-relateng-design.md` ("Generalize
+`prepare` into a package-wide prepared-geometry mechanism"). It consolidates the ideas
+recorded in [PR #278](https://github.com/JuliaGeo/GeometryOps.jl/pull/278),
+[issue #87](https://github.com/JuliaGeo/GeometryOps.jl/issues/87), and
+[issue #103](https://github.com/JuliaGeo/GeometryOps.jl/issues/103), and uses the RelateNG
+port's index inventory as the requirements list.
+
+## Problem
+
+GeometryOps is accreting one-off preparation state with no unifying layer:
+
+- `PreparedRelate` (`src/methods/geom_relations/relateng/relate_ng.jl:596-632`) — an
+  algorithm-side struct: RelateNG + `RelateGeometry` + segment strings + edge tree.
+- `NaturallyIndexedRing` / `prepare_naturally` (`src/utils/NaturalIndexing.jl:199-240`) —
+  a ring wrapper carrying a `NaturalIndex`, explicitly marked as a throwaway experiment.
+- The extent-cached GI wrapper tree `_relate_cache_extents`
+  (`relate_geometry.jl:74,119-139`) — rebuilt privately inside every `RelateGeometry`.
+- Clipping's `AutoAccelerator` docstring promises it "will also consider the existing
+  preparations on the geoms" — with no mechanism to find them.
+
+Each new accelerated algorithm reinvents caching, caches cannot be shared across
+algorithms, and a geometry cannot carry more than one preparation.
+
+## Design summary
+
+A **GeoInterface-forwarding wrapper** that carries a **tuple of preparations**, retrieved
+**by capability trait** ("I only care that you *have* an edge index, not how you got it" —
+PR #278). Preparations are built **eagerly** at `prepare` time; the wrapper and its
+preparation set are **immutable**. Sub-geometry preparations are handled by **recursive
+wrapping**: `prepare` rebuilds the GI tree once, and a preparation always describes the
+geometry it directly wraps.
+
+```julia
+p = prepare(multipoly; preps = (ChildTree(), RingEdgeIndex()), manifold = Planar())
+# Prepared{MultiPolygonTrait, …, Tuple{ChildTree{…}}}        (tree over polygon extents)
+#  └─ Prepared{PolygonTrait, …, Tuple{}}                     (extent-cached pass-through)
+#      └─ Prepared{LinearRingTrait, …, Tuple{RingEdgeIndex{…}}}
+
+tree = get(p, SpatialIndexLike())        # ⇒ the ChildTree
+get(p, PointInAreaLike())                # ⇒ nothing — caller uses the unindexed path
+GI.getgeom(p, 1)                         # ⇒ the *prepared* polygon; GI code sees a normal geometry
+```
+
+## Core interface (GeometryOpsCore)
+
+```julia
+"A built, immutable acceleration structure attached to exactly one geometry."
+abstract type AbstractPreparation end
+
+"Capability traits: what a preparation can do, not what it is."
+abstract type AbstractPreparationTrait end
+struct SpatialIndexLike     <: AbstractPreparationTrait end  # extent tree over child elements
+struct SpatialEdgeIndexLike <: AbstractPreparationTrait end  # extent tree over segments/edges
+struct PointInAreaLike      <: AbstractPreparationTrait end  # point-in-polygonal-area locator
+
+"Every concrete preparation declares its capability."
+function preptrait end   # preptrait(::RingEdgeIndex) = SpatialEdgeIndexLike()
+
+"Configs passed to `prepare`; declare where they attach and how to build."
+abstract type PreparationSpec end
+function appliesto end   # appliesto(::RingEdgeIndex) = GI.LinearRingTrait
+function build end       # build(spec, manifold, geom) -> AbstractPreparation
+```
+
+The wrapper:
+
+```julia
+struct Prepared{T <: GI.AbstractTrait, M <: Manifold, Geom,
+                Preps <: Tuple{Vararg{AbstractPreparation}}, E}
+    geom::Geom      # children are themselves Prepared (recursive rebuild)
+    manifold::M     # preparations are manifold-specific (kernel point types, 3D extents)
+    preps::Preps
+    extent::E       # always cached — subsumes `_relate_cache_extents`
+end
+
+GI.trait(::Prepared{T}) where {T} = T()
+GI.extent(p::Prepared) = p.extent
+# + full GeoInterface forwarding (ngeom/getgeom/npoint/getpoint/coordinates/crs/is3d/ismeasured),
+#   following the 2024 `src/prepared.jl` (commit 225997c65) and `_relate_cache_extents`.
+```
+
+Retrieval:
+
+```julia
+# Hit: first preparation in `preps` whose preptrait matches (compile-time tuple recursion).
+# Miss: `nothing`. Plain geometries always miss, so call sites are uniform.
+Base.get(p::Prepared, t::AbstractPreparationTrait) -> Union{AbstractPreparation, Nothing}
+Base.get(geom, ::AbstractPreparationTrait) = nothing
+
+# Manifold-checked variant for algorithms (a Planar edge tree is useless to a Spherical kernel):
+getprep(m::Manifold, p, t) = (q = get(p, t); q !== nothing && manifold(p) == m ? q : nothing)
+```
+
+Construction is one bottom-up `apply`-style pass — children are prepared first, so a
+parent's preparation (e.g. a tree over ring extents) can index already-prepared children:
+
+```julia
+prepare(geom; preps = (), manifold = Planar(), tuples = true)
+```
+
+Every node is wrapped (empty `preps` allowed) so extents are cached at every level,
+exactly like `_relate_cache_extents` today. `tuples = true` converts coordinates to tuple
+form during the rebuild (the PR #278 default; `tuples = false` preserves the original
+point representation).
+
+## v1 preparations (GeometryOps)
+
+| Spec | Attaches to (`appliesto`) | Capability | Built structure | Replaces / serves |
+|---|---|---|---|---|
+| `SegmentIndex()` | any lineal/polygonal geometry (top level) | `SpatialEdgeIndexLike` | flattened `NaturalIndex` over all segments + `owners` table | `PreparedEdgeIndex` reuse in RelateNG |
+| `RingEdgeIndex()` | `LinearRingTrait` | `SpatialEdgeIndexLike` | `NaturalIndex` over the ring's segment extents | `NaturallyIndexedRing` (delete it) |
+| `ChildTree()` | `Multi*`, `GeometryCollection`, `PolygonTrait` (rings) | `SpatialIndexLike` | STRtree or `NaturalIndex` over child extents | clipping `AutoAccelerator` promise |
+| `PointInArea()` | `PolygonTrait` | `PointInAreaLike` | `IndexedPointInAreaLocator` (sorted leaves) | RelateNG per-polygon locators |
+
+Notes:
+- All specs take the index implementation as a config (default `NaturalIndex`; anything
+  implementing SpatialTreeInterface works — the swap point documented at
+  `edge_intersector.jl:294-299`).
+- `PointInArea` is Planar-only in v1; on `Spherical`, `build` is not defined and `prepare`
+  raises a clear error (the spherical point-in-area index was deliberately time-boxed out
+  of the relateng plan — Task 16).
+- Third-party providers (e.g. a LibGEOS prepared geometry) can ship their own
+  `AbstractPreparation` + `preptrait` method — the issue #103 goal. Nothing in the core
+  interface names a concrete index type.
+
+## Consumer seams (v1 validation)
+
+1. **RelateNG** (`PreparedRelate` stays; it is algorithm-side state, not geometry state):
+   - `RelateGeometry` constructor: if the input is `Prepared`, skip
+     `_relate_cache_extents` — extents are already on the wrapper.
+   - `_build_prepared_edge_index`: `getprep(m, a, SpatialEdgeIndexLike())` hit ⇒ reuse
+     instead of rebuilding.
+   - `RelatePointLocator`: a polygonal element that is `Prepared` with `PointInAreaLike`
+     ⇒ use it as the indexed locator for that element.
+2. **`NaturallyIndexedRing`** is deleted; its two call sites move to
+   `prepare(ring; preps = (RingEdgeIndex(),))`.
+3. **Clipping `AutoAccelerator`**: when an input `isa Prepared` with `SpatialIndexLike`,
+   prefer the existing tree over building one.
+
+Success criterion: the relateng prepared-vs-unprepared equality suite
+(`test/methods/relateng/relate_ng.jl`, `PREPARED_FIXTURES`) passes with `Prepared` inputs
+substituted, plus GI-equivalence tests (`GI.coordinates`, `GI.extent`, trait round-trips)
+for wrapped vs plain geometries.
+
+## What this design deliberately does not do
+
+- **No laziness, no mutation.** `get` never builds; a miss means the caller takes the
+  unindexed path. Laziness is the property of the *unprepared* regime (e.g.
+  `RelatePointLocator`'s second-query indexing stays as-is). Consequence: a
+  `PointInArea()` prep builds locators for *all* polygonal elements up front.
+- **No survival across transformations.** `apply`/`transform`/corrections return plain
+  geometries; preparations are dropped, never patched. Documented, not enforced.
+- **No Symbol-keyed access.** The 2024 `getprep(p, ::Symbol)` NamedTuple approach is
+  superseded by capability traits.
+- **No serialization story.**
+
+## Decisions for ratification
+
+1. **Eager + immutable cache model** — *ratified* (chosen over lazy-inside and
+   JTS-style mutable get-or-cache).
+2. **Design F4 now, `PreparedRelate` kept with a sourcing seam** — *ratified*.
+3. **Recursive wrapping for sub-geometry preparations** — *provisional (recommended)*.
+   Alternatives considered: flat store with level tags + path bookkeeping (leaks
+   `owners`-style bookkeeping into every consumer; sub-geometries can't travel with their
+   preparations); top-level-only v1 (punts on the core of the idea). Flipping this
+   reshapes §Core interface but not the trait/retrieval design.
+4. **Every node wrapped, extent always cached** — provisional. Unifies with
+   `_relate_cache_extents`; cost is deep (but regular) wrapper types.
+5. **Spec/build split** (`PreparationSpec` + `build(spec, m, geom)` vs preparations
+   doubling as their own configs) — provisional; chosen so built state and config don't
+   share a struct.
+6. **Manifold recorded on the wrapper; mismatch = miss** (silent fallback to the
+   unindexed path rather than an error) — provisional.
+7. **Placement: interface in GeometryOpsCore, concrete preparations in GeometryOps** —
+   provisional; enables third-party providers without a GO dependency.
+8. **`Base.get` overload as the retrieval verb** (vs a new exported `getprep` for
+   everything) — provisional; `get` matches the PR #278 sketch, and the manifold-checked
+   `getprep` is the algorithm-facing entry.
+
+## References
+
+- PR #278 (`as/prepare` branch): `Prepared{Pa,Pr}`, `AbstractPreparation`,
+  `AbstractPreparationTrait`, `preptrait`, `SpatialIndex{T}`, `SpatialEdgeIndex{T}`.
+- Issues #87 (closed → #278/#103), #103 (open).
+- Precedents in-tree: `_relate_cache_extents` (`relate_geometry.jl:119-139`),
+  `NaturallyIndexedRing` (`src/utils/NaturalIndexing.jl:199-240`), commit `225997c65`
+  (rafaqz's `src/prepared.jl`).
+- Requirements inventory: `PreparedRelate` internals (`relate_ng.jl:596-676`),
+  `RelatePointLocator` (`point_locator.jl:235-270`), `AutoAccelerator`
+  (`clipping_processor.jl:25-40`).

--- a/docs/plans/2026-07-01-prepared-geometry-design.md
+++ b/docs/plans/2026-07-01-prepared-geometry-design.md
@@ -1,6 +1,6 @@
 # Prepared geometry (F4): `Prepared{Geom, Preparations}` design
 
-**Status: DRAFT — decisions 1–2 ratified by Anshul, 3–8 provisional (made in his absence, listed in §Decisions for ratification).**
+**Status: ACCEPTED — implemented on branch `prepared-geometry`; deviations below.**
 
 This is the design for follow-up **F4** from `2026-06-10-relateng-design.md` ("Generalize
 `prepare` into a package-wide prepared-geometry mechanism"). It consolidates the ideas
@@ -114,7 +114,7 @@ point representation).
 | `SegmentIndex()` | any lineal/polygonal geometry (top level) | `SpatialEdgeIndexLike` | flattened `NaturalIndex` over all segments + `owners` table | `PreparedEdgeIndex` reuse in RelateNG |
 | `RingEdgeIndex()` | `LinearRingTrait` | `SpatialEdgeIndexLike` | `NaturalIndex` over the ring's segment extents | `NaturallyIndexedRing` (delete it) |
 | `ChildTree()` | `Multi*`, `GeometryCollection`, `PolygonTrait` (rings) | `SpatialIndexLike` | STRtree or `NaturalIndex` over child extents | clipping `AutoAccelerator` promise |
-| `PointInArea()` | `PolygonTrait` | `PointInAreaLike` | `IndexedPointInAreaLocator` (sorted leaves) | RelateNG per-polygon locators |
+| `PointInArea()` | `Union{PolygonTrait, MultiPolygonTrait}` | `PointInAreaLike` | `IndexedPointInAreaLocator` (sorted leaves) | RelateNG per-polygon locators |
 
 Notes:
 - All specs take the index implementation as a config (default `NaturalIndex`; anything
@@ -158,28 +158,36 @@ for wrapped vs plain geometries.
   superseded by capability traits.
 - **No serialization story.**
 
-## Decisions for ratification
+## Decisions (ratified)
+
+Decisions 1–2 were ratified by Anshul up front. Decisions 3–8 were provisional in the
+draft and are now resolved: recursive wrapping (3) was ratified verbally by Anshul, and
+4–8 were ratified by implementation on the `prepared-geometry` branch. The per-decision
+statuses below reflect that; see the Amendments section for the deviations encountered.
 
 1. **Eager + immutable cache model** — *ratified* (chosen over lazy-inside and
    JTS-style mutable get-or-cache).
 2. **Design F4 now, `PreparedRelate` kept with a sourcing seam** — *ratified*.
-3. **Recursive wrapping for sub-geometry preparations** — *provisional (recommended)*.
+3. **Recursive wrapping for sub-geometry preparations** — *ratified (verbally, by Anshul)
+   and implemented*.
    Alternatives considered: flat store with level tags + path bookkeeping (leaks
    `owners`-style bookkeeping into every consumer; sub-geometries can't travel with their
    preparations); top-level-only v1 (punts on the core of the idea). Flipping this
    reshapes §Core interface but not the trait/retrieval design.
-4. **Every node wrapped, extent always cached** — provisional. Unifies with
-   `_relate_cache_extents`; cost is deep (but regular) wrapper types.
+4. **Every node wrapped, extent always cached** — *ratified by implementation*. Unifies
+   with `_relate_cache_extents`; cost is deep (but regular) wrapper types.
 5. **Spec/build split** (`PreparationSpec` + `build(spec, m, geom)` vs preparations
-   doubling as their own configs) — provisional; chosen so built state and config don't
-   share a struct.
+   doubling as their own configs) — *ratified by implementation* (built as `buildprep`,
+   not `build` — see Amendments); chosen so built state and config don't share a struct.
 6. **Manifold recorded on the wrapper; mismatch = miss** (silent fallback to the
-   unindexed path rather than an error) — provisional.
+   unindexed path rather than an error) — *ratified by implementation*; the relateng seam
+   refines this (Amendments (e)): a matched-manifold `Prepared` is trusted as-is, a
+   mismatched one is stripped and its extents rebuilt from coordinates.
 7. **Placement: interface in GeometryOpsCore, concrete preparations in GeometryOps** —
-   provisional; enables third-party providers without a GO dependency.
+   *ratified by implementation*; enables third-party providers without a GO dependency.
 8. **`Base.get` overload as the retrieval verb** (vs a new exported `getprep` for
-   everything) — provisional; `get` matches the PR #278 sketch, and the manifold-checked
-   `getprep` is the algorithm-facing entry.
+   everything) — *ratified by implementation*; `get` matches the PR #278 sketch, and the
+   manifold-checked `getprep` is the algorithm-facing entry.
 
 ## References
 
@@ -192,3 +200,72 @@ for wrapped vs plain geometries.
 - Requirements inventory: `PreparedRelate` internals (`relate_ng.jl:596-676`),
   `RelatePointLocator` (`point_locator.jl:235-270`), `AutoAccelerator`
   (`clipping_processor.jl:25-40`).
+
+## Amendments (discovered during implementation, 2026-07-01)
+
+The design was implemented on branch `prepared-geometry` (Tasks 1–11, all green). The
+following deviations and clarifications were recorded during API fact-finding and code
+review. The first group narrows the scope/API from the draft; the second records details
+that surfaced in review of the individual tasks.
+
+### Scope and API deviations (from API fact-finding)
+
+- **`SegmentIndex` dropped from v1.** A flattened whole-geometry edge tree carries an
+  `owners` table whose indices are only meaningful relative to relateng's
+  `extract_segment_strings` traversal order; building it independently risks silent
+  owner mismatches. RelateNG keeps building its own `PreparedEdgeIndex` inside
+  `prepare(::RelateNG, a)`. Revisit when a second consumer needs flat segment trees.
+  (The v1 table above still lists `SegmentIndex` as the original design; it is not built.)
+- **Clipping `AutoAccelerator` seam deferred** for the same reason (clipping indexes
+  flattened edge tables, not child extents).
+- **`tuples` keyword deferred** — compose as `prepare(GO.tuples(geom); ...)`.
+- **`build` is spelled `buildprep`**; `appliesto`/`buildprep` are unexported (providers
+  extend via `import GeometryOpsCore: appliesto, buildprep`).
+- **Topmost-wins attachment:** a spec is consumed at the highest matching level and not
+  offered further down (so `ChildTree` on a MultiPolygon indexes polygons at the top
+  node only). Multi-level trees = call `prepare` with the spec on the sub-geometry.
+- **Mismatched-manifold `Prepared` inputs to relateng** take the ordinary rewrap path
+  (correct extents rebuilt; preparations shadowed) rather than erroring.
+
+### Clarifications from code review
+
+- **(a) Points and multipoints pass through `prepare` unwrapped.** A bare point or
+  multipoint is returned as-is, never wrapped in `Prepared`. The point-trait GeoInterface
+  forwarding that `Prepared` carries (in `GeometryOpsCore/src/types/preparations.jl`)
+  exists purely for method-table hygiene — to forward the point-trait accessors that would
+  otherwise collide with the `AbstractGeometryTrait` forwarding loop, and to stay correct
+  if a third party ever constructs a `Prepared` point directly — not because `prepare` ever
+  produces one. (Task 2 review.)
+- **(b) The legacy `_union_stored_extents` cache is dimensionally collapsed for a spherical
+  GC with a bare point — but contained.** For a `Spherical` GeometryCollection that
+  contains a bare point, the legacy plain-input extent path (`_union_stored_extents`)
+  unions the point's manifold-blind 2D lon/lat box with the polygon's 3D unit-sphere box;
+  `Extents.union` keeps only shared keys, so the cached extent collapses to a
+  coordinate-mixed 2D box (verified `X = (0.604…, 12.0)` — a unit-sphere coordinate unioned
+  with a raw degree value). This is **contained**: `_relate_extent` recomputes the driving
+  extent in both the plain and prepared paths (`relate_geometry.jl:75`), so the `relate`
+  output is unaffected; `prepare`'s `_union_prepared_extents` avoids the garbage cache
+  entirely (it uses `rk_interaction_bounds`); and the Task 10 sweep pins the divergence via
+  a 2D-vs-3D extent-keys tripwire. (Task 4 + Task 10 reviews.)
+- **(c) `PointInArea` attaches to `Union{PolygonTrait, MultiPolygonTrait}`, not
+  `PolygonTrait`** (the v1 table above is updated to match). This mirrors relateng's
+  `addPolygonal` element granularity: `_extract_elements!` (`point_locator.jl:322-328`)
+  keeps a whole polygonal geometry as ONE element, so a MultiPolygon input needs the
+  locator attached at the MultiPolygon node (not per-polygon). GeometryCollection inputs,
+  by contrast, decompose into per-polygon elements, and because the spec is offered
+  top-down it flows past the GC node and attaches per-polygon. (Task 7 review
+  adjudication.)
+- **(d) `Geodesic` is unsupported by `prepare`.** `prepare` fails on the `Geodesic`
+  manifold even with no preps, because it reaches `rk_interaction_bounds`, which has
+  methods for `Planar` and `Spherical` only. This is a prepare-level limitation (not
+  specific to any spec).
+- **(e) Mismatched-manifold handling is part of the relateng seam contract.** When a
+  `Prepared` input's manifold matches the algorithm's, the wrapper (and its cached extents)
+  is trusted as-is; when it mismatches, the wrapper is **stripped** and extents are rebuilt
+  from coordinates (commit `130e278cf`). Planar→spherical was already safe because the
+  spherical path recomputes, but spherical→planar leaked cached 3D extents into the planar
+  `GI.extent` fast path until the strip fix. (Task 8 review.)
+- **(f) relateng `PointInArea` reuse requires matching `exact` types.** The relate point
+  locator reuses a `Prepared` `PointInAreaLike` locator only when the algorithm's `exact`
+  type matches the preparation's; both default to `True()`, so the common case reuses.
+  (Task 9 review.)

--- a/docs/plans/2026-07-01-prepared-geometry.md
+++ b/docs/plans/2026-07-01-prepared-geometry.md
@@ -1,0 +1,1335 @@
+# Prepared Geometry (F4) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement the `Prepared{Geom, Preparations}` wrapper from
+`docs/plans/2026-07-01-prepared-geometry-design.md`: capability-trait-indexed, eagerly
+built, immutable preparations attached to geometries via recursive wrapping, with RelateNG
+consuming them.
+
+**Architecture:** Consumption interface (types, traits, `Prepared`, `get`/`getprep`,
+GeoInterface forwarding) lives in **GeometryOpsCore** (`src/types/preparations.jl`). The
+`prepare` builder and concrete v1 specs (`RingEdgeIndex`, `ChildTree`, `PointInArea`) live
+in **GeometryOps** (`src/prepared/prepared.jl`) because extents are manifold-aware (they
+need `rk_interaction_bounds` from the relateng kernel). RelateNG gains two seams: skip its
+private extent-cache rebuild for matched-manifold `Prepared` inputs, and reuse a
+`PointInAreaLike` preparation in its point locator.
+
+**Tech Stack:** Julia, GeoInterface (`GI`), Extents, the in-repo `NaturalIndexing` and
+`SpatialTreeInterface` modules, relateng kernel helpers (`rk_interaction_bounds`,
+`_segment_extent`, `_to_kernel_point`), `IndexedPointInAreaLocator`.
+
+---
+
+## Deviations from the design doc (discovered during API fact-finding; Task 12 records them in the design doc)
+
+1. **`SegmentIndex` (whole-geometry flattened edge tree) is dropped from v1.** Its
+   `owners::Vector{NTuple{2,Int}}` table only makes sense relative to relateng's
+   `extract_segment_strings` traversal order; building it independently risks silent
+   owner-index mismatch. RelateNG keeps building its own `PreparedEdgeIndex` inside
+   `prepare(::RelateNG, a)`. Revisit when a second consumer needs a flat segment tree.
+2. **The clipping/`AutoAccelerator` seam is deferred.** Clipping accelerators index
+   flattened edge tables (`NaturalIndex(edges)`), not child extents — same owners problem.
+3. **The `tuples` keyword is deferred.** Callers compose: `prepare(GO.tuples(geom); ...)`.
+4. **`build` is named `buildprep`** (a bare exported `build` invites collisions), and
+   `appliesto`/`buildprep` are deliberately **not exported** — providers extend them via
+   `import GeometryOpsCore: appliesto, buildprep`.
+5. **Topmost-wins spec attachment:** a spec is consumed at the highest tree level whose
+   trait matches `appliesto(spec)` and is not offered further down. E.g. `ChildTree()` on a
+   MultiPolygon indexes polygon extents at the MP node; it does not additionally build
+   ring-trees inside each polygon.
+
+## Conventions for the executor
+
+- **Worktree:** use superpowers:using-git-worktrees to create a worktree on a new branch
+  `prepared-geometry` based on `relateng-spherical`. All paths below are relative to the
+  worktree root.
+- **Run single test files from the repo root** (never `Pkg.test()` in the loop; the full
+  suite takes ~25 min): `julia --project=test -e 'include("test/methods/relateng/relate_ng.jl")'`.
+  First run in a fresh depot precompiles (~1–2 min); later runs are seconds.
+- `timeout` does not exist on this macOS — use `gtimeout` if you need one.
+- **Commit style** (AGENTS.md): imperative, capitalized, no conventional-commit prefixes,
+  backticks around identifiers, no trailing period.
+- TDD: write the failing test, SEE it fail, implement, SEE it pass, commit.
+- `GI` is `GeoInterface`; inside GeometryOpsCore it is already imported; test files are
+  self-contained (they do their own `using`).
+
+---
+
+### Task 0: Worktree, baseline, commit the plan docs
+
+**Step 1: Create worktree + branch**
+
+Follow superpowers:using-git-worktrees. Base: `relateng-spherical`. Branch name:
+`prepared-geometry`.
+
+**Step 2: Verify baseline is green**
+
+Run: `julia --project=test -e 'include("test/methods/relateng/relate_ng.jl")'`
+Expected: all tests pass (this file includes the prepared-vs-unprepared fixture sweep).
+
+**Step 3: Commit the design + plan docs**
+
+The two docs were written in the main checkout; copy them into the worktree if the
+worktree was created before they existed.
+
+```bash
+git add docs/plans/2026-07-01-prepared-geometry-design.md docs/plans/2026-07-01-prepared-geometry.md
+git commit -m "Add prepared-geometry design and implementation plan"
+```
+
+---
+
+### Task 1: Core preparation types + trait-indexed retrieval
+
+**Files:**
+- Create: `GeometryOpsCore/src/types/preparations.jl`
+- Modify: `GeometryOpsCore/src/GeometryOpsCore.jl` (include line)
+- Create: `test/core/preparations.jl`
+- Modify: `test/runtests.jl` (wire the new file into the `"Core"` testset, mirroring the
+  existing `test/core/*.jl` entries at lines ~8–13)
+
+**Step 1: Write the failing test**
+
+Create `test/core/preparations.jl`:
+
+```julia
+using Test
+import GeometryOpsCore
+import GeometryOpsCore: Prepared, AbstractPreparation, AbstractPreparationTrait,
+    SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike,
+    preptrait, getprep, Planar, Spherical, manifold
+import GeoInterface as GI
+import GeoInterface: Extents
+
+# Dummy preparations for interface tests
+struct _DummyEdgeTree <: AbstractPreparation
+    payload::Int
+end
+GeometryOpsCore.preptrait(::_DummyEdgeTree) = SpatialEdgeIndexLike()
+
+struct _DummyChildTree <: AbstractPreparation end
+GeometryOpsCore.preptrait(::_DummyChildTree) = SpatialIndexLike()
+
+@testset "Preparation retrieval" begin
+    ring = GI.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)])
+    ext = GI.extent(ring; fallback = true)
+    p = Prepared(ring, Planar(), (_DummyEdgeTree(42), _DummyChildTree()), ext)
+
+    @test manifold(p) === Planar()
+    @test parent(p) === ring
+
+    # hit: first matching preparation, concretely typed
+    et = get(p, SpatialEdgeIndexLike())
+    @test et isa _DummyEdgeTree && et.payload == 42
+    @test get(p, SpatialIndexLike()) isa _DummyChildTree
+
+    # miss: nothing
+    @test get(p, PointInAreaLike()) === nothing
+
+    # plain geometries always miss — uniform call sites
+    @test get(ring, SpatialEdgeIndexLike()) === nothing
+
+    # manifold-checked retrieval: mismatch is a miss, not an error
+    @test getprep(Planar(), p, SpatialEdgeIndexLike()) === et
+    @test getprep(Spherical(), p, SpatialEdgeIndexLike()) === nothing
+    @test getprep(Planar(), ring, SpatialEdgeIndexLike()) === nothing
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/core/preparations.jl")'`
+Expected: FAIL — `UndefVarError` / `ArgumentError` importing `Prepared` etc.
+
+**Step 3: Write the implementation**
+
+Create `GeometryOpsCore/src/types/preparations.jl`:
+
+```julia
+#=
+# Prepared geometry
+
+Interface types for prepared geometry: a GeoInterface-compatible wrapper that carries a
+tuple of immutable, eagerly built acceleration structures ("preparations"), retrieved by
+*capability* trait — algorithms only care that a geometry *has* an edge index, not how it
+was built. Design: `docs/plans/2026-07-01-prepared-geometry-design.md` (repo root).
+
+The consumption interface lives here in GeometryOpsCore so third-party packages can
+provide preparations without depending on GeometryOps. The `prepare` builder and the
+concrete preparations live in GeometryOps (extents are manifold-aware).
+=#
+
+export AbstractPreparation, AbstractPreparationTrait,
+    SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike,
+    preptrait, PreparationSpec, Prepared, getprep, prepare
+
+"""
+    AbstractPreparation
+
+Supertype of built, immutable acceleration structures attached to exactly one geometry via
+[`Prepared`](@ref). Concrete subtypes implement [`preptrait`](@ref).
+"""
+abstract type AbstractPreparation end
+
+"""
+    AbstractPreparationTrait
+
+Capability traits for preparations: what a preparation can answer, not what it is.
+Retrieval via `get(prepared, trait)` returns the first preparation with that capability.
+"""
+abstract type AbstractPreparationTrait end
+
+"Capability: an extent tree over child elements (rings of a polygon, polygons of a multi)."
+struct SpatialIndexLike <: AbstractPreparationTrait end
+"Capability: an extent tree over the segments/edges of a curve or geometry."
+struct SpatialEdgeIndexLike <: AbstractPreparationTrait end
+"Capability: a point-in-polygonal-area locator."
+struct PointInAreaLike <: AbstractPreparationTrait end
+
+"""
+    preptrait(prep::AbstractPreparation)::AbstractPreparationTrait
+
+The capability of `prep`. Every concrete preparation implements this.
+"""
+function preptrait end
+
+"""
+    PreparationSpec
+
+Supertype of the *configs* passed to [`prepare`](@ref)'s `preps` tuple. A spec declares
+which GeoInterface trait it attaches to via `appliesto(spec)` and how to build via
+`buildprep(spec, manifold, geom) -> Union{AbstractPreparation, Nothing}` (`nothing` means
+"nothing to index here", e.g. an empty geometry). Both are extended (not exported) via
+`import GeometryOpsCore: appliesto, buildprep`.
+"""
+abstract type PreparationSpec end
+
+function appliesto end
+function buildprep end
+
+"""
+    Prepared(geom, manifold::Manifold, preps::Tuple, extent::Extents.Extent)
+
+A geometry `geom` carrying preparations `preps`. Forwards GeoInterface, so it works
+anywhere a geometry does. `extent` is always cached (manifold-aware: 3D on `Spherical`).
+The wrapper and its preparation set are immutable; a miss on `get` means the caller takes
+its unindexed path. Children of a `Prepared` built by `prepare` are themselves `Prepared`.
+"""
+struct Prepared{T <: GI.AbstractTrait, M <: Manifold, G,
+                P <: Tuple{Vararg{AbstractPreparation}}, E <: Extents.Extent}
+    geom::G
+    manifold::M
+    preps::P
+    extent::E
+    function Prepared(geom::G, m::M, preps::P, extent::E) where
+            {M <: Manifold, G, P <: Tuple{Vararg{AbstractPreparation}}, E <: Extents.Extent}
+        t = GI.trait(geom)
+        t === nothing && throw(ArgumentError("`Prepared` requires a GeoInterface geometry; got $(typeof(geom))"))
+        new{typeof(t), M, G, P, E}(geom, m, preps, extent)
+    end
+end
+
+Base.parent(p::Prepared) = p.geom
+manifold(p::Prepared) = p.manifold
+
+"""
+    get(p::Prepared, t::AbstractPreparationTrait) -> Union{AbstractPreparation, Nothing}
+    get(geom, t::AbstractPreparationTrait) -> nothing
+
+The first preparation on `p` with capability `t`, or `nothing`. Plain geometries always
+return `nothing`, so call sites need no special-casing.
+"""
+Base.get(p::Prepared, t::AbstractPreparationTrait) = _findprep(t, p.preps)
+Base.get(@nospecialize(_), ::AbstractPreparationTrait) = nothing
+
+_findprep(::AbstractPreparationTrait, ::Tuple{}) = nothing
+_findprep(t::AbstractPreparationTrait, preps::Tuple) =
+    preptrait(first(preps)) === t ? first(preps) : _findprep(t, Base.tail(preps))
+
+"""
+    getprep(m::Manifold, geom, t::AbstractPreparationTrait) -> Union{AbstractPreparation, Nothing}
+
+Manifold-checked retrieval: like `get(geom, t)` but a manifold mismatch is a miss —
+preparations bake in manifold-specific state (kernel point types, 3D extents), so a
+`Planar` edge tree must never be served to a `Spherical` algorithm.
+"""
+getprep(m::Manifold, p::Prepared, t::AbstractPreparationTrait) =
+    manifold(p) === m ? get(p, t) : nothing
+getprep(::Manifold, @nospecialize(_), ::AbstractPreparationTrait) = nothing
+
+"""
+    prepare(...)
+
+Generic entry point for prepared-geometry optimizations. GeometryOps implements
+`prepare(geom; preps, manifold)` (the wrapper builder) and `prepare(alg, geom)` methods
+for algorithms (e.g. `RelateNG`).
+"""
+function prepare end
+```
+
+In `GeometryOpsCore/src/GeometryOpsCore.jl`, add the include directly after
+`include("types/manifold.jl")`:
+
+```julia
+include("types/manifold.jl")
+include("types/preparations.jl")
+```
+
+Wire the test file into `test/runtests.jl` next to the other `test/core/*.jl` entries,
+matching their exact style (look at how `core/manifold.jl` is wired and copy it), e.g.:
+
+```julia
+@safetestset "Core preparations" begin include("core/preparations.jl") end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project=test -e 'include("test/core/preparations.jl")'`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add GeometryOpsCore/src/types/preparations.jl GeometryOpsCore/src/GeometryOpsCore.jl test/core/preparations.jl test/runtests.jl
+git commit -m "Add preparation types and \`Prepared\` wrapper to GeometryOpsCore"
+```
+
+---
+
+### Task 2: GeoInterface forwarding for `Prepared`
+
+**Files:**
+- Modify: `GeometryOpsCore/src/types/preparations.jl` (append)
+- Modify: `test/core/preparations.jl` (append)
+
+**Step 1: Write the failing test**
+
+Append to `test/core/preparations.jl`:
+
+```julia
+@testset "GeoInterface forwarding" begin
+    ring = GI.LinearRing([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 0.0)])
+    rext = GI.extent(ring; fallback = true)
+    pring = Prepared(ring, Planar(), (_DummyEdgeTree(1),), rext)
+
+    @test GI.isgeometry(pring)
+    @test GI.trait(pring) isa GI.LinearRingTrait
+    @test GI.npoint(pring) == GI.npoint(ring)
+    @test collect(GI.getpoint(pring)) == collect(GI.getpoint(ring))
+    @test GI.coordinates(pring) == GI.coordinates(ring)
+    @test GI.is3d(pring) == false
+    @test GI.extent(pring) == rext          # served from the field
+    @test Extents.extent(pring) == rext
+
+    # a Prepared polygon whose ring is itself Prepared: GI hands back the prepared child
+    poly = GI.Polygon([pring])
+    pext = GI.extent(ring; fallback = true)
+    ppoly = Prepared(poly, Planar(), (), pext)
+    @test GI.trait(ppoly) isa GI.PolygonTrait
+    @test GI.nring(ppoly) == 1
+    @test GI.getring(ppoly, 1) === pring
+    @test GI.getexterior(ppoly) === pring
+    @test get(GI.getring(ppoly, 1), SpatialEdgeIndexLike()) isa _DummyEdgeTree
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/core/preparations.jl")'`
+Expected: FAIL — `MethodError` on `GI.npoint`/`GI.trait` etc. for `Prepared`.
+
+**Step 3: Write the implementation**
+
+Append to `GeometryOpsCore/src/types/preparations.jl` (adapted from the fixed forwarding
+on the `as/prepare` branch, `git show origin/as/prepare:src/preparations/prepared_geometry.jl`):
+
+```julia
+#-- GeoInterface forwarding: a Prepared IS-A geometry wherever GI is spoken.
+#-- The extent is served from the cached field, never recomputed.
+GI.isgeometry(::Type{<:Prepared{T, M, G}}) where {T, M, G} = GI.isgeometry(G)
+GI.trait(::Prepared{T}) where {T} = T()
+GI.geomtrait(::Prepared{T}) where {T} = T()
+
+Extents.extent(p::Prepared) = p.extent
+GI.extent(::GI.AbstractTrait, p::Prepared) = p.extent
+GI.crs(t::GI.AbstractTrait, p::Prepared) = GI.crs(t, parent(p))
+
+for f in (:coordnames, :is3d, :ismeasured, :isempty, :coordinates, :ngeom, :getgeom)
+    @eval GI.$f(t::GI.AbstractGeometryTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:npoint, :getpoint, :startpoint, :endpoint, :issimple, :isclosed, :isring)
+    @eval GI.$f(t::GI.AbstractCurveTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:nring, :getring, :getexterior, :nhole, :gethole, :npoint, :getpoint)
+    @eval GI.$f(t::GI.AbstractPolygonTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:nring, :getring, :npoint, :getpoint)
+    @eval GI.$f(t::GI.AbstractMultiPolygonTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+for f in (:npoint, :getpoint, :issimple)
+    @eval GI.$f(t::GI.AbstractMultiPointTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+    @eval GI.$f(t::GI.AbstractMultiCurveTrait, p::Prepared, args...) = GI.$f(t, parent(p), args...)
+end
+
+#-- disambiguation against GI's trait-specific defaults (e.g. npoint(::LineTrait) = 2)
+for T in (:LineTrait, :TriangleTrait, :PentagonTrait, :HexagonTrait, :RectangleTrait, :QuadTrait)
+    @eval GI.npoint(t::GI.$T, p::Prepared) = GI.npoint(t, parent(p))
+end
+for T in (:TriangleTrait, :RectangleTrait, :QuadTrait, :PentagonTrait, :HexagonTrait)
+    @eval GI.nring(t::GI.$T, p::Prepared) = GI.nring(t, parent(p))
+end
+```
+
+If the test surfaces a genuine method ambiguity the lists above don't cover, resolve it
+the same way (a specific `(concrete trait, Prepared)` method that forwards) — do not
+broaden signatures.
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project=test -e 'include("test/core/preparations.jl")'`
+Expected: PASS (both testsets).
+
+**Step 5: Commit**
+
+```bash
+git add GeometryOpsCore/src/types/preparations.jl test/core/preparations.jl
+git commit -m "Forward GeoInterface through \`Prepared\`"
+```
+
+---
+
+### Task 3: Surface the Core names in GeometryOps; `RelateNG.prepare` extends the Core generic
+
+**Files:**
+- Modify: `src/GeometryOps.jl` (the `import GeometryOpsCore:` block at lines ~5–19 and the
+  `export` line at line ~20)
+- Modify: `src/methods/geom_relations/relateng/relate_ng.jl:3` (export line comment only —
+  see below)
+
+**Step 1: Write the failing test**
+
+Create `test/prepared/prepared_geometry.jl`:
+
+```julia
+using Test
+import GeometryOps as GO
+import GeometryOps: Prepared, prepare, getprep,
+    SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike
+import GeometryOpsCore
+import GeoInterface as GI
+import GeoInterface: Extents
+
+@testset "prepare is one generic function" begin
+    # the algorithm method and the (future) geometry method share the Core binding
+    @test GO.prepare === GeometryOpsCore.prepare
+    poly = GI.Polygon([GI.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)])])
+    prep = GO.prepare(GO.RelateNG(), poly)
+    @test prep isa GO.PreparedRelate
+end
+```
+
+Wire into `test/runtests.jl` after the RelateNG entry (line ~34):
+
+```julia
+@safetestset "Prepared geometry" begin include("prepared/prepared_geometry.jl") end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — `GO.prepare === GeometryOpsCore.prepare` is `false` (relateng currently
+*defines* its own `prepare` function rather than extending Core's), or an import error for
+`Prepared` from GeometryOps.
+
+**Step 3: Write the implementation**
+
+In `src/GeometryOps.jl`:
+
+1. Add to the `import GeometryOpsCore:` list (after the `manifold, best_manifold,` line):
+
+```julia
+                AbstractPreparation, AbstractPreparationTrait,
+                SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike,
+                preptrait, PreparationSpec, Prepared, getprep, prepare,
+                appliesto, buildprep,
+```
+
+2. Extend the `export` line (line ~20) with the user-facing names:
+
+```julia
+export TraitTarget, Manifold, Planar, Spherical, Geodesic, apply, applyreduce, flatten, reconstruct, rebuild, unwrap, get_geometries
+export Prepared, prepare, getprep, preptrait, SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike
+```
+
+Because `prepare` is now *imported*, the existing `function prepare(alg::RelateNG, a)` at
+`relate_ng.jl:665` automatically becomes a method of `GeometryOpsCore.prepare` — no code
+change needed there. The `export relate, RelateNG, prepare` at `relate_ng.jl:3` stays (a
+duplicate export of the same binding is harmless).
+
+**Step 4: Run tests to verify they pass**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+Then confirm nothing in relateng broke (this exercises the whole prepared fixture sweep):
+
+Run: `julia --project=test -e 'include("test/methods/relateng/relate_ng.jl")'`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/GeometryOps.jl test/prepared/prepared_geometry.jl test/runtests.jl
+git commit -m "Re-export prepared-geometry interface from GeometryOps and unify \`prepare\`"
+```
+
+---
+
+### Task 4: The `prepare` builder (recursive wrapping, no specs yet)
+
+**Files:**
+- Create: `src/prepared/prepared.jl`
+- Modify: `src/GeometryOps.jl` (add `include("prepared/prepared.jl")` on the line directly
+  after `include("methods/geom_relations/relateng/relate_ng.jl")` — it uses relateng
+  kernel helpers)
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 0: Verify helper names**
+
+The builder uses relateng-internal helpers. Confirm they exist with these exact names
+before writing code; if a name differs, use the actual one:
+
+```bash
+grep -n "_to_kernel_point\|_kernel_point_type" src/methods/geom_relations/relateng/kernel*.jl | head
+grep -n "function rk_interaction_bounds\|rk_interaction_bounds(::\|rk_interaction_bounds(m" src/methods/geom_relations/relateng/kernel*.jl | head
+grep -n "_segment_extent_type\|_segment_extent(" src/methods/geom_relations/relateng/edge_intersector.jl
+```
+
+Expected: `_to_kernel_point(::Planar, p)` / `(::Spherical, p)` (or equivalent),
+`rk_interaction_bounds(m, geom)`, `_segment_extent(m, p, q)`, `_segment_extent_type(m)`.
+
+**Step 1: Write the failing test**
+
+Append to `test/prepared/prepared_geometry.jl`:
+
+```julia
+# shared fixtures for the remaining testsets
+const _PG_RING_OUTER = GI.LinearRing([(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)])
+const _PG_RING_HOLE  = GI.LinearRing([(4.0, 4.0), (6.0, 4.0), (6.0, 6.0), (4.0, 6.0), (4.0, 4.0)])
+const _PG_POLY  = GI.Polygon([_PG_RING_OUTER, _PG_RING_HOLE])
+const _PG_POLY2 = GI.Polygon([GI.LinearRing([(20.0, 0.0), (25.0, 0.0), (25.0, 5.0), (20.0, 0.0)])])
+const _PG_MP    = GI.MultiPolygon([_PG_POLY, _PG_POLY2])
+# mid-latitude spherical quad (lon/lat degrees)
+const _PG_SPH_POLY = GI.Polygon([GI.LinearRing([(10.0, 40.0), (20.0, 40.0), (20.0, 50.0), (10.0, 50.0), (10.0, 40.0)])])
+
+@testset "prepare: recursive wrapping, no specs" begin
+    p = prepare(_PG_POLY)
+    @test p isa Prepared
+    @test GI.trait(p) isa GI.PolygonTrait
+    @test GeometryOpsCore.manifold(p) === GO.Planar()
+    @test p.preps === ()
+
+    # children are themselves Prepared, with per-node extents
+    r1 = GI.getring(p, 1)
+    @test r1 isa Prepared && GI.trait(r1) isa GI.LinearRingTrait
+    @test GI.extent(r1) == GI.extent(_PG_RING_OUTER; fallback = true)
+    @test GI.extent(p) == GI.extent(_PG_POLY; fallback = true)
+
+    # geometry content is unchanged
+    @test GI.coordinates(p) == GI.coordinates(_PG_POLY)
+
+    # points pass through unwrapped
+    pt = GI.Point(1.0, 2.0)
+    @test prepare(pt) === pt
+
+    # multipolygon: every level wrapped
+    mp = prepare(_PG_MP)
+    @test mp isa Prepared && GI.getgeom(mp, 1) isa Prepared
+    @test GI.getring(GI.getgeom(mp, 1), 1) isa Prepared
+
+    # spherical: extents are 3D unit-sphere boxes
+    ps = prepare(_PG_SPH_POLY; manifold = GO.Spherical())
+    @test GI.extent(ps) isa Extents.Extent{(:X, :Y, :Z)}
+    @test GI.extent(GI.getring(ps, 1)) isa Extents.Extent{(:X, :Y, :Z)}
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — `MethodError: no method matching prepare(::GI.Polygon...)`.
+
+**Step 3: Write the implementation**
+
+Create `src/prepared/prepared.jl`:
+
+```julia
+#=
+# Prepared geometry: builder and v1 preparations
+
+`prepare(geom; preps, manifold)` rebuilds the GeoInterface tree once, bottom-up, wrapping
+each node in `GeometryOpsCore.Prepared` with a manifold-aware cached extent
+(`rk_interaction_bounds`), and attaching each spec's built preparation at the *highest*
+tree level whose trait matches `appliesto(spec)` (topmost-wins). Modeled on relateng's
+`_relate_cache_extents` (`relate_geometry.jl`), which it subsumes for `Prepared` inputs.
+
+Design: `docs/plans/2026-07-01-prepared-geometry-design.md`.
+=#
+
+export RingEdgeIndex, ChildTree, PointInArea
+
+"""
+    prepare(geom; preps::Tuple = (), manifold::Manifold = Planar())
+
+Wrap `geom` (and, recursively, its parts) in [`Prepared`](@ref), eagerly building the
+preparations requested in `preps` (a tuple of `PreparationSpec`s such as
+[`RingEdgeIndex`](@ref), [`ChildTree`](@ref), [`PointInArea`](@ref)).
+
+Every wrapped node caches its manifold-aware extent. A spec is consumed at the highest
+matching level of the tree. Preparations do not survive coordinate transformations —
+re-`prepare` after `apply`-style rebuilds.
+"""
+prepare(geom; preps::Tuple = (), manifold::Manifold = Planar()) =
+    _prepare(manifold, preps, GI.trait(geom), geom)
+
+#-- split the spec tuple: consumed at this node vs offered to children (topmost-wins)
+_specs_here(specs::Tuple, trait) = filter(s -> trait isa appliesto(s), specs)
+_specs_below(specs::Tuple, trait) = filter(s -> !(trait isa appliesto(s)), specs)
+
+#-- points and multipoints pass through: their extent is themselves
+_prepare(::Manifold, specs, ::Union{GI.AbstractPointTrait, GI.AbstractMultiPointTrait}, geom) = geom
+
+#-- curve leaves: the only level where coordinates are read
+function _prepare(m::Manifold, specs, trait::GI.AbstractCurveTrait, line)
+    GI.isempty(line) && return line
+    return _wrap(m, _specs_here(specs, trait), line, rk_interaction_bounds(m, line))
+end
+
+function _prepare(m::Manifold, specs, trait::GI.AbstractPolygonTrait, poly)
+    GI.isempty(poly) && return poly
+    below = _specs_below(specs, trait)
+    rings = [_prepare(m, below, GI.trait(r), r) for r in GI.getring(poly)]
+    rebuilt = GI.geointerface_geomtype(trait)(rings; crs = GI.crs(poly))
+    ext = _union_prepared_extents(m, rings)
+    ext === nothing && return rebuilt
+    return _wrap(m, _specs_here(specs, trait), rebuilt, ext)
+end
+
+#-- collections (covers Multi* types too)
+function _prepare(m::Manifold, specs, trait::GI.AbstractGeometryCollectionTrait, geom)
+    GI.isempty(geom) && return geom
+    below = _specs_below(specs, trait)
+    children = [_prepare(m, below, GI.trait(g), g) for g in GI.getgeom(geom)]
+    rebuilt = GI.geointerface_geomtype(trait)(children; crs = GI.crs(geom))
+    ext = _union_prepared_extents(m, children)
+    ext === nothing && return rebuilt
+    return _wrap(m, _specs_here(specs, trait), rebuilt, ext)
+end
+
+#-- unknown traits pass through untouched
+_prepare(::Manifold, specs, ::GI.AbstractTrait, geom) = geom
+
+function _wrap(m::Manifold, specs::Tuple, geom, ext)
+    return Prepared(geom, m, _build_preps(specs, m, geom), ext)
+end
+
+#-- build each consumed spec; a spec may decline (empty geometry) by returning `nothing`
+_build_preps(::Tuple{}, m, geom) = ()
+function _build_preps(specs::Tuple, m, geom)
+    p = buildprep(first(specs), m, geom)
+    rest = _build_preps(Base.tail(specs), m, geom)
+    return p === nothing ? rest : (p, rest...)
+end
+
+function _union_prepared_extents(m::Manifold, children)
+    ext = nothing
+    for c in children
+        ce = if c isa Prepared
+            c.extent
+        elseif GI.isempty(c)
+            nothing
+        else
+            rk_interaction_bounds(m, c)
+        end
+        ce === nothing && continue
+        ext = ext === nothing ? ce : Extents.union(ext, ce)
+    end
+    return ext
+end
+```
+
+Note: if `rk_interaction_bounds` has no method for bare point children inside collections,
+mirror whatever `_relate_extent` (`relate_geometry.jl:104-117`) does for atomic point
+elements instead of inventing a new path.
+
+Add the include to `src/GeometryOps.jl` directly after the relateng block:
+
+```julia
+include("methods/geom_relations/relateng/relate_ng.jl")
+include("prepared/prepared.jl")
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/prepared/prepared.jl src/GeometryOps.jl test/prepared/prepared_geometry.jl
+git commit -m "Add recursive \`prepare\` builder for prepared geometry"
+```
+
+---
+
+### Task 5: `RingEdgeIndex` — per-ring segment extent tree
+
+**Files:**
+- Modify: `src/prepared/prepared.jl` (append)
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 1: Write the failing test**
+
+```julia
+@testset "RingEdgeIndex" begin
+    p = prepare(_PG_POLY; preps = (GO.RingEdgeIndex(),))
+    @test p.preps === ()                       # consumed at ring level, not polygon level
+    ring = GI.getring(p, 1)
+    prep = get(ring, SpatialEdgeIndexLike())
+    @test prep isa GO.SpatialEdgeIndex
+    tree = prep.tree
+    @test tree isa GO.NaturalIndexing.NaturalIndex
+
+    # the tree indexes segments in ring order: query a box covering only segment 1
+    # (outer ring segment 1 runs (0,0)->(10,0))
+    hits = GO.SpatialTreeInterface.query(tree, Extents.Extent(X = (4.0, 5.0), Y = (-0.1, 0.1)))
+    @test hits == [1]
+
+    # spherical: builds 3D arc-extent trees without error
+    ps = prepare(_PG_SPH_POLY; manifold = GO.Spherical(), preps = (GO.RingEdgeIndex(),))
+    sprep = get(GI.getring(ps, 1), SpatialEdgeIndexLike())
+    @test sprep isa GO.SpatialEdgeIndex
+    @test GO.SpatialTreeInterface.node_extent(sprep.tree) isa Extents.Extent{(:X, :Y, :Z)}
+
+    # manifold-checked retrieval
+    @test getprep(GO.Planar(), GI.getring(p, 1), SpatialEdgeIndexLike()) === prep
+    @test getprep(GO.Spherical(), GI.getring(p, 1), SpatialEdgeIndexLike()) === nothing
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — `UndefVarError: RingEdgeIndex`.
+
+**Step 3: Write the implementation**
+
+Append to `src/prepared/prepared.jl`:
+
+```julia
+"""
+    SpatialEdgeIndex(tree)
+
+Built preparation: an extent tree (anything implementing SpatialTreeInterface) over the
+segments of the wrapped curve, in traversal order. Capability: `SpatialEdgeIndexLike`.
+"""
+struct SpatialEdgeIndex{T} <: AbstractPreparation
+    tree::T
+end
+preptrait(::SpatialEdgeIndex) = SpatialEdgeIndexLike()
+
+"""
+    RingEdgeIndex(; nodecapacity = 16)
+
+Spec: build a `NaturalIndex` over each linear ring's segment extents (manifold-aware:
+3D arc extents on `Spherical`). Replaces the `NaturallyIndexedRing` experiment.
+"""
+struct RingEdgeIndex <: PreparationSpec
+    nodecapacity::Int
+end
+RingEdgeIndex(; nodecapacity::Integer = 16) = RingEdgeIndex(Int(nodecapacity))
+appliesto(::RingEdgeIndex) = GI.LinearRingTrait
+
+function buildprep(spec::RingEdgeIndex, m::Manifold, ring)
+    exts = _curve_segment_extents(m, ring)
+    isempty(exts) && return nothing
+    return SpatialEdgeIndex(NaturalIndex(exts; nodecapacity = spec.nodecapacity))
+end
+
+function _curve_segment_extents(m::Manifold, curve)
+    exts = _segment_extent_type(m)[]
+    n = GI.npoint(curve)
+    n < 2 && return exts
+    sizehint!(exts, n - 1)
+    prev = _to_kernel_point(m, GI.getpoint(curve, 1))
+    for i in 2:n
+        cur = _to_kernel_point(m, GI.getpoint(curve, i))
+        push!(exts, _segment_extent(m, prev, cur))
+        prev = cur
+    end
+    return exts
+end
+```
+
+(Use the actual helper names confirmed in Task 4 Step 0.)
+
+Also export the built-prep types: change the export line at the top of
+`src/prepared/prepared.jl` to:
+
+```julia
+export RingEdgeIndex, ChildTree, PointInArea
+export SpatialEdgeIndex, SpatialIndex, PointInAreaIndex
+```
+
+(`ChildTree`/`SpatialIndex`/`PointInArea`/`PointInAreaIndex` come in Tasks 6–7; exporting
+ahead is fine since the names will exist by the time the module loads — if you prefer,
+add each name in its own task.)
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/prepared/prepared.jl test/prepared/prepared_geometry.jl
+git commit -m "Add \`RingEdgeIndex\` preparation"
+```
+
+---
+
+### Task 6: `ChildTree` — extent tree over child elements
+
+**Files:**
+- Modify: `src/prepared/prepared.jl` (append)
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 1: Write the failing test**
+
+```julia
+@testset "ChildTree" begin
+    # on a multipolygon: consumed at the MP node (topmost-wins), indexing polygon extents
+    mp = prepare(_PG_MP; preps = (GO.ChildTree(),))
+    prep = get(mp, SpatialIndexLike())
+    @test prep isa GO.SpatialIndex
+    # polygon 2 lives at x in (20, 25): a query box there hits only child 2
+    @test GO.SpatialTreeInterface.query(prep.tree, Extents.Extent(X = (21.0, 22.0), Y = (0.0, 1.0))) == [2]
+    # children did not also get trees
+    @test get(GI.getgeom(mp, 1), SpatialIndexLike()) === nothing
+
+    # on a bare polygon: indexes ring extents
+    p = prepare(_PG_POLY; preps = (GO.ChildTree(),))
+    rprep = get(p, SpatialIndexLike())
+    @test rprep isa GO.SpatialIndex
+    # the hole (ring 2) occupies (4..6, 4..6)
+    @test GO.SpatialTreeInterface.query(rprep.tree, Extents.Extent(X = (4.5, 5.5), Y = (4.5, 5.5))) == [1, 2]
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — `UndefVarError: ChildTree`.
+
+**Step 3: Write the implementation**
+
+Append to `src/prepared/prepared.jl`:
+
+```julia
+"""
+    SpatialIndex(tree)
+
+Built preparation: an extent tree over the wrapped geometry's *child elements* (rings of a
+polygon, polygons of a multipolygon, members of a collection), in child order.
+Capability: `SpatialIndexLike`.
+"""
+struct SpatialIndex{T} <: AbstractPreparation
+    tree::T
+end
+preptrait(::SpatialIndex) = SpatialIndexLike()
+
+"""
+    ChildTree(; nodecapacity = 32)
+
+Spec: build a `NaturalIndex` over child-element extents. Attaches (topmost-wins) to
+polygons, multi-geometries, and geometry collections.
+"""
+struct ChildTree <: PreparationSpec
+    nodecapacity::Int
+end
+ChildTree(; nodecapacity::Integer = 32) = ChildTree(Int(nodecapacity))
+appliesto(::ChildTree) = Union{GI.PolygonTrait, GI.AbstractMultiPolygonTrait,
+    GI.AbstractMultiCurveTrait, GI.GeometryCollectionTrait}
+
+function buildprep(spec::ChildTree, m::Manifold, geom)
+    exts = _segment_extent_type(m)[]
+    for c in GI.getgeom(geom)
+        GI.isempty(c) && continue
+        push!(exts, c isa Prepared ? c.extent : rk_interaction_bounds(m, c))
+    end
+    isempty(exts) && return nothing
+    return SpatialIndex(NaturalIndex(exts; nodecapacity = spec.nodecapacity))
+end
+```
+
+(Note: `_segment_extent_type(m)` doubles as "the manifold's extent type" — segment and
+interaction bounds share it. If empty children make child indices ambiguous for a caller,
+that caller filters; v1 keeps build simple and skips empties.)
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/prepared/prepared.jl test/prepared/prepared_geometry.jl
+git commit -m "Add \`ChildTree\` preparation"
+```
+
+---
+
+### Task 7: `PointInArea` — planar point-in-polygonal-area locator
+
+**Files:**
+- Modify: `src/prepared/prepared.jl` (append)
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 1: Write the failing test**
+
+```julia
+@testset "PointInArea" begin
+    p = prepare(_PG_POLY; preps = (GO.PointInArea(),))
+    prep = get(p, PointInAreaLike())
+    @test prep isa GO.PointInAreaIndex
+    # ground truth against the unindexed locator: interior, hole, boundary, exterior
+    @test GO.locate(prep.locator, (1.0, 1.0)) == GO.LOC_INTERIOR
+    @test GO.locate(prep.locator, (5.0, 5.0)) == GO.LOC_EXTERIOR   # inside the hole
+    @test GO.locate(prep.locator, (5.0, 0.0)) == GO.LOC_BOUNDARY
+    @test GO.locate(prep.locator, (11.0, 5.0)) == GO.LOC_EXTERIOR
+
+    # multipolygon input: consumed at the MP node (relateng's element granularity)
+    mp = prepare(_PG_MP; preps = (GO.PointInArea(),))
+    @test get(mp, PointInAreaLike()) isa GO.PointInAreaIndex
+    @test get(GI.getgeom(mp, 1), PointInAreaLike()) === nothing
+
+    # spherical: a clear, early error (Task 16 of the spherical plan was skipped)
+    @test_throws ArgumentError prepare(_PG_SPH_POLY;
+        manifold = GO.Spherical(), preps = (GO.PointInArea(),))
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — `UndefVarError: PointInArea`.
+
+**Step 3: Write the implementation**
+
+Append to `src/prepared/prepared.jl`:
+
+```julia
+"""
+    PointInAreaIndex(locator)
+
+Built preparation: an `IndexedPointInAreaLocator` (sorted leaves) over the wrapped
+polygonal geometry. Capability: `PointInAreaLike`. `Planar` only.
+"""
+struct PointInAreaIndex{L} <: AbstractPreparation
+    locator::L
+end
+preptrait(::PointInAreaIndex) = PointInAreaLike()
+
+"""
+    PointInArea(; exact = True())
+
+Spec: build an indexed point-in-area locator for a polygon or multipolygon. `Planar` only —
+the spherical point-in-area index is deliberately unimplemented (relateng falls back to an
+O(n) `rk_point_in_ring` walk on `Spherical`).
+"""
+struct PointInArea{E} <: PreparationSpec
+    exact::E
+end
+PointInArea(; exact = True()) = PointInArea(exact)
+appliesto(::PointInArea) = Union{GI.PolygonTrait, GI.MultiPolygonTrait}
+
+buildprep(spec::PointInArea, m::Planar, geom) =
+    PointInAreaIndex(IndexedPointInAreaLocator(m, geom; exact = spec.exact, sort_leaves = true))
+buildprep(::PointInArea, m::Manifold, _) =
+    throw(ArgumentError("`PointInArea` requires the `Planar` manifold; got `$(typeof(m))`. \
+        The spherical point-in-area index is not implemented — spherical algorithms use an \
+        O(n) ring walk instead, so simply omit this spec."))
+```
+
+If `GO.locate`/`GO.LOC_INTERIOR` etc. are named differently, check
+`src/methods/geom_relations/relateng/indexed_point_in_area.jl:307-316` and
+`point_locator.jl` for the actual names (`locate`, `LOC_INTERIOR`, `LOC_BOUNDARY`,
+`LOC_EXTERIOR` are the expected ones) and use those in the test.
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/prepared/prepared.jl test/prepared/prepared_geometry.jl
+git commit -m "Add \`PointInArea\` preparation"
+```
+
+---
+
+### Task 8: RelateNG seam 1 — trust `Prepared` extents
+
+**Files:**
+- Modify: `src/methods/geom_relations/relateng/relate_geometry.jl:136` (the 1-arg
+  `_relate_cache_extents` dispatcher)
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 1: Write the failing test**
+
+```julia
+@testset "relateng seam: Prepared extents are trusted" begin
+    m = GO.Planar()
+    pp = prepare(_PG_POLY; preps = (GO.RingEdgeIndex(),))
+    rg = GO.RelateGeometry(m, pp; exact = GO.True())
+    # matched manifold: the Prepared tree is used as-is (no rewrap)
+    @test rg.geom === pp
+
+    # mismatched manifold: falls back to the rewrap path (correctness over reuse)
+    ps = prepare(_PG_SPH_POLY)   # Planar-prepared (2D extents)
+    rgs = GO.RelateGeometry(GO.Spherical(), ps; exact = GO.True())
+    @test rgs.geom !== ps
+    @test GI.extent(rgs.geom) isa Extents.Extent{(:X, :Y, :Z)}
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — `rg.geom === pp` is false (relateng rewraps the Prepared tree today).
+
+**Step 3: Write the implementation**
+
+In `relate_geometry.jl`, replace the 1-arg dispatcher
+
+```julia
+_relate_cache_extents(m::Manifold, geom) = _relate_cache_extents(m, GI.trait(geom), geom)
+```
+
+with
+
+```julia
+#-- a Prepared input built on the same manifold already carries exactly the extents this
+#-- rebuild would compute (rk_interaction_bounds at every level) — use it as-is. A
+#-- mismatched manifold falls through to the rewrap: wrong-manifold extents must not leak.
+function _relate_cache_extents(m::Manifold, geom)
+    geom isa Prepared && GeometryOpsCore.manifold(geom) === m && return geom
+    return _relate_cache_extents(m, GI.trait(geom), geom)
+end
+```
+
+Do NOT extend `_has_stored_extent` — for mismatched manifolds the trait-dispatched rewrap
+must treat `Prepared` nodes as *not* having usable stored extents, which the existing
+`WrapperGeometry`-only check already guarantees.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+Run: `julia --project=test -e 'include("test/methods/relateng/relate_geometry.jl")'`
+Expected: PASS (no regression in the extent-cache tests).
+
+**Step 5: Commit**
+
+```bash
+git add src/methods/geom_relations/relateng/relate_geometry.jl test/prepared/prepared_geometry.jl
+git commit -m "Trust matched-manifold \`Prepared\` extents in relateng"
+```
+
+---
+
+### Task 9: RelateNG seam 2 — reuse `PointInAreaLike` in the point locator
+
+**Files:**
+- Modify: `src/methods/geom_relations/relateng/point_locator.jl` (the
+  `locate_on_polygonal` / `_get_poly_locator` region, lines ~522–556)
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 1: Write the failing test**
+
+```julia
+@testset "relateng seam: PointInArea reuse" begin
+    m = GO.Planar()
+    pp = prepare(_PG_POLY; preps = (GO.PointInArea(),))
+    prep = get(pp, PointInAreaLike())
+
+    # unprepared locator over a Prepared element uses the preparation immediately
+    loc = GO.RelatePointLocator(m, pp; exact = GO.True())
+    @test GO.locate(loc, (1.0, 1.0)) == GO.LOC_INTERIOR   # forces the polygonal path
+    @test loc.poly_locator[1] === prep.locator             # identity: reused, not rebuilt
+
+    # and in prepared mode too
+    ploc = GO.RelatePointLocator(m, pp; exact = GO.True(), is_prepared = true)
+    GO.locate(ploc, (1.0, 1.0))
+    @test ploc.poly_locator[1] === prep.locator
+end
+```
+
+If `locate(loc::RelatePointLocator, p)` is not the public entry (check
+`point_locator.jl` for the actual query function relateng calls — e.g.
+`locate_with_dim` or similar), call whatever function routes through
+`locate_on_polygonal`, or call `GO.locate_on_polygonal(loc, (1.0,1.0), false, nothing, 1)`
+directly with its real signature.
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: FAIL — identity test fails (a fresh `IndexedPointInAreaLocator` is built), or in
+the unprepared case the direct ring walk is used for the first 8 queries so
+`poly_locator[1] === nothing`.
+
+**Step 3: Write the implementation**
+
+In `point_locator.jl`, modify the planar branch of `locate_on_polygonal` (lines ~528–536)
+so a preparation counts as "use the index now":
+
+```julia
+    if loc.m isa Planar
+        use_index = loc.is_prepared ||
+            getprep(loc.m, polygonal, PointInAreaLike()) !== nothing
+        if !use_index
+            count = (loc.poly_query_count[index] += Int32(1))
+            use_index = count > _LAZY_INDEX_QUERY_THRESHOLD
+        end
+        if use_index
+            return locate(_get_poly_locator(loc, index), p)
+        end
+    end
+```
+
+and modify `_get_poly_locator` (lines ~548–556) to reuse the prepared locator when its
+manifold and `exact` types match the locator slot:
+
+```julia
+function _get_poly_locator(loc::RelatePointLocator, index::Int)
+    locator = loc.poly_locator[index]
+    if locator === nothing
+        polygonal = loc.polygons[index]
+        prep = getprep(loc.m, polygonal, PointInAreaLike())
+        locator = if prep isa PointInAreaIndex &&
+                prep.locator isa IndexedPointInAreaLocator{typeof(loc.m), typeof(loc.exact)}
+            prep.locator
+        else
+            IndexedPointInAreaLocator(loc.m, polygonal;
+                exact = loc.exact, sort_leaves = loc.is_prepared)
+        end
+        loc.poly_locator[index] = locator
+    end
+    return locator
+end
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS.
+
+Run: `julia --project=test -e 'include("test/methods/relateng/point_locator.jl")'`
+Expected: PASS (no regression).
+
+**Step 5: Commit**
+
+```bash
+git add src/methods/geom_relations/relateng/point_locator.jl test/prepared/prepared_geometry.jl
+git commit -m "Reuse \`PointInAreaLike\` preparations in the relate point locator"
+```
+
+---
+
+### Task 10: End-to-end equality — `relate` over `Prepared` inputs
+
+**Files:**
+- Modify: `test/prepared/prepared_geometry.jl` (append)
+
+**Step 1: Write the test (expected to pass — this is the safety net, watch it actually run)**
+
+```julia
+@testset "relate: plain == Prepared, planar & spherical" begin
+    line = GI.LineString([(-1.0, -1.0), (5.0, 5.0), (12.0, 5.0)])
+    pt   = GI.Point(5.0, 1.0)
+    pairs = [
+        (_PG_POLY, _PG_POLY2),   # disjoint
+        (_PG_POLY, GI.Polygon([GI.LinearRing([(5.0, 5.0), (15.0, 5.0), (15.0, 15.0), (5.0, 5.0)])])), # overlap
+        (_PG_POLY, line),
+        (_PG_POLY, pt),
+        (_PG_MP, _PG_POLY),
+    ]
+    alg = GO.RelateNG()
+    for (a, b) in pairs
+        expected = string(GO.relate(alg, a, b))
+        pa = prepare(a; preps = (GO.RingEdgeIndex(), GO.ChildTree(), GO.PointInArea()))
+        # plain path with a Prepared input
+        @test string(GO.relate(alg, pa, b)) == expected
+        # algorithm-prepared path on top of a Prepared input
+        pr = GO.prepare(alg, pa)
+        @test string(GO.relate(pr, b)) == expected
+        # B side Prepared as well
+        @test string(GO.relate(alg, pa, prepare(b; preps = (GO.RingEdgeIndex(),)))) == expected
+    end
+
+    # spherical (no PointInArea on the sphere)
+    salg = GO.RelateNG(; manifold = GO.Spherical())
+    sb = GI.Polygon([GI.LinearRing([(15.0, 45.0), (25.0, 45.0), (25.0, 55.0), (15.0, 55.0), (15.0, 45.0)])])
+    sexpected = string(GO.relate(salg, _PG_SPH_POLY, sb))
+    spa = prepare(_PG_SPH_POLY; manifold = GO.Spherical(), preps = (GO.RingEdgeIndex(),))
+    @test string(GO.relate(salg, spa, sb)) == sexpected
+    @test string(GO.relate(GO.prepare(salg, spa), sb)) == sexpected
+end
+```
+
+**Step 2: Run the test**
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS. If any pair disagrees, STOP and debug with
+superpowers:systematic-debugging — an equality failure here means a seam changed
+semantics, which is never acceptable; do not "fix" the test.
+
+**Step 3: Run the relateng sweeps to confirm no regression**
+
+Run: `julia --project=test -e 'include("test/methods/relateng/relate_ng.jl")'`
+Expected: PASS.
+Run: `julia --project=test -e 'include("test/methods/relateng/spherical_end_to_end.jl")'`
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add test/prepared/prepared_geometry.jl
+git commit -m "Test \`relate\` equality over \`Prepared\` inputs"
+```
+
+---
+
+### Task 11: Delete the `NaturallyIndexedRing` experiment
+
+It has zero call sites outside its own file (verified by grep during planning) and its
+docstring says it exists only to prototype what `Prepared` now provides.
+
+**Files:**
+- Modify: `src/utils/NaturalIndexing.jl`
+
+**Step 1: Delete**
+
+In `src/utils/NaturalIndexing.jl`:
+1. Delete the `NaturallyIndexedRing` struct, its constructors, its GI methods, and
+   `prepare_naturally` (the block at lines ~199–243, from the section comment above the
+   struct through end of file — read the file first to get the exact block).
+2. Change the export line (line ~10) from
+   `export NaturalIndex, NaturallyIndexedRing, prepare_naturally` to
+   `export NaturalIndex`.
+3. Delete the module-header line
+   `import ..GeometryOps as GO # TODO: only needed for NaturallyIndexedRing, remove when that is removed.`
+   (line ~8) — that TODO is now done.
+
+**Step 2: Verify**
+
+```bash
+grep -rn "NaturallyIndexedRing\|prepare_naturally" src/ test/ ext/ 2>/dev/null
+```
+Expected: no output.
+
+Run: `julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'`
+Expected: PASS (package still loads; `RingEdgeIndex` is the replacement).
+
+**Step 3: Commit**
+
+```bash
+git add src/utils/NaturalIndexing.jl
+git commit -m "Remove \`NaturallyIndexedRing\` in favor of \`RingEdgeIndex\` preparation"
+```
+
+---
+
+### Task 12: Versions, design-doc amendments
+
+**Files:**
+- Modify: `GeometryOpsCore/Project.toml` (`version = "0.1.10"` → `"0.1.11"`)
+- Modify: `Project.toml` (GO `version = "0.1.40"` → `"0.1.41"`; compat
+  `GeometryOpsCore = "=0.1.10"` → `"=0.1.11"`)
+- Modify: `docs/plans/2026-07-01-prepared-geometry-design.md`
+
+**Step 1: Bump versions** as above.
+
+**Step 2: Amend the design doc.** Update the status line to
+`**Status: ACCEPTED — implemented on branch \`prepared-geometry\`; deviations below.**`
+and append this section verbatim:
+
+```markdown
+## Amendments (discovered during implementation, 2026-07-01)
+
+- **`SegmentIndex` dropped from v1.** A flattened whole-geometry edge tree carries an
+  `owners` table whose indices are only meaningful relative to relateng's
+  `extract_segment_strings` traversal order; building it independently risks silent
+  owner mismatches. RelateNG keeps building its own `PreparedEdgeIndex` inside
+  `prepare(::RelateNG, a)`. Revisit when a second consumer needs flat segment trees.
+- **Clipping `AutoAccelerator` seam deferred** for the same reason (clipping indexes
+  flattened edge tables, not child extents).
+- **`tuples` keyword deferred** — compose as `prepare(GO.tuples(geom); ...)`.
+- **`build` is spelled `buildprep`**; `appliesto`/`buildprep` are unexported (providers
+  extend via `import GeometryOpsCore: appliesto, buildprep`).
+- **Topmost-wins attachment:** a spec is consumed at the highest matching level and not
+  offered further down (so `ChildTree` on a MultiPolygon indexes polygons at the top
+  node only). Multi-level trees = call `prepare` with the spec on the sub-geometry.
+- **Mismatched-manifold `Prepared` inputs to relateng** take the ordinary rewrap path
+  (correct extents rebuilt; preparations shadowed) rather than erroring.
+```
+
+**Step 3: Verify the workspace still resolves**
+
+Run: `julia --project=test -e 'import Pkg; Pkg.resolve(); using GeometryOps'`
+Expected: resolves and loads without error.
+
+**Step 4: Commit**
+
+```bash
+git add GeometryOpsCore/Project.toml Project.toml docs/plans/2026-07-01-prepared-geometry-design.md
+git commit -m "Bump GeometryOpsCore to 0.1.11 and record prepared-geometry design amendments"
+```
+
+---
+
+### Task 13: Final verification sweep
+
+**Step 1: Run the targeted suites** (each from repo root; a few minutes total):
+
+```bash
+julia --project=test -e 'include("test/core/preparations.jl")'
+julia --project=test -e 'include("test/prepared/prepared_geometry.jl")'
+julia --project=test -e 'include("test/methods/relateng/relate_ng.jl")'
+julia --project=test -e 'include("test/methods/relateng/relate_geometry.jl")'
+julia --project=test -e 'include("test/methods/relateng/point_locator.jl")'
+julia --project=test -e 'include("test/methods/relateng/kernel_conformance.jl")'
+julia --project=test -e 'include("test/methods/relateng/spherical_end_to_end.jl")'
+```
+
+Expected: all PASS. (`kernel_conformance.jl` is ~77k assertions; it runs in seconds once
+precompiled.)
+
+**Step 2: Kick off the slow differential suite in the background** (final gate, ~25 min —
+do not block on it interactively):
+
+```bash
+julia --project=test -e 'include("test/methods/relateng/xml_suite.jl")'
+```
+
+Run it as a background task and check the result when it finishes. Expected: PASS.
+
+**Step 3:** Use superpowers:verification-before-completion, then report done with the
+evidence (test counts), and hand off per superpowers:finishing-a-development-branch.

--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -7,6 +7,10 @@ import GeometryOpsCore:
                 TraitTarget,
                 Manifold, Planar, Spherical, Geodesic, AutoManifold, WrongManifoldException,
                 manifold, best_manifold,
+                AbstractPreparation, AbstractPreparationTrait,
+                SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike,
+                preptrait, PreparationSpec, Prepared, getprep, prepare,
+                appliesto, buildprep,
                 Algorithm, AutoAlgorithm, ManifoldIndependentAlgorithm, SingleManifoldAlgorithm, NoAlgorithm,
                 BoolsAsTypes, True, False, booltype, istrue,
                 TaskFunctors,
@@ -17,7 +21,8 @@ import GeometryOpsCore:
                 get_geometries,
                 APPLY_KEYWORDS, THREADED_KEYWORD, CRS_KEYWORD, CALC_EXTENT_KEYWORD
 
-export TraitTarget, Manifold, Planar, Spherical, Geodesic, apply, applyreduce, flatten, reconstruct, rebuild, unwrap, get_geometries 
+export TraitTarget, Manifold, Planar, Spherical, Geodesic, apply, applyreduce, flatten, reconstruct, rebuild, unwrap, get_geometries
+export Prepared, prepare, getprep, preptrait, SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike
 
 using GeoInterface
 using LinearAlgebra, Statistics, Random

--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -125,6 +125,8 @@ include("methods/geom_relations/relateng/topology_computer.jl")
 include("methods/geom_relations/relateng/edge_intersector.jl")
 # The RelateNG engine: drives all of the above through the phased evaluation.
 include("methods/geom_relations/relateng/relate_ng.jl")
+# Prepared-geometry builder: after relateng (uses the kernel's `rk_interaction_bounds`).
+include("prepared/prepared.jl")
 include("methods/orientation.jl")
 include("methods/polygonize.jl")
 include("methods/minimum_bounding_circle.jl")

--- a/src/methods/geom_relations/relateng/point_locator.jl
+++ b/src/methods/geom_relations/relateng/point_locator.jl
@@ -528,7 +528,10 @@ function locate_on_polygonal(loc::RelatePointLocator, p, is_node::Bool, parent_p
     #-- logic (as is all of JTS), so a future non-planar kernel falls
     #-- through to its own rk_point_in_ring even when prepared
     if loc.m isa Planar
-        use_index = loc.is_prepared
+        #-- a matched-manifold PointInArea preparation on this element is a prebuilt
+        #-- indexed locator: skip the lazy ring-walk warmup and index from the first query
+        use_index = loc.is_prepared ||
+            getprep(loc.m, polygonal, PointInAreaLike()) !== nothing
         if !use_index
             count = (loc.poly_query_count[index] += Int32(1))
             use_index = count > _LAZY_INDEX_QUERY_THRESHOLD
@@ -548,8 +551,17 @@ end
 function _get_poly_locator(loc::RelatePointLocator, index::Int)
     locator = loc.poly_locator[index]
     if locator === nothing
-        locator = IndexedPointInAreaLocator(loc.m, loc.polygons[index];
-            exact = loc.exact, sort_leaves = loc.is_prepared)
+        polygonal = loc.polygons[index]
+        #-- reuse a matched-manifold PointInArea preparation whose locator matches this
+        #-- locator's manifold and `exact` types exactly; otherwise build fresh as before
+        prep = getprep(loc.m, polygonal, PointInAreaLike())
+        locator = if prep isa PointInAreaIndex &&
+                prep.locator isa IndexedPointInAreaLocator{typeof(loc.m), typeof(loc.exact)}
+            prep.locator
+        else
+            IndexedPointInAreaLocator(loc.m, polygonal;
+                exact = loc.exact, sort_leaves = loc.is_prepared)
+        end
         loc.poly_locator[index] = locator
     end
     return locator

--- a/src/methods/geom_relations/relateng/point_locator.jl
+++ b/src/methods/geom_relations/relateng/point_locator.jl
@@ -260,7 +260,10 @@ mutable struct RelatePointLocator{M <: Manifold, E, G, BR <: BoundaryNodeRule, P
     # per-polygonal-element indexed locators, created lazily by
     # `_get_poly_locator` (Java: polyLocator, filled by getLocator).
     # Prepared mode fills an entry on its first query; unprepared mode on
-    # its second (see `locate_on_polygonal`).
+    # its second — but with the prepared-geometry seam an element carrying a
+    # matched `PointInAreaLike` preparation fills its slot on the FIRST query
+    # in either mode (the prep's locator is reused, not rebuilt; see
+    # `locate_on_polygonal`).
     const poly_locator::Vector{Union{Nothing, IndexedPointInAreaLocator{M, E}}}
     # unprepared mode: queries seen per polygonal element, driving the lazy
     # index heuristic above

--- a/src/methods/geom_relations/relateng/point_locator.jl
+++ b/src/methods/geom_relations/relateng/point_locator.jl
@@ -259,11 +259,12 @@ mutable struct RelatePointLocator{M <: Manifold, E, G, BR <: BoundaryNodeRule, P
     const is_empty::Bool
     # per-polygonal-element indexed locators, created lazily by
     # `_get_poly_locator` (Java: polyLocator, filled by getLocator).
-    # Prepared mode fills an entry on its first query; unprepared mode on
-    # its second — but with the prepared-geometry seam an element carrying a
-    # matched `PointInAreaLike` preparation fills its slot on the FIRST query
-    # in either mode (the prep's locator is reused, not rebuilt; see
-    # `locate_on_polygonal`).
+    # Prepared mode fills an entry on its first query; unprepared mode after
+    # 8 warm-up queries (`_LAZY_INDEX_QUERY_THRESHOLD`) — but with the
+    # prepared-geometry seam an element carrying a matched `PointInAreaLike`
+    # preparation fills its slot on the FIRST query in either mode (reused
+    # when the prep's `exact` type also matches; otherwise a fresh locator is
+    # built; see `locate_on_polygonal`).
     const poly_locator::Vector{Union{Nothing, IndexedPointInAreaLocator{M, E}}}
     # unprepared mode: queries seen per polygonal element, driving the lazy
     # index heuristic above

--- a/src/methods/geom_relations/relateng/relate_geometry.jl
+++ b/src/methods/geom_relations/relateng/relate_geometry.jl
@@ -133,7 +133,13 @@ _has_stored_extent(geom) =
     geom isa GI.Wrappers.WrapperGeometry && hasproperty(geom, :extent) &&
     geom.extent isa Extents.Extent
 
-_relate_cache_extents(m::Manifold, geom) = _relate_cache_extents(m, GI.trait(geom), geom)
+#-- a Prepared input built on the same manifold already carries exactly the extents this
+#-- rebuild would compute (rk_interaction_bounds at every level) — use it as-is. A
+#-- mismatched manifold falls through to the rewrap: wrong-manifold extents must not leak.
+function _relate_cache_extents(m::Manifold, geom)
+    geom isa Prepared && GeometryOpsCore.manifold(geom) === m && return geom
+    return _relate_cache_extents(m, GI.trait(geom), geom)
+end
 
 #-- point elements: their extent is themselves, nothing to cache
 _relate_cache_extents(::Manifold, ::Union{GI.AbstractPointTrait, GI.AbstractMultiPointTrait}, geom) = geom

--- a/src/methods/geom_relations/relateng/relate_geometry.jl
+++ b/src/methods/geom_relations/relateng/relate_geometry.jl
@@ -134,10 +134,14 @@ _has_stored_extent(geom) =
     geom.extent isa Extents.Extent
 
 #-- a Prepared input built on the same manifold already carries exactly the extents this
-#-- rebuild would compute (rk_interaction_bounds at every level) — use it as-is. A
-#-- mismatched manifold falls through to the rewrap: wrong-manifold extents must not leak.
+#-- rebuild would compute (rk_interaction_bounds at every level) — use it as-is. On a
+#-- manifold mismatch the wrapper is STRIPPED and the tree rebuilt from coordinates:
+#-- cached wrong-manifold extents must never reach the planar GI.extent fast path.
 function _relate_cache_extents(m::Manifold, geom)
-    geom isa Prepared && GeometryOpsCore.manifold(geom) === m && return geom
+    if geom isa Prepared
+        GeometryOpsCore.manifold(geom) === m && return geom
+        geom = Base.parent(geom)   #-- children are stripped by the recursion below
+    end
     return _relate_cache_extents(m, GI.trait(geom), geom)
 end
 
@@ -156,7 +160,7 @@ function _relate_cache_extents(m::Manifold, trait::GI.AbstractPolygonTrait, poly
     if _has_stored_extent(poly) && all(r -> GI.isempty(r) || _has_stored_extent(r), GI.getring(poly))
         return poly
     end
-    rings = [_relate_cache_extents(m, GI.trait(r), r) for r in GI.getring(poly)]
+    rings = [_relate_cache_extents(m, r) for r in GI.getring(poly)]
     ext = _union_stored_extents(rings)
     ext === nothing && return poly
     return GI.geointerface_geomtype(trait)(rings; extent = ext, crs = GI.crs(poly))
@@ -164,7 +168,7 @@ end
 
 #-- collections (covers Multi* types too): recurse, union the child extents
 function _relate_cache_extents(m::Manifold, trait::GI.AbstractGeometryCollectionTrait, geom)
-    children = [_relate_cache_extents(m, GI.trait(g), g) for g in GI.getgeom(geom)]
+    children = [_relate_cache_extents(m, g) for g in GI.getgeom(geom)]
     ext = _union_stored_extents(children)
     ext === nothing && return geom
     return GI.geointerface_geomtype(trait)(children; extent = ext, crs = GI.crs(geom))

--- a/src/prepared/prepared.jl
+++ b/src/prepared/prepared.jl
@@ -10,10 +10,8 @@ tree level whose trait matches `appliesto(spec)` (topmost-wins). Modeled on rela
 Design: `docs/plans/2026-07-01-prepared-geometry-design.md`.
 =#
 
-export RingEdgeIndex, ChildTree
-export SpatialEdgeIndex, SpatialIndex
-# NOTE: the spec `PointInArea` and its built-prep type (`PointInAreaIndex`) arrive in
-# Task 7; their `export` lines are added alongside them.
+export RingEdgeIndex, ChildTree, PointInArea
+export SpatialEdgeIndex, SpatialIndex, PointInAreaIndex
 
 """
     prepare(geom; preps::Tuple = (), manifold::Manifold = Planar())
@@ -185,3 +183,38 @@ function buildprep(spec::ChildTree, m::Manifold, geom)
     isempty(exts) && return nothing
     return SpatialIndex(NaturalIndex(exts; nodecapacity = spec.nodecapacity))
 end
+
+# ## `PointInArea` — planar point-in-polygonal-area locator
+
+"""
+    PointInAreaIndex(locator)
+
+Built preparation: an `IndexedPointInAreaLocator` (sorted leaves) over the wrapped
+polygonal geometry. Capability: `PointInAreaLike`. `Planar` only.
+"""
+struct PointInAreaIndex{L} <: AbstractPreparation
+    locator::L
+end
+preptrait(::PointInAreaIndex) = PointInAreaLike()
+
+"""
+    PointInArea(; exact = True())
+
+Spec: build an indexed point-in-area locator for a polygon or multipolygon. `Planar` only —
+the spherical point-in-area index is deliberately unimplemented (relateng falls back to an
+O(n) `rk_point_in_ring` walk on `Spherical`).
+"""
+struct PointInArea{E} <: PreparationSpec
+    exact::E
+end
+PointInArea(; exact = True()) = PointInArea(exact)
+appliesto(::PointInArea) = Union{GI.PolygonTrait, GI.MultiPolygonTrait}
+
+#-- Planar only: the rebuilt polygon/multipolygon whose rings are themselves `Prepared` is
+#-- fed straight to the locator (GI forwarding makes the prepared children transparent).
+buildprep(spec::PointInArea, m::Planar, geom) =
+    PointInAreaIndex(IndexedPointInAreaLocator(m, geom; exact = spec.exact, sort_leaves = true))
+buildprep(::PointInArea, m::Manifold, _) =
+    throw(ArgumentError("`PointInArea` requires the `Planar` manifold; got `$(typeof(m))`. \
+        The spherical point-in-area index is not implemented — spherical algorithms use an \
+        O(n) ring walk instead, so simply omit this spec."))

--- a/src/prepared/prepared.jl
+++ b/src/prepared/prepared.jl
@@ -203,6 +203,9 @@ preptrait(::PointInAreaIndex) = PointInAreaLike()
 Spec: build an indexed point-in-area locator for a polygon or multipolygon. `Planar` only —
 the spherical point-in-area index is deliberately unimplemented (relateng falls back to an
 O(n) `rk_point_in_ring` walk on `Spherical`).
+
+Reuse note: relateng's point locator reuses this prepared locator only when the algorithm's
+`exact` type matches the prep's (both default `True()`); otherwise it builds its own.
 """
 struct PointInArea{E} <: PreparationSpec
     exact::E
@@ -215,6 +218,7 @@ appliesto(::PointInArea) = Union{GI.PolygonTrait, GI.MultiPolygonTrait}
 buildprep(spec::PointInArea, m::Planar, geom) =
     PointInAreaIndex(IndexedPointInAreaLocator(m, geom; exact = spec.exact, sort_leaves = true))
 buildprep(::PointInArea, m::Manifold, _) =
-    throw(ArgumentError("`PointInArea` requires the `Planar` manifold; got `$(typeof(m))`. \
-        The spherical point-in-area index is not implemented — spherical algorithms use an \
-        O(n) ring walk instead, so simply omit this spec."))
+    throw(ArgumentError("`PointInArea` requires the `Planar` manifold (as of now); got \
+        `$(typeof(m))`. A point-in-area index is implemented for `Planar` only — for any \
+        other manifold omit this spec (on `Spherical`, relateng falls back to an O(n) ring \
+        walk instead)."))

--- a/src/prepared/prepared.jl
+++ b/src/prepared/prepared.jl
@@ -1,0 +1,93 @@
+#=
+# Prepared geometry: builder and v1 preparations
+
+`prepare(geom; preps, manifold)` rebuilds the GeoInterface tree once, bottom-up, wrapping
+each node in `GeometryOpsCore.Prepared` with a manifold-aware cached extent
+(`rk_interaction_bounds`), and attaching each spec's built preparation at the *highest*
+tree level whose trait matches `appliesto(spec)` (topmost-wins). Modeled on relateng's
+`_relate_cache_extents` (`relate_geometry.jl`), which it subsumes for `Prepared` inputs.
+
+Design: `docs/plans/2026-07-01-prepared-geometry-design.md`.
+=#
+
+# NOTE (Task 4): the concrete specs `RingEdgeIndex`, `ChildTree`, `PointInArea` and the
+# built-prep types arrive in Tasks 5–7; their `export` lines are added alongside them.
+
+"""
+    prepare(geom; preps::Tuple = (), manifold::Manifold = Planar())
+
+Wrap `geom` (and, recursively, its parts) in [`Prepared`](@ref), eagerly building the
+preparations requested in `preps` (a tuple of `PreparationSpec`s such as
+[`RingEdgeIndex`](@ref), [`ChildTree`](@ref), [`PointInArea`](@ref)).
+
+Every wrapped node caches its manifold-aware extent. A spec is consumed at the highest
+matching level of the tree. Preparations do not survive coordinate transformations —
+re-`prepare` after `apply`-style rebuilds.
+"""
+prepare(geom; preps::Tuple = (), manifold::Manifold = Planar()) =
+    _prepare(manifold, preps, GI.trait(geom), geom)
+
+#-- split the spec tuple: consumed at this node vs offered to children (topmost-wins)
+_specs_here(specs::Tuple, trait) = filter(s -> trait isa appliesto(s), specs)
+_specs_below(specs::Tuple, trait) = filter(s -> !(trait isa appliesto(s)), specs)
+
+#-- points and multipoints pass through: their extent is themselves
+_prepare(::Manifold, specs, ::Union{GI.AbstractPointTrait, GI.AbstractMultiPointTrait}, geom) = geom
+
+#-- curve leaves: the only level where coordinates are read
+function _prepare(m::Manifold, specs, trait::GI.AbstractCurveTrait, line)
+    GI.isempty(line) && return line
+    return _wrap(m, _specs_here(specs, trait), line, rk_interaction_bounds(m, line))
+end
+
+function _prepare(m::Manifold, specs, trait::GI.AbstractPolygonTrait, poly)
+    GI.isempty(poly) && return poly
+    below = _specs_below(specs, trait)
+    rings = [_prepare(m, below, GI.trait(r), r) for r in GI.getring(poly)]
+    rebuilt = GI.geointerface_geomtype(trait)(rings; crs = GI.crs(poly))
+    ext = _union_prepared_extents(m, rings)
+    ext === nothing && return rebuilt
+    return _wrap(m, _specs_here(specs, trait), rebuilt, ext)
+end
+
+#-- collections (covers Multi* types too)
+function _prepare(m::Manifold, specs, trait::GI.AbstractGeometryCollectionTrait, geom)
+    GI.isempty(geom) && return geom
+    below = _specs_below(specs, trait)
+    children = [_prepare(m, below, GI.trait(g), g) for g in GI.getgeom(geom)]
+    rebuilt = GI.geointerface_geomtype(trait)(children; crs = GI.crs(geom))
+    ext = _union_prepared_extents(m, children)
+    ext === nothing && return rebuilt
+    return _wrap(m, _specs_here(specs, trait), rebuilt, ext)
+end
+
+#-- unknown traits pass through untouched
+_prepare(::Manifold, specs, ::GI.AbstractTrait, geom) = geom
+
+function _wrap(m::Manifold, specs::Tuple, geom, ext)
+    return Prepared(geom, m, _build_preps(specs, m, geom), ext)
+end
+
+#-- build each consumed spec; a spec may decline (empty geometry) by returning `nothing`
+_build_preps(::Tuple{}, m, geom) = ()
+function _build_preps(specs::Tuple, m, geom)
+    p = buildprep(first(specs), m, geom)
+    rest = _build_preps(Base.tail(specs), m, geom)
+    return p === nothing ? rest : (p, rest...)
+end
+
+function _union_prepared_extents(m::Manifold, children)
+    ext = nothing
+    for c in children
+        ce = if c isa Prepared
+            c.extent
+        elseif GI.isempty(c)
+            nothing
+        else
+            rk_interaction_bounds(m, c)
+        end
+        ce === nothing && continue
+        ext = ext === nothing ? ce : Extents.union(ext, ce)
+    end
+    return ext
+end

--- a/src/prepared/prepared.jl
+++ b/src/prepared/prepared.jl
@@ -148,7 +148,9 @@ end
     SpatialIndex(tree)
 
 Built preparation: an extent tree over the wrapped geometry's *child elements* (rings of a
-polygon, polygons of a multipolygon, members of a collection), in child order.
+polygon, polygons of a multipolygon, members of a collection). Empty children are skipped,
+so leaf `i` is the `i`-th *non-empty* child in `GI.getgeom` order — not necessarily original
+child `i`. Callers whose geometries may contain empty children must account for that shift.
 Capability: `SpatialIndexLike`.
 """
 struct SpatialIndex{T} <: AbstractPreparation
@@ -160,7 +162,9 @@ preptrait(::SpatialIndex) = SpatialIndexLike()
     ChildTree(; nodecapacity = 32)
 
 Spec: build a `NaturalIndex` over child-element extents. Attaches (topmost-wins) to
-polygons, multi-geometries, and geometry collections.
+polygons, multi-geometries, and geometry collections. Empty children are skipped, so leaf
+`i` in the built [`SpatialIndex`](@ref) is the `i`-th *non-empty* child in `GI.getgeom`
+order — callers with possibly-empty children must account for the shift.
 """
 struct ChildTree <: PreparationSpec
     nodecapacity::Int

--- a/src/prepared/prepared.jl
+++ b/src/prepared/prepared.jl
@@ -10,8 +10,10 @@ tree level whose trait matches `appliesto(spec)` (topmost-wins). Modeled on rela
 Design: `docs/plans/2026-07-01-prepared-geometry-design.md`.
 =#
 
-# NOTE (Task 4): the concrete specs `RingEdgeIndex`, `ChildTree`, `PointInArea` and the
-# built-prep types arrive in Tasks 5–7; their `export` lines are added alongside them.
+export RingEdgeIndex
+export SpatialEdgeIndex
+# NOTE: the specs `ChildTree`/`PointInArea` and their built-prep types (`SpatialIndex`,
+# `PointInAreaIndex`) arrive in Tasks 6–7; their `export` lines are added alongside them.
 
 """
     prepare(geom; preps::Tuple = (), manifold::Manifold = Planar())
@@ -90,4 +92,52 @@ function _union_prepared_extents(m::Manifold, children)
         ext = ext === nothing ? ce : Extents.union(ext, ce)
     end
     return ext
+end
+
+# ## `RingEdgeIndex` — per-ring segment extent tree
+
+"""
+    SpatialEdgeIndex(tree)
+
+Built preparation: an extent tree (anything implementing SpatialTreeInterface) over the
+segments of the wrapped curve, in traversal order. Capability: `SpatialEdgeIndexLike`.
+"""
+struct SpatialEdgeIndex{T} <: AbstractPreparation
+    tree::T
+end
+preptrait(::SpatialEdgeIndex) = SpatialEdgeIndexLike()
+
+"""
+    RingEdgeIndex(; nodecapacity = 16)
+
+Spec: build a `NaturalIndex` over each linear ring's segment extents (manifold-aware:
+3D arc extents on `Spherical`). Replaces the `NaturallyIndexedRing` experiment.
+"""
+struct RingEdgeIndex <: PreparationSpec
+    nodecapacity::Int
+end
+RingEdgeIndex(; nodecapacity::Integer = 16) = RingEdgeIndex(Int(nodecapacity))
+appliesto(::RingEdgeIndex) = GI.LinearRingTrait
+
+function buildprep(spec::RingEdgeIndex, m::Manifold, ring)
+    exts = _curve_segment_extents(m, ring)
+    isempty(exts) && return nothing
+    return SpatialEdgeIndex(NaturalIndex(exts; nodecapacity = spec.nodecapacity))
+end
+
+#-- per-segment manifold-aware extents of a curve, in point order (planar 2D boxes,
+#-- 3D great-circle arc extents on the sphere). Mirrors the kernel's segment-extent path
+#-- (`_segment_extent_table`) but per-ring and without the relateng owners table.
+function _curve_segment_extents(m::Manifold, curve)
+    exts = _segment_extent_type(m)[]
+    n = GI.npoint(curve)
+    n < 2 && return exts
+    sizehint!(exts, n - 1)
+    prev = _to_kernel_point(m, GI.getpoint(curve, 1))
+    for i in 2:n
+        cur = _to_kernel_point(m, GI.getpoint(curve, i))
+        push!(exts, _segment_extent(m, prev, cur))
+        prev = cur
+    end
+    return exts
 end

--- a/src/prepared/prepared.jl
+++ b/src/prepared/prepared.jl
@@ -10,10 +10,10 @@ tree level whose trait matches `appliesto(spec)` (topmost-wins). Modeled on rela
 Design: `docs/plans/2026-07-01-prepared-geometry-design.md`.
 =#
 
-export RingEdgeIndex
-export SpatialEdgeIndex
-# NOTE: the specs `ChildTree`/`PointInArea` and their built-prep types (`SpatialIndex`,
-# `PointInAreaIndex`) arrive in Tasks 6–7; their `export` lines are added alongside them.
+export RingEdgeIndex, ChildTree
+export SpatialEdgeIndex, SpatialIndex
+# NOTE: the spec `PointInArea` and its built-prep type (`PointInAreaIndex`) arrive in
+# Task 7; their `export` lines are added alongside them.
 
 """
     prepare(geom; preps::Tuple = (), manifold::Manifold = Planar())
@@ -140,4 +140,44 @@ function _curve_segment_extents(m::Manifold, curve)
         prev = cur
     end
     return exts
+end
+
+# ## `ChildTree` — extent tree over child elements
+
+"""
+    SpatialIndex(tree)
+
+Built preparation: an extent tree over the wrapped geometry's *child elements* (rings of a
+polygon, polygons of a multipolygon, members of a collection), in child order.
+Capability: `SpatialIndexLike`.
+"""
+struct SpatialIndex{T} <: AbstractPreparation
+    tree::T
+end
+preptrait(::SpatialIndex) = SpatialIndexLike()
+
+"""
+    ChildTree(; nodecapacity = 32)
+
+Spec: build a `NaturalIndex` over child-element extents. Attaches (topmost-wins) to
+polygons, multi-geometries, and geometry collections.
+"""
+struct ChildTree <: PreparationSpec
+    nodecapacity::Int
+end
+ChildTree(; nodecapacity::Integer = 32) = ChildTree(Int(nodecapacity))
+appliesto(::ChildTree) = Union{GI.PolygonTrait, GI.AbstractMultiPolygonTrait,
+    GI.AbstractMultiCurveTrait, GI.GeometryCollectionTrait}
+
+#-- `_segment_extent_type(m)` doubles as "the manifold's extent type" — segment and
+#-- interaction bounds share it. Empty children are skipped, so if empties make child
+#-- indices ambiguous for a caller, that caller filters; v1 keeps build simple.
+function buildprep(spec::ChildTree, m::Manifold, geom)
+    exts = _segment_extent_type(m)[]
+    for c in GI.getgeom(geom)
+        GI.isempty(c) && continue
+        push!(exts, c isa Prepared ? c.extent : rk_interaction_bounds(m, c))
+    end
+    isempty(exts) && return nothing
+    return SpatialIndex(NaturalIndex(exts; nodecapacity = spec.nodecapacity))
 end

--- a/src/utils/NaturalIndexing.jl
+++ b/src/utils/NaturalIndexing.jl
@@ -5,9 +5,7 @@ import Extents
 
 using ..SpatialTreeInterface
 
-import ..GeometryOps as GO # TODO: only needed for NaturallyIndexedRing, remove when that is removed.
-
-export NaturalIndex, NaturallyIndexedRing, prepare_naturally
+export NaturalIndex
 
 """
     NaturalLevel{E <: Extents.Extent}
@@ -194,52 +192,5 @@ SpatialTreeInterface.getchild(node::NaturalIndex) = SpatialTreeInterface.getchil
 SpatialTreeInterface.getchild(node::NaturalIndex, i) = SpatialTreeInterface.getchild(NaturalIndexNode(node, 0, 1, node.extent), i)
 
 SpatialTreeInterface.child_indices_extents(node::NaturalIndex) = (i_ext for i_ext in enumerate(node.levels[1].extents))
-
-"""
-    NaturallyIndexedRing(points; nodecapacity = 32)
-
-A linear ring that contains a natural index.
-
-!!! warning
-    This will be removed in favour of prepared geometry - the idea here
-    is just to test what interface works best to store things in.
-"""
-struct NaturallyIndexedRing
-    points::Vector{Tuple{Float64, Float64}}
-    index::NaturalIndex{Extents.Extent{(:X, :Y), NTuple{2, NTuple{2, Float64}}}}
-end
-
-function NaturallyIndexedRing(points::Vector{Tuple{Float64, Float64}}; nodecapacity = 32)
-    index = NaturalIndex(GO.edge_extents(GI.LinearRing(points)); nodecapacity)
-    return NaturallyIndexedRing(points, index)
-end
-NaturallyIndexedRing(ring::NaturallyIndexedRing) = ring
-
-function GI.convert(::Type{NaturallyIndexedRing}, ::GI.LinearRingTrait, geom)
-    points = GO.tuples(geom).geom
-    return NaturallyIndexedRing(points)
-end
-
-Base.show(io::IO, ::MIME"text/plain", ring::NaturallyIndexedRing) = Base.show(io, ring)
-Base.show(io::IO, ring::NaturallyIndexedRing) = print(io, "NaturallyIndexedRing($(length(ring.points)) points) with index $(sprint(show, ring.index))")
-
-GI.ncoord(::GI.LinearRingTrait, ring::NaturallyIndexedRing) = 2
-GI.is3d(::GI.LinearRingTrait, ring::NaturallyIndexedRing) = false
-GI.ismeasured(::GI.LinearRingTrait, ring::NaturallyIndexedRing) = false
-
-GI.ngeom(::GI.LinearRingTrait, ring::NaturallyIndexedRing) = length(ring.points)
-GI.getgeom(::GI.LinearRingTrait, ring::NaturallyIndexedRing) = ring.points
-GI.getgeom(::GI.LinearRingTrait, ring::NaturallyIndexedRing, i::Int) = ring.points[i]
-
-Extents.extent(ring::NaturallyIndexedRing) = ring.index.extent
-
-GI.isgeometry(::Type{<: NaturallyIndexedRing}) = true
-GI.geomtrait(::NaturallyIndexedRing) = GI.LinearRingTrait()
-
-function prepare_naturally(geom)
-    return GO.apply(GI.PolygonTrait(), geom) do poly
-        return GI.Polygon([GI.convert(NaturallyIndexedRing, GI.LinearRingTrait(), ring) for ring in GI.getring(poly)])
-    end
-end
 
 end # module NaturalIndexing

--- a/test/core/preparations.jl
+++ b/test/core/preparations.jl
@@ -1,0 +1,41 @@
+using Test
+import GeometryOpsCore
+import GeometryOpsCore: Prepared, AbstractPreparation, AbstractPreparationTrait,
+    SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike,
+    preptrait, getprep, Planar, Spherical, manifold
+import GeoInterface as GI
+import GeoInterface: Extents
+
+# Dummy preparations for interface tests
+struct _DummyEdgeTree <: AbstractPreparation
+    payload::Int
+end
+GeometryOpsCore.preptrait(::_DummyEdgeTree) = SpatialEdgeIndexLike()
+
+struct _DummyChildTree <: AbstractPreparation end
+GeometryOpsCore.preptrait(::_DummyChildTree) = SpatialIndexLike()
+
+@testset "Preparation retrieval" begin
+    ring = GI.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)])
+    ext = GI.extent(ring; fallback = true)
+    p = Prepared(ring, Planar(), (_DummyEdgeTree(42), _DummyChildTree()), ext)
+
+    @test manifold(p) === Planar()
+    @test parent(p) === ring
+
+    # hit: first matching preparation, concretely typed
+    et = get(p, SpatialEdgeIndexLike())
+    @test et isa _DummyEdgeTree && et.payload == 42
+    @test get(p, SpatialIndexLike()) isa _DummyChildTree
+
+    # miss: nothing
+    @test get(p, PointInAreaLike()) === nothing
+
+    # plain geometries always miss — uniform call sites
+    @test get(ring, SpatialEdgeIndexLike()) === nothing
+
+    # manifold-checked retrieval: mismatch is a miss, not an error
+    @test getprep(Planar(), p, SpatialEdgeIndexLike()) === et
+    @test getprep(Spherical(), p, SpatialEdgeIndexLike()) === nothing
+    @test getprep(Planar(), ring, SpatialEdgeIndexLike()) === nothing
+end

--- a/test/core/preparations.jl
+++ b/test/core/preparations.jl
@@ -38,4 +38,36 @@ GeometryOpsCore.preptrait(::_DummyChildTree) = SpatialIndexLike()
     @test getprep(Planar(), p, SpatialEdgeIndexLike()) === et
     @test getprep(Spherical(), p, SpatialEdgeIndexLike()) === nothing
     @test getprep(Planar(), ring, SpatialEdgeIndexLike()) === nothing
+
+    # first-match-wins tie-break: two preparations with the same capability → the first
+    p2 = Prepared(ring, Planar(), (_DummyEdgeTree(1), _DummyEdgeTree(2)), ext)
+    @test get(p2, SpatialEdgeIndexLike()).payload == 1
+
+    # constructor validation: a non-geometry is rejected
+    @test_throws ArgumentError Prepared(42, Planar(), (), ext)
+end
+
+@testset "GeoInterface forwarding" begin
+    ring = GI.LinearRing([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 0.0)])
+    rext = GI.extent(ring; fallback = true)
+    pring = Prepared(ring, Planar(), (_DummyEdgeTree(1),), rext)
+
+    @test GI.isgeometry(pring)
+    @test GI.trait(pring) isa GI.LinearRingTrait
+    @test GI.npoint(pring) == GI.npoint(ring)
+    @test collect(GI.getpoint(pring)) == collect(GI.getpoint(ring))
+    @test GI.coordinates(pring) == GI.coordinates(ring)
+    @test GI.is3d(pring) == false
+    @test GI.extent(pring) == rext          # served from the field
+    @test Extents.extent(pring) == rext
+
+    # a Prepared polygon whose ring is itself Prepared: GI hands back the prepared child
+    poly = GI.Polygon([pring])
+    pext = GI.extent(ring; fallback = true)
+    ppoly = Prepared(poly, Planar(), (), pext)
+    @test GI.trait(ppoly) isa GI.PolygonTrait
+    @test GI.nring(ppoly) == 1
+    @test GI.getring(ppoly, 1) === pring
+    @test GI.getexterior(ppoly) === pring
+    @test get(GI.getring(ppoly, 1), SpatialEdgeIndexLike()) isa _DummyEdgeTree
 end

--- a/test/core/preparations.jl
+++ b/test/core/preparations.jl
@@ -71,3 +71,8 @@ end
     @test GI.getexterior(ppoly) === pring
     @test get(GI.getring(ppoly, 1), SpatialEdgeIndexLike()) isa _DummyEdgeTree
 end
+
+@testset "Method hygiene" begin
+    # the Prepared forwarding must not introduce method ambiguities
+    @test isempty(Test.detect_ambiguities(GeometryOpsCore; recursive = false))
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -5,6 +5,7 @@ import GeometryOps: Prepared, prepare, getprep,
 import GeometryOpsCore
 import GeoInterface as GI
 import GeoInterface: Extents
+import LibGEOS as LG  # only for EMPTY geometries — GI wrappers cannot be empty
 
 @testset "prepare is one generic function" begin
     # the algorithm method and the (future) geometry method share the Core binding
@@ -118,4 +119,19 @@ end
     @test rprep isa GO.SpatialIndex
     # the hole (ring 2) occupies (4..6, 4..6)
     @test GO.SpatialTreeInterface.query(rprep.tree, Extents.Extent(X = (4.5, 5.5), Y = (4.5, 5.5))) == [1, 2]
+
+    # `buildprep(::ChildTree, ...)` SKIPS empty children, so tree leaf `i` is the `i`-th
+    # NON-EMPTY child in `GI.getgeom` order, not original child `i`. Pin that index shift.
+    # (GI wrappers cannot be empty — `GeoInterface.isempty` falls back to `false` for every
+    # geometry trait — so the empty middle child is built with LibGEOS, matching the
+    # convention in `test/methods/area.jl` and `test/methods/relateng/topology_computer.jl`.)
+    mp_gap = prepare(GI.MultiPolygon([_PG_POLY, LG.readgeom("POLYGON EMPTY"), _PG_POLY2]);
+        preps = (GO.ChildTree(),))
+    prep_gap = get(mp_gap, SpatialIndexLike())
+    @test prep_gap isa GO.SpatialIndex
+    # the empty middle child is dropped, so the tree has exactly 2 leaves: a box over the
+    # whole extent hits both, in tree order [1, 2]
+    @test GO.SpatialTreeInterface.query(prep_gap.tree, Extents.Extent(X = (0.0, 25.0), Y = (0.0, 10.0))) == [1, 2]
+    # leaf 2 is ORIGINAL child 3 (`_PG_POLY2`, x in (20, 25)): a box over its area returns [2]
+    @test GO.SpatialTreeInterface.query(prep_gap.tree, Extents.Extent(X = (21.0, 22.0), Y = (0.0, 1.0))) == [2]
 end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -1,0 +1,15 @@
+using Test
+import GeometryOps as GO
+import GeometryOps: Prepared, prepare, getprep,
+    SpatialIndexLike, SpatialEdgeIndexLike, PointInAreaLike
+import GeometryOpsCore
+import GeoInterface as GI
+import GeoInterface: Extents
+
+@testset "prepare is one generic function" begin
+    # the algorithm method and the (future) geometry method share the Core binding
+    @test GO.prepare === GeometryOpsCore.prepare
+    poly = GI.Polygon([GI.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)])])
+    prep = GO.prepare(GO.RelateNG(), poly)
+    @test prep isa GO.PreparedRelate
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -168,4 +168,18 @@ end
     rgs = GO.RelateGeometry(GO.Spherical(), ps; exact = GO.True())
     @test rgs.geom !== ps
     @test GI.extent(rgs.geom) isa Extents.Extent{(:X, :Y, :Z)}
+
+    # mismatched manifold, reverse direction: spherical-prepared input to a planar
+    # relate must be stripped and rebuilt, not silently mis-pruned via cached 3D extents
+    sph_prep = prepare(_PG_SPH_POLY; manifold = GO.Spherical())
+    overlap_b = GI.Polygon([GI.LinearRing([(15.0, 45.0), (25.0, 45.0), (25.0, 55.0), (15.0, 55.0), (15.0, 45.0)])])
+    cross_line = GI.LineString([(5.0, 39.0), (25.0, 51.0)])
+    palg = GO.RelateNG()
+    @test string(GO.relate(palg, sph_prep, overlap_b)) == string(GO.relate(palg, _PG_SPH_POLY, overlap_b))
+    @test string(GO.relate(palg, sph_prep, cross_line)) == string(GO.relate(palg, _PG_SPH_POLY, cross_line))
+    @test string(GO.relate(palg, overlap_b, sph_prep)) == string(GO.relate(palg, overlap_b, _PG_SPH_POLY))
+    # the rewrap must carry freshly computed 2D extents equal to the plain rebuild's
+    rg_mm = GO.RelateGeometry(GO.Planar(), sph_prep; exact = GO.True())
+    rg_plain = GO.RelateGeometry(GO.Planar(), _PG_SPH_POLY; exact = GO.True())
+    @test GI.extent(rg_mm.geom) == GI.extent(rg_plain.geom)
 end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -135,3 +135,23 @@ end
     # leaf 2 is ORIGINAL child 3 (`_PG_POLY2`, x in (20, 25)): a box over its area returns [2]
     @test GO.SpatialTreeInterface.query(prep_gap.tree, Extents.Extent(X = (21.0, 22.0), Y = (0.0, 1.0))) == [2]
 end
+
+@testset "PointInArea" begin
+    p = prepare(_PG_POLY; preps = (GO.PointInArea(),))
+    prep = get(p, PointInAreaLike())
+    @test prep isa GO.PointInAreaIndex
+    # ground truth against the unindexed locator: interior, hole, boundary, exterior
+    @test GO.locate(prep.locator, (1.0, 1.0)) == GO.LOC_INTERIOR
+    @test GO.locate(prep.locator, (5.0, 5.0)) == GO.LOC_EXTERIOR   # inside the hole
+    @test GO.locate(prep.locator, (5.0, 0.0)) == GO.LOC_BOUNDARY
+    @test GO.locate(prep.locator, (11.0, 5.0)) == GO.LOC_EXTERIOR
+
+    # multipolygon input: consumed at the MP node (relateng's element granularity)
+    mp = prepare(_PG_MP; preps = (GO.PointInArea(),))
+    @test get(mp, PointInAreaLike()) isa GO.PointInAreaIndex
+    @test get(GI.getgeom(mp, 1), PointInAreaLike()) === nothing
+
+    # spherical: a clear, early error (Task 16 of the spherical plan was skipped)
+    @test_throws ArgumentError prepare(_PG_SPH_POLY;
+        manifold = GO.Spherical(), preps = (GO.PointInArea(),))
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -155,3 +155,17 @@ end
     @test_throws ArgumentError prepare(_PG_SPH_POLY;
         manifold = GO.Spherical(), preps = (GO.PointInArea(),))
 end
+
+@testset "relateng seam: Prepared extents are trusted" begin
+    m = GO.Planar()
+    pp = prepare(_PG_POLY; preps = (GO.RingEdgeIndex(),))
+    rg = GO.RelateGeometry(m, pp; exact = GO.True())
+    # matched manifold: the Prepared tree is used as-is (no rewrap)
+    @test rg.geom === pp
+
+    # mismatched manifold: falls back to the rewrap path (correctness over reuse)
+    ps = prepare(_PG_SPH_POLY)   # Planar-prepared (2D extents)
+    rgs = GO.RelateGeometry(GO.Spherical(), ps; exact = GO.True())
+    @test rgs.geom !== ps
+    @test GI.extent(rgs.geom) isa Extents.Extent{(:X, :Y, :Z)}
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -266,6 +266,9 @@ end
     pia3    = (GO.RingEdgeIndex(), GO.ChildTree(), GO.PointInArea())
 
     # each row: (name, a, b, a_combos, b_prep, both_positions)
+    # `b_prep` is only read when `both_positions` is true (it preps the B side for the
+    # B-prepared / both-prepared cells); rows with `both_positions = false` never read it,
+    # so their `b_prep` entry is inert.
     planar_pairs = [
         ("poly|poly disjoint", _PG_POLY, _PG_POLY2, poly_combos, pia3, true),
         ("poly|poly overlap",  _PG_POLY, overlap,   poly_combos, pia3, true),
@@ -274,6 +277,9 @@ end
         ("mp|poly",            _PG_MP,   _PG_POLY,  poly_combos, pia3, false),
         ("poly|mp",            _PG_POLY, _PG_MP,    poly_combos, (GO.RingEdgeIndex(), GO.ChildTree()), true),
         ("gc|poly",            gc,       _PG_POLY,  nonpoly_combos, pia3, false),
+        # `a` is a bare Point and `prepare` returns points unwrapped (`pa === pt`), so the
+        # `:Aplain`/`:Aprep` cells here are pass-through-vacuous by design — they compare
+        # `relate` against itself. They auto-arm if `prepare` ever starts wrapping points.
         ("point|multipoint",   pt,       mpt,       nonpoly_combos, (), false),
     ]
 

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -183,3 +183,43 @@ end
     rg_plain = GO.RelateGeometry(GO.Planar(), _PG_SPH_POLY; exact = GO.True())
     @test GI.extent(rg_mm.geom) == GI.extent(rg_plain.geom)
 end
+
+@testset "relateng seam: PointInArea reuse" begin
+    m = GO.Planar()
+    pp = prepare(_PG_POLY; preps = (GO.PointInArea(),))
+    prep = get(pp, PointInAreaLike())
+
+    # `GO.locate(::RelatePointLocator, p)` routes locate_with_dim -> compute_dim_location
+    # -> locate_on_polygons -> locate_on_polygonal, which is the seam under test.
+
+    # unprepared locator over a Prepared element uses the preparation immediately
+    loc = GO.RelatePointLocator(m, pp; exact = GO.True())
+    @test GO.locate(loc, (1.0, 1.0)) == GO.LOC_INTERIOR   # forces the polygonal path
+    @test loc.poly_locator[1] === prep.locator             # identity: reused, not rebuilt
+
+    # and in prepared mode too
+    ploc = GO.RelatePointLocator(m, pp; exact = GO.True(), is_prepared = true)
+    GO.locate(ploc, (1.0, 1.0))
+    @test ploc.poly_locator[1] === prep.locator
+
+    # (a) MultiPolygon whole-element pin: `_extract_elements!` keeps a Polygon/MultiPolygon
+    # as ONE element, so the prepared MP's own PointInArea node (attached topmost-wins at the
+    # MP) is the element at index 1 and is reused there — not a per-polygon rebuild.
+    mp_prep = prepare(_PG_MP; preps = (GO.PointInArea(),))
+    mp_loc = GO.RelatePointLocator(m, mp_prep; exact = GO.True())
+    @test mp_loc.polygons[1] === mp_prep                   # the element IS the whole Prepared MP
+    @test GO.locate(mp_loc, (1.0, 1.0)) == GO.LOC_INTERIOR # forces the polygonal path
+    @test mp_loc.poly_locator[1] === get(mp_prep, PointInAreaLike()).locator
+
+    # (b) Type-guard fallback: a locator with `exact = False()` cannot reuse a prep whose
+    # locator was built with `exact = True()` (the `isa IndexedPointInAreaLocator{M, E}` guard
+    # fails on the E mismatch), so a fresh locator is built — but results still match plain.
+    guard_loc = GO.RelatePointLocator(m, pp; exact = GO.False())
+    @test GO.locate(guard_loc, (1.0, 1.0)) == GO.LOC_INTERIOR
+    @test guard_loc.poly_locator[1] !== prep.locator       # NOT reused: `exact` type mismatch
+    @test guard_loc.poly_locator[1] !== nothing            # but a locator WAS still built
+    plain_loc = GO.RelatePointLocator(m, _PG_POLY; exact = GO.False())
+    for q in [(1.0, 1.0), (5.0, 5.0), (5.0, 0.0), (11.0, 5.0)]
+        @test GO.locate(guard_loc, q) == GO.locate(plain_loc, q)
+    end
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -53,3 +53,28 @@ const _PG_SPH_POLY = GI.Polygon([GI.LinearRing([(10.0, 40.0), (20.0, 40.0), (20.
     @test GI.extent(ps) isa Extents.Extent{(:X, :Y, :Z)}
     @test GI.extent(GI.getring(ps, 1)) isa Extents.Extent{(:X, :Y, :Z)}
 end
+
+@testset "RingEdgeIndex" begin
+    p = prepare(_PG_POLY; preps = (GO.RingEdgeIndex(),))
+    @test p.preps === ()                       # consumed at ring level, not polygon level
+    ring = GI.getring(p, 1)
+    prep = get(ring, SpatialEdgeIndexLike())
+    @test prep isa GO.SpatialEdgeIndex
+    tree = prep.tree
+    @test tree isa GO.NaturalIndexing.NaturalIndex
+
+    # the tree indexes segments in ring order: query a box covering only segment 1
+    # (outer ring segment 1 runs (0,0)->(10,0))
+    hits = GO.SpatialTreeInterface.query(tree, Extents.Extent(X = (4.0, 5.0), Y = (-0.1, 0.1)))
+    @test hits == [1]
+
+    # spherical: builds 3D arc-extent trees without error
+    ps = prepare(_PG_SPH_POLY; manifold = GO.Spherical(), preps = (GO.RingEdgeIndex(),))
+    sprep = get(GI.getring(ps, 1), SpatialEdgeIndexLike())
+    @test sprep isa GO.SpatialEdgeIndex
+    @test GO.SpatialTreeInterface.node_extent(sprep.tree) isa Extents.Extent{(:X, :Y, :Z)}
+
+    # manifold-checked retrieval
+    @test getprep(GO.Planar(), GI.getring(p, 1), SpatialEdgeIndexLike()) === prep
+    @test getprep(GO.Spherical(), GI.getring(p, 1), SpatialEdgeIndexLike()) === nothing
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -13,3 +13,43 @@ import GeoInterface: Extents
     prep = GO.prepare(GO.RelateNG(), poly)
     @test prep isa GO.PreparedRelate
 end
+
+# shared fixtures for the remaining testsets
+const _PG_RING_OUTER = GI.LinearRing([(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)])
+const _PG_RING_HOLE  = GI.LinearRing([(4.0, 4.0), (6.0, 4.0), (6.0, 6.0), (4.0, 6.0), (4.0, 4.0)])
+const _PG_POLY  = GI.Polygon([_PG_RING_OUTER, _PG_RING_HOLE])
+const _PG_POLY2 = GI.Polygon([GI.LinearRing([(20.0, 0.0), (25.0, 0.0), (25.0, 5.0), (20.0, 0.0)])])
+const _PG_MP    = GI.MultiPolygon([_PG_POLY, _PG_POLY2])
+# mid-latitude spherical quad (lon/lat degrees)
+const _PG_SPH_POLY = GI.Polygon([GI.LinearRing([(10.0, 40.0), (20.0, 40.0), (20.0, 50.0), (10.0, 50.0), (10.0, 40.0)])])
+
+@testset "prepare: recursive wrapping, no specs" begin
+    p = prepare(_PG_POLY)
+    @test p isa Prepared
+    @test GI.trait(p) isa GI.PolygonTrait
+    @test GeometryOpsCore.manifold(p) === GO.Planar()
+    @test p.preps === ()
+
+    # children are themselves Prepared, with per-node extents
+    r1 = GI.getring(p, 1)
+    @test r1 isa Prepared && GI.trait(r1) isa GI.LinearRingTrait
+    @test GI.extent(r1) == GI.extent(_PG_RING_OUTER; fallback = true)
+    @test GI.extent(p) == GI.extent(_PG_POLY; fallback = true)
+
+    # geometry content is unchanged
+    @test GI.coordinates(p) == GI.coordinates(_PG_POLY)
+
+    # points pass through unwrapped
+    pt = GI.Point(1.0, 2.0)
+    @test prepare(pt) === pt
+
+    # multipolygon: every level wrapped
+    mp = prepare(_PG_MP)
+    @test mp isa Prepared && GI.getgeom(mp, 1) isa Prepared
+    @test GI.getring(GI.getgeom(mp, 1), 1) isa Prepared
+
+    # spherical: extents are 3D unit-sphere boxes
+    ps = prepare(_PG_SPH_POLY; manifold = GO.Spherical())
+    @test GI.extent(ps) isa Extents.Extent{(:X, :Y, :Z)}
+    @test GI.extent(GI.getring(ps, 1)) isa Extents.Extent{(:X, :Y, :Z)}
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -223,3 +223,153 @@ end
         @test GO.locate(guard_loc, q) == GO.locate(plain_loc, q)
     end
 end
+
+# ============================================================================
+# Task 10 — end-to-end equality: `relate(alg, a, b)` must be string-identical
+# whether the inputs are plain or `Prepared`, for ANY preparation combination,
+# in BOTH operand positions, on BOTH manifolds. A `relate` string that changes
+# with preparation means a seam changed topological semantics — never
+# acceptable. The sweep loops over (name, a, b, preps, position) tuples;
+# `@test` expressions embed a (name, prep-label, position) tuple so a failure
+# names the exact cell.
+#
+# Axes swept:
+#   geometry type : polygon-with-hole, multipolygon, linestring, geometry
+#                   collection, point, multipoint
+#   preparation   : planar {(), ring, PointInArea, ring+child+PIA};
+#                   spherical {(), ring, ring+child}  (no PointInArea on the
+#                   sphere — it throws; PointInArea only where polygonal+planar)
+#   operand pos.  : A-plain, A-prepared-algorithm, B-plain, both, both+algorithm
+#   manifold      : Planar, Spherical
+# ============================================================================
+@testset "relate: plain == Prepared sweep" begin
+    # -- planar prep-combination axis --
+    poly_combos = [                                # polygonal a-side: PointInArea allowed
+        ("noprep", ()),
+        ("ring",   (GO.RingEdgeIndex(),)),
+        ("pia",    (GO.PointInArea(),)),
+        ("all",    (GO.RingEdgeIndex(), GO.ChildTree(), GO.PointInArea())),
+    ]
+    nonpoly_combos = [                             # non-polygonal a-side: omit PointInArea
+        ("noprep",    ()),
+        ("ring",      (GO.RingEdgeIndex(),)),
+        ("ringchild", (GO.RingEdgeIndex(), GO.ChildTree())),
+    ]
+
+    # -- planar fixtures --
+    line    = GI.LineString([(-1.0, -1.0), (5.0, 5.0), (12.0, 5.0)])  # in, through hole, out
+    line2   = GI.LineString([(0.0, 5.0), (10.0, 5.0)])               # spans _PG_POLY + its hole
+    pt      = GI.Point(5.0, 1.0)                                     # interior to _PG_POLY
+    mpt     = GI.MultiPoint([(5.0, 1.0), (30.0, 30.0)])             # one in, one far outside
+    overlap = GI.Polygon([GI.LinearRing([(5.0, 5.0), (15.0, 5.0), (15.0, 15.0), (5.0, 5.0)])])
+    gc      = GI.GeometryCollection([_PG_POLY2, line2])            # mixed-dimension collection
+    pia3    = (GO.RingEdgeIndex(), GO.ChildTree(), GO.PointInArea())
+
+    # each row: (name, a, b, a_combos, b_prep, both_positions)
+    planar_pairs = [
+        ("poly|poly disjoint", _PG_POLY, _PG_POLY2, poly_combos, pia3, true),
+        ("poly|poly overlap",  _PG_POLY, overlap,   poly_combos, pia3, true),
+        ("poly|line",          _PG_POLY, line,      poly_combos, (GO.RingEdgeIndex(),), true),
+        ("poly|point",         _PG_POLY, pt,        poly_combos, (), false),
+        ("mp|poly",            _PG_MP,   _PG_POLY,  poly_combos, pia3, false),
+        ("poly|mp",            _PG_POLY, _PG_MP,    poly_combos, (GO.RingEdgeIndex(), GO.ChildTree()), true),
+        ("gc|poly",            gc,       _PG_POLY,  nonpoly_combos, pia3, false),
+        ("point|multipoint",   pt,       mpt,       nonpoly_combos, (), false),
+    ]
+
+    palg = GO.RelateNG()
+    for (name, a, b, a_combos, b_prep, both) in planar_pairs
+        @testset "$name" begin
+            expected = string(GO.relate(palg, a, b))
+            # axis: a-side preparation × {plain path, algorithm-prepared path}
+            for (plabel, preps) in a_combos
+                pa = prepare(a; preps = preps, manifold = GO.Planar())
+                @test (name, plabel, :Aplain, string(GO.relate(palg, pa, b))) ==
+                      (name, plabel, :Aplain, expected)
+                @test (name, plabel, :Aprep, string(GO.relate(GO.prepare(palg, pa), b))) ==
+                      (name, plabel, :Aprep, expected)
+            end
+            # axis: operand position — B-prepared and both-prepared (richest a-combo)
+            if both
+                pa = prepare(a; preps = last(a_combos)[2], manifold = GO.Planar())
+                pb = prepare(b; preps = b_prep, manifold = GO.Planar())
+                @test (name, :Bplain, string(GO.relate(palg, a, pb))) ==
+                      (name, :Bplain, expected)
+                @test (name, :AB, string(GO.relate(palg, pa, pb))) ==
+                      (name, :AB, expected)
+                @test (name, :ABprep, string(GO.relate(GO.prepare(palg, pa), pb))) ==
+                      (name, :ABprep, expected)
+            end
+        end
+    end
+
+    # -- spherical sweep (no PointInArea on the sphere) --
+    salg         = GO.RelateNG(; manifold = GO.Spherical())
+    sph_overlap  = GI.Polygon([GI.LinearRing([(15.0, 45.0), (25.0, 45.0), (25.0, 55.0), (15.0, 55.0), (15.0, 45.0)])])
+    sph_disjoint = GI.Polygon([GI.LinearRing([(40.0, 40.0), (50.0, 40.0), (50.0, 50.0), (40.0, 50.0), (40.0, 40.0)])])
+    sph_line     = GI.LineString([(5.0, 39.0), (25.0, 51.0)])   # crosses _PG_SPH_POLY
+    sph_combos   = [
+        ("noprep",    ()),
+        ("ring",      (GO.RingEdgeIndex(),)),
+        ("ringchild", (GO.RingEdgeIndex(), GO.ChildTree())),
+    ]
+    spherical_pairs = [
+        ("sph poly|poly overlap",  _PG_SPH_POLY, sph_overlap,  sph_combos, (GO.RingEdgeIndex(), GO.ChildTree()), true),
+        ("sph poly|poly disjoint", _PG_SPH_POLY, sph_disjoint, sph_combos, (GO.RingEdgeIndex(),), false),
+        ("sph poly|line",          _PG_SPH_POLY, sph_line,     sph_combos, (GO.RingEdgeIndex(),), true),
+    ]
+    for (name, a, b, a_combos, b_prep, both) in spherical_pairs
+        @testset "$name" begin
+            expected = string(GO.relate(salg, a, b))
+            for (plabel, preps) in a_combos
+                pa = prepare(a; preps = preps, manifold = GO.Spherical())
+                @test (name, plabel, :Aplain, string(GO.relate(salg, pa, b))) ==
+                      (name, plabel, :Aplain, expected)
+                @test (name, plabel, :Aprep, string(GO.relate(GO.prepare(salg, pa), b))) ==
+                      (name, plabel, :Aprep, expected)
+            end
+            if both
+                pa = prepare(a; preps = last(a_combos)[2], manifold = GO.Spherical())
+                pb = prepare(b; preps = b_prep, manifold = GO.Spherical())
+                @test (name, :Bplain, string(GO.relate(salg, a, pb))) ==
+                      (name, :Bplain, expected)
+                @test (name, :AB, string(GO.relate(salg, pa, pb))) ==
+                      (name, :AB, expected)
+                @test (name, :ABprep, string(GO.relate(GO.prepare(salg, pa), pb))) ==
+                      (name, :ABprep, expected)
+            end
+        end
+    end
+
+    # -- REQUIRED: Spherical GeometryCollection with a BARE Point + a Polygon (Task 4 review).
+    # The legacy plain-input extent path (`_union_stored_extents`) reads the bare point's
+    # extent via `GI.extent(pt; fallback=true)` — a manifold-BLIND 2D lon/lat box — and unions
+    # it with the polygon's 3D unit-sphere box; `Extents.union` keeps only shared keys, so the
+    # GC WRAPPER caches a dimensionally-collapsed, coordinate-mixed 2D garbage extent.
+    # `prepare`'s `_union_prepared_extents` instead uses `rk_interaction_bounds(m, pt)` (a real
+    # 3D box), matching `_relate_extent` exactly. The relate STRING is nonetheless IDENTICAL:
+    # the garbage is shadowed — `RelateGeometry.extent` (the field driving the envelope
+    # short-circuit) is recomputed to the correct 3D box by `_relate_extent` in BOTH paths. So
+    # plain == prepared, and both are correct (ground truth `212101212`/overlap, `FF2FF1212`/
+    # disjoint verified against the GC's members related separately + planar intuition; the
+    # interior point is absorbed by the polygon, so the GC relates to b exactly as the polygon
+    # does). This is NOT the latent legacy bug reaching an output — it stays contained.
+    @testset "spherical GC{bare point, polygon}" begin
+        gc_pt = GI.GeometryCollection([GI.Point(12.0, 42.0), _PG_SPH_POLY])  # point interior to poly
+        # Pin that this fixture actually exercises the divergent extent path (else the equality
+        # below would be a vacuous no-op): legacy caches a collapsed 2D GC extent, prepare a 3D one.
+        legacy_gc_ext = GI.extent(GO._relate_cache_extents(GO.Spherical(), gc_pt))
+        prep_gc_ext   = prepare(gc_pt; manifold = GO.Spherical()).extent
+        @test keys(legacy_gc_ext) == (:X, :Y)          # legacy: dimensionally collapsed (the bug)
+        @test keys(prep_gc_ext)   == (:X, :Y, :Z)      # prepare: correct 3D unit-sphere box
+
+        for (blabel, b) in [(:overlap, sph_overlap), (:disjoint, sph_disjoint)]
+            expected = string(GO.relate(salg, gc_pt, b))
+            pgc = prepare(gc_pt; manifold = GO.Spherical(), preps = (GO.RingEdgeIndex(),))
+            pb  = prepare(b; manifold = GO.Spherical(), preps = (GO.RingEdgeIndex(),))
+            @test (blabel, :Aplain, string(GO.relate(salg, pgc, b))) == (blabel, :Aplain, expected)
+            @test (blabel, :Aprep, string(GO.relate(GO.prepare(salg, pgc), b))) == (blabel, :Aprep, expected)
+            @test (blabel, :Bprep, string(GO.relate(salg, gc_pt, pb))) == (blabel, :Bprep, expected)
+        end
+    end
+end

--- a/test/prepared/prepared_geometry.jl
+++ b/test/prepared/prepared_geometry.jl
@@ -77,4 +77,45 @@ end
     # manifold-checked retrieval
     @test getprep(GO.Planar(), GI.getring(p, 1), SpatialEdgeIndexLike()) === prep
     @test getprep(GO.Spherical(), GI.getring(p, 1), SpatialEdgeIndexLike()) === nothing
+
+    # every edge of a square ring is individually isolatable: a thin box centered on
+    # each edge midpoint hits exactly that segment
+    sq = prepare(GI.LinearRing([(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)]);
+        preps = (GO.RingEdgeIndex(),))
+    sqtree = get(sq, SpatialEdgeIndexLike()).tree
+    @test GO.SpatialTreeInterface.query(sqtree, Extents.Extent(X = (4.9, 5.1), Y = (-0.1, 0.1))) == [1]  # y ≈ 0 edge
+    @test GO.SpatialTreeInterface.query(sqtree, Extents.Extent(X = (9.9, 10.1), Y = (4.9, 5.1))) == [2]  # x ≈ 10 edge
+    @test GO.SpatialTreeInterface.query(sqtree, Extents.Extent(X = (4.9, 5.1), Y = (9.9, 10.1))) == [3]  # y ≈ 10 edge
+    @test GO.SpatialTreeInterface.query(sqtree, Extents.Extent(X = (-0.1, 0.1), Y = (4.9, 5.1))) == [4]  # x ≈ 0 edge
+
+    # spherical: the tree's stored arc extents round-trip against the kernel's
+    # `_segment_extent` — segment 2's own box hits it; a provably disjoint segment's box
+    # cannot hit segment 1. (Segment 4 shares vertex (10,40) with segment 1, so adjacent
+    # arc extents overlap — use segment 3, the lat-50 edge, and prove disjointness first.)
+    spts = collect(GI.getpoint(GI.getring(_PG_SPH_POLY, 1)))
+    sseg(i, j) = GO._segment_extent(GO.Spherical(),
+        GO._to_kernel_point(GO.Spherical(), spts[i]),
+        GO._to_kernel_point(GO.Spherical(), spts[j]))
+    @test 2 in GO.SpatialTreeInterface.query(sprep.tree, sseg(2, 3))
+    @test !Extents.intersects(sseg(1, 2), sseg(3, 4))
+    @test 3 in GO.SpatialTreeInterface.query(sprep.tree, sseg(3, 4))
+    @test 1 ∉ GO.SpatialTreeInterface.query(sprep.tree, sseg(3, 4))
+end
+
+@testset "ChildTree" begin
+    # on a multipolygon: consumed at the MP node (topmost-wins), indexing polygon extents
+    mp = prepare(_PG_MP; preps = (GO.ChildTree(),))
+    prep = get(mp, SpatialIndexLike())
+    @test prep isa GO.SpatialIndex
+    # polygon 2 lives at x in (20, 25): a query box there hits only child 2
+    @test GO.SpatialTreeInterface.query(prep.tree, Extents.Extent(X = (21.0, 22.0), Y = (0.0, 1.0))) == [2]
+    # children did not also get trees
+    @test get(GI.getgeom(mp, 1), SpatialIndexLike()) === nothing
+
+    # on a bare polygon: indexes ring extents
+    p = prepare(_PG_POLY; preps = (GO.ChildTree(),))
+    rprep = get(p, SpatialIndexLike())
+    @test rprep isa GO.SpatialIndex
+    # the hole (ring 2) occupies (4..6, 4..6)
+    @test GO.SpatialTreeInterface.query(rprep.tree, Extents.Extent(X = (4.5, 5.5), Y = (4.5, 5.5))) == [1, 2]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ end
 @safetestset "Voronoi" begin include("methods/voronoi.jl") end
 @safetestset "DE-9IM Geom Relations" begin include("methods/geom_relations.jl") end
 @safetestset "RelateNG" begin include("methods/relateng/runtests.jl") end
+@safetestset "Prepared geometry" begin include("prepared/prepared_geometry.jl") end
 @safetestset "Distance" begin include("methods/distance.jl") end
 @safetestset "Equals" begin include("methods/equals.jl") end
 @safetestset "Minimum Bounding Circle" begin include("methods/minimum_bounding_circle.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ import Test, GeoInterface, ArchGDAL, GeometryBasics, LibGEOS # enable GOTestHelp
 @testset "Core" begin
     @safetestset "Algorithm" begin include("core/algorithm.jl") end
     @safetestset "Manifold" begin include("core/manifold.jl") end
+    @safetestset "Preparations" begin include("core/preparations.jl") end
     @safetestset "Applicators" begin include("core/applicators.jl") end
     @safetestset "Geometry Utils" begin include("core/geometry_utils.jl") end
 end


### PR DESCRIPTION
## Summary
- `Prepared` recursively wraps any GeoInterface geometry and carries type-indexed preparations, retrievable via `Base.get(p, PointInAreaLike())` or `getprep(manifold, geom, trait)` (manifold mismatch = miss). Types + retrieval live in GeometryOpsCore; the `prepare(geom; preps, manifold)` builder and v1 preparations live in GeometryOps. Extents are cached at every wrapped node.
- v1 preparations: `RingEdgeIndex` (per-ring edge tree), `ChildTree` (child-extent tree for multis/collections), `PointInArea` (prebuilt indexed point-in-area locator, planar).
- RelateNG consumes them at two seams: matched-manifold `Prepared` extents are trusted as-is (mismatched wrappers are stripped and rebuilt — also fixes a latent leak where spherical-prepared inputs to planar `relate` produced wrong DE-9IM matrices), and `PointInAreaLike` locators are reused by identity in the relate point locator.
- A 104-cell sweep proves `relate` is identical for plain vs `Prepared` inputs across geometry types × prep combinations × operand positions × both manifolds.
- Removes the superseded `NaturallyIndexedRing`; bumps GeometryOpsCore to 0.1.11, GeometryOps to 0.1.41. Design doc + as-built amendments under `docs/plans/`.
- Scope note: only the extent-trust and `PointInAreaLike` seams are wired internally; `RingEdgeIndex`/`ChildTree` ship as forward-looking capabilities (edge-index and clipping seams deferred).

## Test plan
- [x] `test/core/preparations.jl` (25) and `test/prepared/prepared_geometry.jl` (171, incl. the equality sweep)
- [x] RelateNG suites: `relate_ng` 1868, `relate_geometry` 118, `point_locator` 45, `kernel_conformance` 76908, `spherical_end_to_end` 14, `SpatialTreeInterface` 66
- [x] JTS XML conformance suite: 6537/6537

🤖 Generated with [Claude Code](https://claude.com/claude-code)