### PR TITLE
Allow spherical caps to intersect 3D extents

### DIFF
--- a/src/utils/UnitSpherical/UnitSpherical.jl
+++ b/src/utils/UnitSpherical/UnitSpherical.jl
@@ -3,6 +3,7 @@ module UnitSpherical
 using CoordinateTransformations
 using StaticArrays, LinearAlgebra
 import GeoInterface as GI, GeoFormatTypes as GFT
+import Extents
 
 import Random
 

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -120,18 +120,13 @@ end
     Extents.intersects(ext::Extents.Extent{(:X, :Y, :Z)}, cap::SphericalCap)
 
 Whether `cap` intersects the part of the unit sphere covered by the 3D
-Cartesian bounding box `ext`.
+Cartesian bounding box `ext` (also in unit-spherical space).
 
 A point on the sphere lies in the cap iff its Euclidean (chord) distance to
-the cap's center is at most `2sin(radius/2)`, so this tests whether the box
-comes within that distance of the center — the same comparison as S2's
-`S2Cap::Contains(S2Point)`, which compares squared chord lengths
-(`S1ChordAngle`s), extended to a box by clamping the center into it.  The
-on-sphere contents of the box are a subset of the box, so the test never
-returns a false negative, though it can return `true` for a box that only
-approaches the cap away from the sphere's surface — the safe direction for
-pruning searches over spatial trees built on 3D extents of unit-sphere
-geometry.
+the cap's center is at most ``2 * sin(radius/2)``, so this tests whether the box
+comes within that distance of the center.
+
+This is a fail-safe comparison, so may have false positives but never false negatives.
 """
 function Extents.intersects(cap::SphericalCap, ext::Extents.Extent{(:X, :Y, :Z)})
     c = cap.point

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -113,6 +113,39 @@ function _contains(cap::SphericalCap, point::UnitSphericalPoint)
     spherical_distance(cap.point, point) <= cap.radius
 end
 
+# ## Cap–extent intersection
+
+"""
+    Extents.intersects(cap::SphericalCap, ext::Extents.Extent{(:X, :Y, :Z)})
+    Extents.intersects(ext::Extents.Extent{(:X, :Y, :Z)}, cap::SphericalCap)
+
+Whether `cap` intersects the part of the unit sphere covered by the 3D
+Cartesian bounding box `ext`.
+
+A point on the sphere lies in the cap iff its Euclidean (chord) distance to
+the cap's center is at most `2sin(radius/2)`, so this tests whether the box
+comes within that distance of the center — the same comparison as S2's
+`S2Cap::Contains(S2Point)`, which compares squared chord lengths
+(`S1ChordAngle`s), extended to a box by clamping the center into it.  The
+on-sphere contents of the box are a subset of the box, so the test never
+returns a false negative, though it can return `true` for a box that only
+approaches the cap away from the sphere's surface — the safe direction for
+pruning searches over spatial trees built on 3D extents of unit-sphere
+geometry.
+"""
+function Extents.intersects(cap::SphericalCap, ext::Extents.Extent{(:X, :Y, :Z)})
+    c = cap.point
+    dx = c.x - clamp(c.x, ext.X[1], ext.X[2])
+    dy = c.y - clamp(c.y, ext.Y[1], ext.Y[2])
+    dz = c.z - clamp(c.z, ext.Z[1], ext.Z[2])
+    # the chord radius as S2's `S1ChordAngle(S1Angle)` computes it: accurate
+    # for small radii, where `2 - 2 * radiuslike` cancels to 0
+    chord = 2 * sin(0.5 * min(cap.radius, π))
+    return dx^2 + dy^2 + dz^2 <= chord^2
+end
+Extents.intersects(ext::Extents.Extent{(:X, :Y, :Z)}, cap::SphericalCap) =
+    Extents.intersects(cap, ext)
+
 #Comment by asinghvi: this could be transformed to GO.union
 function _merge(x::SphericalCap, y::SphericalCap)
 

--- a/test/utils/unitspherical.jl
+++ b/test/utils/unitspherical.jl
@@ -3,7 +3,9 @@ using LinearAlgebra
 
 using GeometryOps.UnitSpherical
 
+import GeometryOps as GO
 import GeoInterface as GI
+import Extents
 
 @testset "spherical_distance" begin
     @testset "Basic correctness" begin
@@ -544,4 +546,44 @@ end
     result = spherical_arc_intersection(a7, b7, a8, b8)
     @test result.type == arc_overlap
     @test length(result.points) == 2
+end
+
+@testset "Cap–extent intersection" begin
+    cap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π/4)
+    around_center = Extents.Extent(X = (0.9, 1.1), Y = (-0.1, 0.1), Z = (-0.1, 0.1))
+    antipodal = Extents.Extent(X = (-1.1, -0.9), Y = (-0.1, 0.1), Z = (-0.1, 0.1))
+    @test Extents.intersects(cap, around_center)
+    @test Extents.intersects(around_center, cap)
+    @test !Extents.intersects(cap, antipodal)
+    @test !Extents.intersects(antipodal, cap)
+
+    # Degenerate (point) extents straddling the cap boundary
+    just_inside = UnitSphericalPoint(cos(π/4 - 1e-3), sin(π/4 - 1e-3), 0.0)
+    just_outside = UnitSphericalPoint(cos(π/4 + 1e-3), sin(π/4 + 1e-3), 0.0)
+    @test Extents.intersects(cap, GI.extent(just_inside))
+    @test !Extents.intersects(cap, GI.extent(just_outside))
+
+    # A whole-sphere cap reaches the antipodal box; radii past π clamp to full
+    @test Extents.intersects(SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π), antipodal)
+    @test Extents.intersects(SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 3π/2), antipodal)
+
+    # Tiny radii keep full precision (the chord radius is computed as
+    # `2sin(radius/2)`, not from `radiuslike = cos(radius)`, which rounds
+    # to 1 below radius ≈ 1.5e-8 and would empty the cap)
+    tinycap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 1e-9)
+    @test Extents.intersects(tinycap, GI.extent(UnitSphericalPoint(cos(0.9e-9), sin(0.9e-9), 0.0)))
+    @test !Extents.intersects(tinycap, GI.extent(UnitSphericalPoint(cos(1.1e-9), sin(1.1e-9), 0.0)))
+
+    @testset "Spatial tree pruning against brute force" begin
+        using Random: Xoshiro
+        rng = Xoshiro(1312)
+        points = rand(rng, UnitSphericalPoint{Float64}, 1000)
+        tree = GO.FlexibleRTrees.RTree(GO.FlexibleRTrees.HPR(), points)
+        for radius in (0.05, 0.5, 2.0, π)
+            querycap = SphericalCap(rand(rng, UnitSphericalPoint{Float64}), radius)
+            hits = sort!(GO.SpatialTreeInterface.depth_first_search(
+                Base.Fix1(Extents.intersects, querycap), tree))
+            @test hits == findall(p -> spherical_distance(querycap.point, p) <= querycap.radius, points)
+        end
+    end
 end


### PR DESCRIPTION
Adds `Extents.intersects(::SphericalCap, ::Extents.Extent{(:X, :Y, :Z)})` (plus the flipped argument order), so a cap can be used directly as a query predicate over spatial trees built on 3D extents of unit-sphere geometry:

```julia
points = rand(UnitSphericalPoint{Float64}, 100_000)
tree = GO.FlexibleRTrees.RTree(GO.FlexibleRTrees.HPR(), points)   # GI.extent(p) is a 3D extent
hits = GO.SpatialTreeInterface.depth_first_search(Base.Fix1(Extents.intersects, cap), tree)
```

## How it works, and the S2 correspondence

A point on the sphere lies in a cap iff its Euclidean (chord) distance to the cap center is at most `2sin(radius/2)`. The predicate clamps the cap center into the box and compares squared distance against the squared chord radius — checked against the S2 sources side by side:

- **Comparison structure** is `S2Cap::Contains(S2Point)` (`s2cap.cc`): squared chord distance `(x − y).Norm2()` vs the squared chord radius (`S1ChordAngle::length2()`), extended to a box via the standard clamp. (S2 itself has no cap-vs-3D-AABB predicate — it prunes with `S2Cell`s — so the box part is the one piece without a direct S2 counterpart.)
- **Chord radius** is computed as `2sin(0.5min(radius, π))`, exactly `S1ChordAngle(S1Angle)` (`s1chord_angle.h:339`). The tempting shortcut `2 − 2·radiuslike` (from the stored `cos(radius)`) cancels catastrophically: below `radius ≈ 1.5e-8` (~10 cm on Earth) `cos(radius)` rounds to exactly 1 and the cap would empty out, producing false negatives. There is a regression test for this.

The test is exact for the box as a solid, hence conservative for the on-sphere geometry the box bounds: never a false negative, occasionally `true` for a box that only approaches the cap off the sphere surface — the safe direction for tree pruning.

One deviation from S2, deliberately: S2 precomputes the chord radius at cap construction (`S2Cap` stores an `S1ChordAngle`), while this computes one `sin` per predicate call — `SphericalCap.radiuslike` stays `cos(radius)` because `minimum_bounding_circle` relies on the dot-product form. If the `sin` ever shows up in profiles, storing the squared chord alongside is the follow-up.

## Tests

- Boxes around the center / antipode, both argument orders
- Degenerate (point) extents straddling the cap boundary
- Whole-sphere caps and radii past π (exercises the `min(π, ·)` clamp)
- Tiny-radius regression (`1e-9`) for the chord-precision point above
- R-tree queries with random caps against brute-force `spherical_distance`, radii from 0.05 to π

🤖 Generated with [Claude Code](https://claude.com/claude-code)