### PR TITLE
Add manifold-aware construction to `RTree` and `NaturalIndex`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,10 +56,10 @@ end
 ucfirst(str::String) = string(uppercase(str[1]), str[2:end])
 
 function current_module_from_paths(source_path, relative_path)
+    # `source_path` ends with "src" for everything in the main package, so the
+    # submodule checks must dispatch on `relative_path`, before any src catch-all
     if contains(source_path, "GeometryOpsCore")
         return "GeometryOpsCore"
-    elseif endswith(source_path, "src")
-        return "GeometryOps"
     elseif endswith(source_path, "ext")
         return "Base.get_extension(GeometryOps, :$(splitpath(relative_path)[1]))"
     elseif contains(relative_path, "SpatialTreeInterface")
@@ -68,6 +68,10 @@ function current_module_from_paths(source_path, relative_path)
         return "GeometryOps.LoopStateMachine"
     elseif contains(relative_path, "NaturalIndexing")
         return "GeometryOps.NaturalIndexing"
+    elseif contains(relative_path, "UnitSpherical")
+        return "GeometryOps.UnitSpherical"
+    elseif contains(relative_path, "FlexibleRTrees")
+        return "GeometryOps.FlexibleRTrees"
     else
         return "GeometryOps" # default to GO as a last resort
     end

--- a/docs/src/explanations/manifolds.md
+++ b/docs/src/explanations/manifolds.md
@@ -50,3 +50,71 @@ When GeometryOps sees a geometry, it first checks its CRS to see if it is a geog
 ## Algorithms and manifolds
 
 Algorithms define what operation is performed on the geometry; however, the choice of algorithm can also depend on the manifold.  L'Huilier's algorithm for the area of a polygon is not applicable to the plane, but is applicable to either the sphere or ellipsoid, for example.
+
+## Extents and spatial indexing
+
+The manifold also changes what a bounding box is.  On `Planar()`, the extent of a geometry
+is the coordinate-wise minimum and maximum of its vertices — what `GI.extent` returns — and
+it contains the whole geometry, because straight edges stay inside the box around their
+endpoints.  On the sphere, the lon/lat box of the vertices under-covers in two ways:
+
+- Edges are great-circle arcs, which bulge away from the chord between their endpoints.
+  An arc between two points at latitude 60° runs poleward of the 60° parallel, leaving
+  the box around its vertices.
+- A ring can enclose a pole without touching it.  A cell whose vertices all sit at
+  latitude 80° contains the pole and every longitude, and no union of per-edge boxes
+  will discover that.
+
+(Longitude also wraps at the antimeridian, so for a geometry crossing it the lon/lat
+box isn't even well defined without splitting or special-casing.)
+
+`Extents.extent(m::Manifold, geom)` computes extents *on the manifold*.  On `Planar()`
+it is `GI.extent(geom)`.  On `Spherical()` it returns a 3D Cartesian
+`Extent{(:X, :Y, :Z)}`: the box in ℝ³ around the geometry as a region on the unit
+sphere.  Cartesian boxes have no antimeridian or pole singularities, and compose with
+the ordinary `Extents.union` and `Extents.intersects`.  The box covers arc bulge and
+enclosed poles; rings and polygons follow S2's convention of counterclockwise winding
+with the interior on the left, so a clockwise ring is read as enclosing the (huge)
+region outside it.
+
+```@example manifold-extents
+import GeometryOps as GO, GeoInterface as GI
+import Extents
+
+cap = GI.Polygon([[(lon, 80.0) for lon in 0.0:30.0:360.0]])  # a cell around the north pole
+
+GI.extent(cap)   # the lon/lat box of the vertices — can't tell the pole is inside
+```
+
+```@example manifold-extents
+GO.extent(GO.Spherical(), cap)   # the 3D box on the unit sphere — Z reaches 1
+```
+
+Spatial index construction accepts a manifold the same way: `RTree(m::Manifold, algorithm, geoms)`
+and `NaturalIndex(m::Manifold, geoms)` build the tree over each geometry's extent on `m`.
+On `Spherical()` the leaf boxes are the 3D boxes above, and queries work in that space —
+with a 3D extent, or with any predicate over extents, like a `SphericalCap` through
+`Extents.intersects`:
+
+```@example manifold-extents
+import GeometryOps.FlexibleRTrees: RTree, HPR
+import GeometryOps.SpatialTreeInterface as STI
+using GeometryOps.UnitSpherical: SphericalCap, UnitSphericalPoint
+
+# 12 cells in a band from latitude 60° to 80°, plus the polar cap above them
+band = [GI.Polygon([[(lon, 60.0), (lon + 30.0, 60.0), (lon + 30.0, 80.0), (lon, 80.0), (lon, 60.0)]])
+        for lon in 0.0:30.0:330.0]
+tree = RTree(GO.Spherical(), HPR(), vcat(band, [cap]))
+
+polecap = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), 0.05)  # 0.05 rad around the pole
+STI.query(tree, Base.Fix1(Extents.intersects, polecap))
+```
+
+Only geometry 13 — the polar cap — is returned: the band cells' boxes stop short of the
+pole even though their vertices reach latitude 80°, so the tree prunes them.
+
+The one thing to keep straight is that a tree and its queries must live on the same
+manifold.  `GI.extent(geom)` of a geographic geometry is a lon/lat box; handed to a
+spherical tree, `Extents.intersects` will happily compare its `X` (longitude, up to 180)
+against the tree's `X` (a Cartesian coordinate, up to 1) and return nonsense.  Convert
+the query the same way the tree was built: `Extents.extent(Spherical(), geom)`.

--- a/src/utils/FlexibleRTrees/FlexibleRTrees.jl
+++ b/src/utils/FlexibleRTrees/FlexibleRTrees.jl
@@ -34,6 +34,8 @@ import GeoInterface as GI
 import Extents
 using StaticArrays: MVector
 
+import ..GeometryOps: Manifold
+
 export RTree, BulkLoadAlgorithm, STR, HPR, Unsorted, query
 
 include("types.jl")         # `BulkLoadAlgorithm`s and the `RTree` type

--- a/src/utils/FlexibleRTrees/types.jl
+++ b/src/utils/FlexibleRTrees/types.jl
@@ -72,6 +72,17 @@ function RTree(algorithm::A, data; nodecapacity::Int = 16) where A <: BulkLoadAl
     return RTree{A, E}(algorithm, nodecapacity, total, levels, perm)
 end
 
+"""
+    RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity = 16)
+
+Build the tree over each element's extent *on the manifold `m`*, via
+`Extents.extent(m, x)`.  On `Spherical()` the leaves are the 3D Cartesian
+boxes of the elements as regions on the unit sphere, covering the arc bulge
+and enclosed poles that vertex extents miss.
+"""
+RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity::Int = 16) =
+    RTree(algorithm, [Extents.extent(m, x) for x in data]; nodecapacity)
+
 Extents.extent(tree::RTree) = tree.extent
 
 function Base.show(io::IO, tree::RTree{A}) where A

--- a/src/utils/NaturalIndexing.jl
+++ b/src/utils/NaturalIndexing.jl
@@ -60,6 +60,16 @@ function NaturalIndex(last_level_extents::Vector{E}; nodecapacity = 32) where E 
     return NaturalIndex{E}(last_level_extents; nodecapacity = nodecapacity)
 end
 
+"""
+    NaturalIndex(m::Manifold, geoms; nodecapacity = 32)
+
+Index each geometry's extent *on the manifold `m`*, via
+`Extents.extent(m, geom)`.  On `Spherical()` the leaf extents are the 3D
+Cartesian boxes of the geometries as regions on the unit sphere.
+"""
+NaturalIndex(m::GO.Manifold, geoms; nodecapacity = 32) =
+    NaturalIndex([Extents.extent(m, g) for g in geoms]; nodecapacity)
+
 function NaturalIndex{E}(geoms; nodecapacity = 32) where E <: Extents.Extent
     # If passed a vector of geometries, and we know the type of the extent,
     # then simply retrieve the extents so they can serve as the "last-level" 

--- a/test/utils/FlexibleRTrees.jl
+++ b/test/utils/FlexibleRTrees.jl
@@ -6,6 +6,7 @@ import GeometryOps.FlexibleRTrees as FRT
 import GeometryOps.FlexibleRTrees: RTree, STR, HPR, Unsorted, query, hilbert_key
 import GeometryOps.SpatialTreeInterface as STI
 import Extents
+using GeometryOps.UnitSpherical: UnitSphericalPoint, SphericalCap
 using Random: Xoshiro
 
 # Random boxes with side lengths ~5% of the unit cube, in N dims.
@@ -83,4 +84,37 @@ end
         path = cells[sortperm(keys)]
         @test all(sum(abs.(path[i + 1] .- path[i])) == 1 for i in 1:(length(path) - 1))
     end
+end
+
+@testset "Manifold-aware construction" begin
+    band = [GI.Polygon([[(lon, 60.0), (lon + 30.0, 60.0), (lon + 30.0, 80.0), (lon, 80.0), (lon, 60.0)]])
+            for lon in 0.0:30.0:330.0]
+    cap = GI.Polygon([[(lon, 80.0) for lon in 0.0:30.0:360.0]])  # around the north pole
+    geoms = vcat(band, [cap])
+
+    tree = RTree(GO.Spherical(), HPR(), geoms)
+    @test Extents.extent(tree) isa Extents.Extent{(:X, :Y, :Z)}
+
+    # only the cap's region reaches the pole; every vertex stops at lat 80
+    pole_box = Extents.Extent(X = (-0.01, 0.01), Y = (-0.01, 0.01), Z = (0.99, 1.0))
+    @test query(tree, pole_box) == [13]
+
+    # a SphericalCap query against the 3D leaf boxes, end to end
+    polecap = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), 0.05)
+    @test STI.query(tree, Base.Fix1(Extents.intersects, polecap)) == [13]
+
+    ni = GO.NaturalIndexing.NaturalIndex(GO.Spherical(), geoms)
+    @test Extents.extent(ni) isa Extents.Extent{(:X, :Y, :Z)}
+    @test STI.query(ni, pole_box) == [13]
+
+    # a ring of UnitSphericalPoints needs no geographic conversion
+    z = 0.9; s = sqrt(1 - z^2)
+    usp_ring = GI.LinearRing([UnitSphericalPoint(s * cos(t), s * sin(t), z)
+                              for t in range(0, 2π; length = 9)[1:8]])
+    @test query(RTree(GO.Spherical(), STR(), [usp_ring]), pole_box) == [1]
+
+    # Planar() matches the manifold-less constructors
+    pt = RTree(GO.Planar(), HPR(), band)
+    t = RTree(HPR(), band)
+    @test pt.levels == t.levels && pt.indices == t.indices
 end


### PR DESCRIPTION
Stacked on #434 (the base branch is `spherical-arc-extent`); will be rebased and retargeted to `main` once that merges.

## What this does

`RTree` and `NaturalIndex` already accept a vector of extents, so making them manifold-aware is one delegating method each:

```julia
RTree(m::Manifold, algorithm, data; nodecapacity = 16)
NaturalIndex(m::Manifold, geoms; nodecapacity = 32)
```

Each maps its elements through `Extents.extent(m, x)` (from #434) and calls the existing extent-vector constructor. On `Spherical()` the leaf boxes are the 3D Cartesian boxes of the elements as regions on the unit sphere — covering the arc bulge and enclosed poles that the default `GI.extent` vertex boxes miss. Leaf indices still map back to positions in the input collection.

This closes the loop with #432's `Extents.intersects(::SphericalCap, ::Extent{(:X, :Y, :Z)})`:

```julia
band = [GI.Polygon([[(lon, 60.0), (lon + 30.0, 60.0), (lon + 30.0, 80.0), (lon, 80.0), (lon, 60.0)]])
        for lon in 0.0:30.0:330.0]
cap  = GI.Polygon([[(lon, 80.0) for lon in 0.0:30.0:360.0]])   # a cell around the north pole
tree = RTree(GO.Spherical(), HPR(), vcat(band, [cap]))

polecap = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), 0.05)
STI.query(tree, Base.Fix1(Extents.intersects, polecap))        # == [13]: the cap, and only the cap
```

The query side is deliberately **not** manifold-overloaded: a query has to be in the space the tree was built in, and a hypothetical `query(tree, geographic_geom)` convenience would go through `GI.extent` and silently compare a lon/lat box against XYZ boxes over the shared `X`/`Y` keys. Convert explicitly — `GO.extent(GO.Spherical(), geom)` — as the docs now spell out.

## Docs

- New **"Extents and spatial indexing"** section in the manifolds explanation: why vertex boxes under-cover on the sphere, what `Extents.extent(m::Manifold, geom)` returns, the manifold-aware tree constructors, and the same-manifold caveat — with executable `@example` blocks.
- Fixed `current_module_from_paths` in `docs/make.jl`: the `endswith(source_path, "src")` branch matched every main-package file before the `relative_path` checks were reached, so the existing `SpatialTreeInterface`/`LoopStateMachine`/`NaturalIndexing` mappings were dead code and every submodule source page rendered with `CurrentModule = GeometryOps` (which also broke `@docs circumcenter_on_unit_sphere`, an unexported name). Now dispatches on `relative_path` first, with new `UnitSpherical` and `FlexibleRTrees` entries.

## Tests

New "Manifold-aware construction" testset in `test/utils/FlexibleRTrees.jl`: spherical trees carry 3D extents; a pole box and a `SphericalCap` query (through `SpatialTreeInterface.query`) each return exactly the polar-cap cell out of 13 geometries; `NaturalIndex(Spherical(), ...)` agrees; rings already made of `UnitSphericalPoint`s index without geographic conversion; `Planar()` construction is identical to the manifold-less constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
