### PR TITLE
Hoist loop-invariant `node_extent` calls in `dual_depth_first_search`

### DIFF
--- a/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
+++ b/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
@@ -33,21 +33,27 @@ function dual_depth_first_search(f::F, predicate::P, node1::N1, node2::N2) where
             end
         end
     elseif isleaf(node1) # node2 is not a leaf, node1 is - recurse further into node2
+        # Hoist loop-invariant extents out of the child loops: `node_extent` may be
+        # expensive (e.g. computed from a grid's perimeter points on the fly), and
+        # recomputing it per inner iteration multiplies that cost by the fanout.
+        extent1 = node_extent(node1)
         for child in getchild(node2)
-            if predicate(node_extent(node1), node_extent(child))
+            if predicate(extent1, node_extent(child))
                 @controlflow dual_depth_first_search(f, predicate, node1, child)
             end
         end
     elseif isleaf(node2) # node1 is not a leaf, node2 is - recurse further into node1
+        extent2 = node_extent(node2)
         for child in getchild(node1)
-            if predicate(node_extent(child), node_extent(node2))
+            if predicate(node_extent(child), extent2)
                 @controlflow dual_depth_first_search(f, predicate, child, node2)
             end
         end
     else # neither node is a leaf, recurse into both children
         for child1 in getchild(node1)
+            extent1 = node_extent(child1)
             for child2 in getchild(node2)
-                if predicate(node_extent(child1), node_extent(child2))
+                if predicate(extent1, node_extent(child2))
                     @controlflow dual_depth_first_search(f, predicate, child1, child2)
                 end
             end

--- a/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
+++ b/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
@@ -33,9 +33,7 @@ function dual_depth_first_search(f::F, predicate::P, node1::N1, node2::N2) where
             end
         end
     elseif isleaf(node1) # node2 is not a leaf, node1 is - recurse further into node2
-        # Hoist loop-invariant extents out of the child loops: `node_extent` may be
-        # expensive (e.g. computed from a grid's perimeter points on the fly), and
-        # recomputing it per inner iteration multiplies that cost by the fanout.
+        # Hoist loop-invariant extents out of the child loops
         extent1 = node_extent(node1)
         for child in getchild(node2)
             if predicate(extent1, node_extent(child))


### PR DESCRIPTION
`dual_depth_first_search` evaluated `node_extent` inside its pairwise child loops, so each child's extent was recomputed once per counterpart on the other side — `|C2|`× for the outer child, `|C1|×|C2|` evaluations total per node-pair visit where `|C1| + |C2|` suffice. For trees with *precomputed* extents this is a free array read and nobody notices. For trees that compute `node_extent` on the fly — like ConservativeRegridding's quadtree cursors, which fit a `SphericalCap` (or a 3D box) over a grid block's perimeter points at every call — the recomputation multiplies the dominant cost of the whole traversal by the fanout.

This hoists the loop-invariant extent in each branch:

- leaf × internal (both directions): the leaf's extent moves out of the child loop — 1 evaluation instead of `|children|`;
- internal × internal: `node_extent(child1)` moves out of the inner loop — `|C1|` evaluations instead of `|C1|×|C2|`.

No allocation is introduced, and predicate evaluation order is unchanged, so traversal results are bit-identical.

## Measurements

Dual-tree candidate search between two spherical grids (1,036,800 × 524,288 cells) in ConservativeRegridding, serial, identical candidate sets verified pair-for-pair:

| tree (extent regime) | before | after |
|---|---|---|
| quadtree cursor, SphericalCaps computed per visit | 24.1 s | 19.6 s (**1.23×**) |
| quadtree cursor, 3D boxes computed per visit | 13.5 s | 10.6 s (**1.28×**) |
| `FlexibleRTrees.RTree` (precomputed extents) | 0.23 s | 0.25 s (noise) |
| cached-extent quadtree (precomputed extents) | 0.32 s | 0.33 s (noise) |

A **full** hoist — also buffering the inner side's child extents in a per-visit vector so child2 extents are computed `|C2|` instead of `|C1|×|C2|` times — was measured and rejected: the buffer allocation **doubles** descent time on precomputed-extent trees (0.33 s → 0.62 s on an `RTree` over the same grids), where extents are free reads and the allocation is pure overhead. The allocation-free variant here is a strict improvement or neutral for every tree.

## Tests

`test/utils/SpatialTreeInterface.jl` (FlatNoTree, STRtree — includes dual-DFS self-join checks) and `test/utils/FlexibleRTrees.jl` all pass. No behavioral change to test: same predicate calls in the same order, cached values only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)