### PR TITLE
Add a fast WKB polygon codec to GeometryOpsTestHelpers

### DIFF
--- a/GeometryOpsTestHelpers/src/GeometryOpsTestHelpers.jl
+++ b/GeometryOpsTestHelpers/src/GeometryOpsTestHelpers.jl
@@ -6,6 +6,8 @@ using Test
 
 export @test_implementations, @testset_implementations
 
+include("wkb.jl")
+
 # List of test modules - will be populated when extensions load
 # GeoInterface is always available as it's a regular dependency
 const TEST_MODULES = Module[GeoInterface]

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -1,0 +1,264 @@
+# # Fast WKB codec for polygonal geometry
+export parse_wkb, write_wkb
+
+#=
+## What is this?
+
+A dependency-light, single-pass reader and writer for **Well-Known Binary (WKB)**
+restricted to polygonal geometry (`Polygon` and `MultiPolygon`).  It exists to move
+geometry in and out of C libraries (s2geography's C API, LibGEOS) as `geoarrow.wkb`
+(standard ISO WKB) during differential-validation testing, without pulling in a full
+WKB stack.
+
+* [`parse_wkb`](@ref) reads a byte buffer and returns a `GI.Polygon` or `GI.MultiPolygon`
+  whose rings are `Vector{Tuple{Float64,Float64}}` — the same nested-tuple representation
+  `GO.tuples` produces, so results compare `==` coordinate-exact against it.
+* [`write_wkb`](@ref) serializes any GeoInterface `PolygonTrait`/`MultiPolygonTrait`
+  geometry to little-endian ISO WKB.
+
+Parsing is the hot path (results come back from C as WKB), so the reader is a single
+pass over the buffer using pointer loads — no `IOBuffer`, no per-value `read`, no
+intermediate geometry objects.  Every count is validated against the remaining buffer
+length *before* any allocation, so a truncated or hostile buffer throws a clean error
+instead of segfaulting or OOMing on a giant preallocation.
+
+## WKB layout (ISO)
+
+Each geometry is: a **byte-order** byte (`0x00` big-endian/XDR, `0x01` little-endian/NDR),
+a `UInt32` **type code**, then a type-specific payload.  A `MultiPolygon` payload is a
+`UInt32` count followed by full sub-geometries — **each carrying its own byte-order byte
+and type code**, so mixed endianness within one buffer is legal and handled.
+
+Dimensionality is detected two ways and rejected (2D only): ISO codes (`type + 1000` Z,
+`+ 2000` M, `+ 3000` ZM) and EWKB high-bit flags (`0x80000000` Z, `0x40000000` M).  The
+EWKB SRID flag (`0x20000000`) is accepted and its 4-byte SRID skipped.
+=#
+
+import GeoInterface as GI
+
+# Concrete geometry types.  These match exactly what `GO.tuples` returns for 2D
+# polygonal geometry, so `parse_wkb(...) == GO.tuples(geom)` holds structurally.
+# Building them through the inner constructors (rather than the public `GI.Polygon`
+# etc.) skips validation and, crucially, works for empty rings/polygons/multipolygons
+# (the public constructors call `first(geom)` and throw on empty input).
+const _WKBRing  = Vector{Tuple{Float64,Float64}}
+const _WKBLinRing = GI.LinearRing{false,false,_WKBRing,Nothing,Nothing}
+const _WKBRings = Vector{_WKBLinRing}
+const _WKBPoly  = GI.Polygon{false,false,_WKBRings,Nothing,Nothing}
+const _WKBPolys = Vector{_WKBPoly}
+const _WKBMPoly = GI.MultiPolygon{false,false,_WKBPolys,Nothing,Nothing}
+
+@inline _wkb_linearring(coords::_WKBRing) = _WKBLinRing(coords, nothing, nothing)
+@inline _wkb_polygon(rings::_WKBRings) = _WKBPoly(rings, nothing, nothing)
+@inline _wkb_multipolygon(polys::_WKBPolys) = _WKBMPoly(polys, nothing, nothing)
+
+# WKB integer type codes -> human names, for error messages.
+function _wkb_type_name(code::Integer)
+    code == 1 ? "Point" :
+    code == 2 ? "LineString" :
+    code == 3 ? "Polygon" :
+    code == 4 ? "MultiPoint" :
+    code == 5 ? "MultiLineString" :
+    code == 6 ? "MultiPolygon" :
+    code == 7 ? "GeometryCollection" :
+    "unknown"
+end
+
+# Cold error paths, kept out of the hot loop.
+@noinline _wkb_truncated(need, have) =
+    throw(ArgumentError("Truncated WKB buffer: need $(need) more byte(s) but only $(have) remain"))
+@noinline _wkb_bad_order(b) =
+    throw(ArgumentError("Invalid WKB byte-order flag $(Int(b)); expected 0 (big-endian) or 1 (little-endian)"))
+@noinline _wkb_zm(rawtype) =
+    throw(ArgumentError("parse_wkb supports 2D geometries only, but WKB type code $(Int(rawtype)) declares Z and/or M coordinates"))
+@noinline _wkb_unsupported(code) =
+    throw(ArgumentError("parse_wkb only supports Polygon (3) and MultiPolygon (6); found WKB type $(code) ($(_wkb_type_name(code)))"))
+@noinline _wkb_mp_child(code) =
+    throw(ArgumentError("A MultiPolygon element must be a Polygon (3), but found WKB type $(code) ($(_wkb_type_name(code)))"))
+
+# ## Low-level reads.
+# `p0` points at byte 1; `pos` is a 0-based byte offset; `n` is the buffer length.
+# `ltoh`/`ntoh` make endianness host-independent: little-endian data goes through
+# `ltoh`, big-endian through `ntoh`, each a no-op or `bswap` depending on host.
+
+@inline function _read_u8(p0::Ptr{UInt8}, pos::Int, n::Int)
+    pos + 1 <= n || _wkb_truncated(1, n - pos)
+    return unsafe_load(p0 + pos), pos + 1
+end
+
+@inline function _read_u32(p0::Ptr{UInt8}, pos::Int, n::Int, le::Bool)
+    pos + 4 <= n || _wkb_truncated(4, n - pos)
+    v = unsafe_load(Ptr{UInt32}(p0 + pos))
+    return (le ? ltoh(v) : ntoh(v)), pos + 4
+end
+
+# No bounds check here: callers validate the whole run of coordinates up front.
+@inline function _read_f64(p0::Ptr{UInt8}, pos::Int, le::Bool)
+    u = unsafe_load(Ptr{UInt64}(p0 + pos))
+    return reinterpret(Float64, le ? ltoh(u) : ntoh(u)), pos + 8
+end
+
+# Read a geometry header (byte order + type + optional SRID); return `(geomcode, le, pos)`.
+@inline function _read_header(p0::Ptr{UInt8}, pos::Int, n::Int)
+    order, pos = _read_u8(p0, pos, n)
+    le = order == 0x01 ? true : order == 0x00 ? false : _wkb_bad_order(order)
+    rawtype, pos = _read_u32(p0, pos, n, le)
+    has_z    = (rawtype & 0x80000000) != 0
+    has_m    = (rawtype & 0x40000000) != 0
+    has_srid = (rawtype & 0x20000000) != 0
+    base = rawtype & 0x1fffffff          # strip the three EWKB flag bits
+    isodim  = base ÷ UInt32(1000)        # ISO Z/M encoding lives in the thousands digit
+    geomcode = base % UInt32(1000)
+    (has_z || has_m || isodim != 0) && _wkb_zm(rawtype)
+    if has_srid
+        _, pos = _read_u32(p0, pos, n, le)   # accept and discard the 4-byte SRID
+    end
+    return Int(geomcode), le, pos
+end
+
+# Parse a Polygon body (header already consumed); return `(polygon, pos)`.
+@inline function _read_polygon_body(p0::Ptr{UInt8}, pos::Int, n::Int, le::Bool)
+    nrings32, pos = _read_u32(p0, pos, n, le)
+    nrings = Int(nrings32)
+    # Each ring is at least its own 4-byte point count; bound the allocation first.
+    Int64(pos) + Int64(nrings) * 4 <= n || _wkb_truncated(nrings * 4, n - pos)
+    rings = Vector{_WKBLinRing}(undef, nrings)
+    @inbounds for r in 1:nrings
+        npts32, pos = _read_u32(p0, pos, n, le)
+        npts = Int(npts32)
+        need = Int64(npts) * 16
+        Int64(pos) + need <= n || _wkb_truncated(need, n - pos)
+        coords = Vector{Tuple{Float64,Float64}}(undef, npts)
+        for i in 1:npts
+            x, pos = _read_f64(p0, pos, le)
+            y, pos = _read_f64(p0, pos, le)
+            coords[i] = (x, y)
+        end
+        rings[r] = _wkb_linearring(coords)
+    end
+    return _wkb_polygon(rings), pos
+end
+
+# Parse a MultiPolygon body (header already consumed); return `(multipolygon, pos)`.
+@inline function _read_multipolygon_body(p0::Ptr{UInt8}, pos::Int, n::Int, le::Bool)
+    ngeoms32, pos = _read_u32(p0, pos, n, le)
+    ngeoms = Int(ngeoms32)
+    # Each sub-polygon is at least order(1) + type(4) + nrings(4) = 9 bytes.
+    Int64(pos) + Int64(ngeoms) * 9 <= n || _wkb_truncated(ngeoms * 9, n - pos)
+    polys = Vector{_WKBPoly}(undef, ngeoms)
+    @inbounds for g in 1:ngeoms
+        geomcode, le2, pos = _read_header(p0, pos, n)   # per-element byte order + type
+        geomcode == 3 || _wkb_mp_child(geomcode)
+        poly, pos = _read_polygon_body(p0, pos, n, le2)
+        polys[g] = poly
+    end
+    return _wkb_multipolygon(polys), pos
+end
+
+"""
+    parse_wkb(bytes::AbstractVector{UInt8})
+
+Parse ISO/EWKB Well-Known Binary into a `GI.Polygon` or `GI.MultiPolygon` whose rings
+are `Vector{Tuple{Float64,Float64}}` (the `GO.tuples` representation).
+
+Only 2D `Polygon` (type 3) and `MultiPolygon` (type 6) are supported, including empty
+ones.  Big-endian and little-endian buffers are both handled, as is mixed endianness
+across the sub-geometries of a `MultiPolygon`.  The EWKB SRID flag is accepted and the
+SRID ignored; any Z/M dimension (ISO or EWKB flavor) throws.  Malformed or truncated
+buffers throw an `ArgumentError` rather than crashing.
+"""
+function parse_wkb(bytes::AbstractVector{UInt8})
+    n = length(bytes)
+    GC.@preserve bytes begin
+        p0 = pointer(bytes)
+        geomcode, le, pos = _read_header(p0, 0, n)
+        if geomcode == 3
+            poly, _ = _read_polygon_body(p0, pos, n, le)
+            return poly
+        elseif geomcode == 6
+            mp, _ = _read_multipolygon_body(p0, pos, n, le)
+            return mp
+        else
+            _wkb_unsupported(geomcode)
+        end
+    end
+end
+
+# ## Writing.
+# Little-endian ISO WKB.  `htol` maps host order to little-endian (a no-op or `bswap`).
+
+@inline function _put_u8!(p0::Ptr{UInt8}, pos::Int, v::UInt8)
+    unsafe_store!(p0 + pos, v)
+    return pos + 1
+end
+@inline function _put_u32!(p0::Ptr{UInt8}, pos::Int, v::UInt32)
+    unsafe_store!(Ptr{UInt32}(p0 + pos), htol(v))
+    return pos + 4
+end
+@inline function _put_f64!(p0::Ptr{UInt8}, pos::Int, v::Float64)
+    unsafe_store!(Ptr{UInt64}(p0 + pos), htol(reinterpret(UInt64, v)))
+    return pos + 8
+end
+
+# Byte size of a Polygon / MultiPolygon in little-endian ISO WKB.
+function _polygon_wkb_size(poly)
+    sz = 1 + 4 + 4                       # order + type + ring count
+    for ring in GI.getgeom(poly)
+        sz += 4 + Int(GI.npoint(ring)) * 16
+    end
+    return sz
+end
+function _multipolygon_wkb_size(mp)
+    sz = 1 + 4 + 4                       # order + type + polygon count
+    for poly in GI.getgeom(mp)
+        sz += _polygon_wkb_size(poly)
+    end
+    return sz
+end
+
+function _write_polygon!(p0::Ptr{UInt8}, pos::Int, poly)
+    pos = _put_u8!(p0, pos, 0x01)                     # little-endian
+    pos = _put_u32!(p0, pos, UInt32(3))               # Polygon
+    pos = _put_u32!(p0, pos, UInt32(GI.ngeom(poly)))
+    for ring in GI.getgeom(poly)
+        pos = _put_u32!(p0, pos, UInt32(GI.npoint(ring)))
+        for pt in GI.getpoint(ring)
+            pos = _put_f64!(p0, pos, Float64(GI.x(pt)))
+            pos = _put_f64!(p0, pos, Float64(GI.y(pt)))
+        end
+    end
+    return pos
+end
+
+function _write_multipolygon!(p0::Ptr{UInt8}, pos::Int, mp)
+    pos = _put_u8!(p0, pos, 0x01)                     # little-endian
+    pos = _put_u32!(p0, pos, UInt32(6))               # MultiPolygon
+    pos = _put_u32!(p0, pos, UInt32(GI.ngeom(mp)))
+    for poly in GI.getgeom(mp)
+        pos = _write_polygon!(p0, pos, poly)
+    end
+    return pos
+end
+
+"""
+    write_wkb(geom)::Vector{UInt8}
+
+Serialize a 2D GeoInterface `PolygonTrait` or `MultiPolygonTrait` geometry to
+little-endian ISO WKB (type 3 / 6).  Doubles are written bit-for-bit; the output buffer
+is preallocated from an exact size computation.  Throws `ArgumentError` for any other
+geometry.
+"""
+function write_wkb(geom)
+    t = GI.trait(geom)
+    if t isa GI.PolygonTrait
+        out = Vector{UInt8}(undef, _polygon_wkb_size(geom))
+        GC.@preserve out _write_polygon!(pointer(out), 0, geom)
+        return out
+    elseif t isa GI.MultiPolygonTrait
+        out = Vector{UInt8}(undef, _multipolygon_wkb_size(geom))
+        GC.@preserve out _write_multipolygon!(pointer(out), 0, geom)
+        return out
+    else
+        throw(ArgumentError("write_wkb only supports Polygon and MultiPolygon geometries, got trait $(t)"))
+    end
+end

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -137,18 +137,25 @@ end
     return Int(geomcode), le, pos
 end
 
+# Reject a run of `count` items of `stride` bytes before anything is allocated for it.
+# Counts arrive as `UInt32`, so `count * stride` stays under 2^36: on the 64-bit `Int` this
+# codec assumes, neither it nor `pos + need` can overflow.
+@inline function _check_run(pos::Int, n::Int, count::Int, stride::Int)
+    need = count * stride
+    pos + need <= n || throw(WKBTruncatedError(need, n - pos))
+    return nothing
+end
+
 # Parse a Polygon body (header already consumed); return `(polygon, pos)`.
 @inline function _read_polygon_body(bytes, pos::Int, n::Int, le::Bool)
     nrings32, pos = _read_u32(bytes, pos, n, le)
     nrings = Int(nrings32)
-    # Each ring is at least its own 4-byte point count; bound the allocation first.
-    Int64(pos) + Int64(nrings) * 4 <= n || throw(WKBTruncatedError(nrings * 4, n - pos))
+    _check_run(pos, n, nrings, 4)      # each ring is at least its own 4-byte point count
     rings = Vector{_WKBLinearRing}(undef, nrings)
     @inbounds for r in 1:nrings
         npts32, pos = _read_u32(bytes, pos, n, le)
         npts = Int(npts32)
-        need = Int64(npts) * 16
-        Int64(pos) + need <= n || throw(WKBTruncatedError(need, n - pos))
+        _check_run(pos, n, npts, 16)   # two `Float64`s per point
         coords = Vector{Tuple{Float64,Float64}}(undef, npts)
         for i in 1:npts
             x, pos = _read_f64(bytes, pos, le)
@@ -164,8 +171,7 @@ end
 @inline function _read_multipolygon_body(bytes, pos::Int, n::Int, le::Bool)
     ngeoms32, pos = _read_u32(bytes, pos, n, le)
     ngeoms = Int(ngeoms32)
-    # Each sub-polygon is at least order(1) + type(4) + nrings(4) = 9 bytes.
-    Int64(pos) + Int64(ngeoms) * 9 <= n || throw(WKBTruncatedError(ngeoms * 9, n - pos))
+    _check_run(pos, n, ngeoms, 9)      # order(1) + type(4) + nrings(4) per sub-polygon
     polys = Vector{_WKBPolygon}(undef, ngeoms)
     @inbounds for g in 1:ngeoms
         geomcode, le2, pos = _read_header(bytes, pos, n)   # per-element byte order + type

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -102,31 +102,35 @@ Base.showerror(io::IO, e::WKBMultiPolygonElementError) = print(io,
 @noinline _wkb_mp_child(code) = throw(WKBMultiPolygonElementError(code))
 
 # ## Low-level reads
-# `p0` points at byte 1, `pos` is a 0-based offset from it, `n` is the buffer length.
-# `ltoh`/`ntoh` decode little-/big-endian data on either host.
+# `pos` is a 0-based offset into `bytes`, `n` is the buffer length.  Values are assembled
+# little-endian-first and `bswap`ped for big-endian input, so decoding is host-independent.
 
-@inline function _read_u8(p0::Ptr{UInt8}, pos::Int, n::Int)
+@inline function _read_u8(bytes, pos::Int, n::Int)
     pos + 1 <= n || _wkb_truncated(1, n - pos)
-    return unsafe_load(p0 + pos), pos + 1
+    return @inbounds(bytes[pos+1]), pos + 1
 end
 
-@inline function _read_u32(p0::Ptr{UInt8}, pos::Int, n::Int, le::Bool)
+@inline function _read_u32(bytes, pos::Int, n::Int, le::Bool)
     pos + 4 <= n || _wkb_truncated(4, n - pos)
-    v = unsafe_load(Ptr{UInt32}(p0 + pos))
-    return (le ? ltoh(v) : ntoh(v)), pos + 4
+    v = @inbounds(UInt32(bytes[pos+1])       | UInt32(bytes[pos+2]) << 8 |
+                  UInt32(bytes[pos+3]) << 16 | UInt32(bytes[pos+4]) << 24)
+    return (le ? v : bswap(v)), pos + 4
 end
 
 # No bounds check here: callers validate the whole run of coordinates up front.
-@inline function _read_f64(p0::Ptr{UInt8}, pos::Int, le::Bool)
-    u = unsafe_load(Ptr{UInt64}(p0 + pos))
-    return reinterpret(Float64, le ? ltoh(u) : ntoh(u)), pos + 8
+@inline function _read_f64(bytes, pos::Int, le::Bool)
+    u = @inbounds(UInt64(bytes[pos+1])       | UInt64(bytes[pos+2]) << 8  |
+                  UInt64(bytes[pos+3]) << 16 | UInt64(bytes[pos+4]) << 24 |
+                  UInt64(bytes[pos+5]) << 32 | UInt64(bytes[pos+6]) << 40 |
+                  UInt64(bytes[pos+7]) << 48 | UInt64(bytes[pos+8]) << 56)
+    return reinterpret(Float64, le ? u : bswap(u)), pos + 8
 end
 
 # Read a geometry header (byte order + type + optional SRID); return `(geomcode, le, pos)`.
-@inline function _read_header(p0::Ptr{UInt8}, pos::Int, n::Int)
-    order, pos = _read_u8(p0, pos, n)
+@inline function _read_header(bytes, pos::Int, n::Int)
+    order, pos = _read_u8(bytes, pos, n)
     le = order == 0x01 ? true : order == 0x00 ? false : _wkb_bad_order(order)
-    rawtype, pos = _read_u32(p0, pos, n, le)
+    rawtype, pos = _read_u32(bytes, pos, n, le)
     has_z    = (rawtype & 0x80000000) != 0
     has_m    = (rawtype & 0x40000000) != 0
     has_srid = (rawtype & 0x20000000) != 0
@@ -135,27 +139,27 @@ end
     geomcode = base % UInt32(1000)
     (has_z || has_m || isodim != 0) && _wkb_zm(rawtype)
     if has_srid
-        _, pos = _read_u32(p0, pos, n, le)   # accept and discard the 4-byte SRID
+        _, pos = _read_u32(bytes, pos, n, le)   # accept and discard the 4-byte SRID
     end
     return Int(geomcode), le, pos
 end
 
 # Parse a Polygon body (header already consumed); return `(polygon, pos)`.
-@inline function _read_polygon_body(p0::Ptr{UInt8}, pos::Int, n::Int, le::Bool)
-    nrings32, pos = _read_u32(p0, pos, n, le)
+@inline function _read_polygon_body(bytes, pos::Int, n::Int, le::Bool)
+    nrings32, pos = _read_u32(bytes, pos, n, le)
     nrings = Int(nrings32)
     # Each ring is at least its own 4-byte point count; bound the allocation first.
     Int64(pos) + Int64(nrings) * 4 <= n || _wkb_truncated(nrings * 4, n - pos)
     rings = Vector{_WKBLinearRing}(undef, nrings)
     @inbounds for r in 1:nrings
-        npts32, pos = _read_u32(p0, pos, n, le)
+        npts32, pos = _read_u32(bytes, pos, n, le)
         npts = Int(npts32)
         need = Int64(npts) * 16
         Int64(pos) + need <= n || _wkb_truncated(need, n - pos)
         coords = Vector{Tuple{Float64,Float64}}(undef, npts)
         for i in 1:npts
-            x, pos = _read_f64(p0, pos, le)
-            y, pos = _read_f64(p0, pos, le)
+            x, pos = _read_f64(bytes, pos, le)
+            y, pos = _read_f64(bytes, pos, le)
             coords[i] = (x, y)
         end
         rings[r] = _WKBLinearRing(coords, nothing, nothing)
@@ -164,16 +168,16 @@ end
 end
 
 # Parse a MultiPolygon body (header already consumed); return `(multipolygon, pos)`.
-@inline function _read_multipolygon_body(p0::Ptr{UInt8}, pos::Int, n::Int, le::Bool)
-    ngeoms32, pos = _read_u32(p0, pos, n, le)
+@inline function _read_multipolygon_body(bytes, pos::Int, n::Int, le::Bool)
+    ngeoms32, pos = _read_u32(bytes, pos, n, le)
     ngeoms = Int(ngeoms32)
     # Each sub-polygon is at least order(1) + type(4) + nrings(4) = 9 bytes.
     Int64(pos) + Int64(ngeoms) * 9 <= n || _wkb_truncated(ngeoms * 9, n - pos)
     polys = Vector{_WKBPolygon}(undef, ngeoms)
     @inbounds for g in 1:ngeoms
-        geomcode, le2, pos = _read_header(p0, pos, n)   # per-element byte order + type
+        geomcode, le2, pos = _read_header(bytes, pos, n)   # per-element byte order + type
         geomcode == 3 || _wkb_mp_child(geomcode)
-        poly, pos = _read_polygon_body(p0, pos, n, le2)
+        poly, pos = _read_polygon_body(bytes, pos, n, le2)
         polys[g] = poly
     end
     return _WKBMultiPolygon(polys, nothing, nothing), pos
@@ -190,37 +194,44 @@ ones.  Big-endian and little-endian buffers are both handled, as is mixed endian
 across the sub-geometries of a `MultiPolygon`.  The EWKB SRID flag is accepted and the
 SRID ignored; any Z/M dimension (ISO or EWKB flavor) throws.  Malformed or truncated
 buffers throw a [`WKBParseError`](@ref) rather than crashing.
+
+`bytes` is only ever indexed, so any one-based `AbstractVector{UInt8}` will do.
 """
 function parse_wkb(bytes::AbstractVector{UInt8})
+    Base.require_one_based_indexing(bytes)
     n = length(bytes)
-    GC.@preserve bytes begin
-        p0 = pointer(bytes)
-        geomcode, le, pos = _read_header(p0, 0, n)
-        if geomcode == 3
-            poly, _ = _read_polygon_body(p0, pos, n, le)
-            return poly
-        elseif geomcode == 6
-            mp, _ = _read_multipolygon_body(p0, pos, n, le)
-            return mp
-        else
-            _wkb_unsupported(geomcode)
-        end
+    geomcode, le, pos = _read_header(bytes, 0, n)
+    if geomcode == 3
+        poly, _ = _read_polygon_body(bytes, pos, n, le)
+        return poly
+    elseif geomcode == 6
+        mp, _ = _read_multipolygon_body(bytes, pos, n, le)
+        return mp
+    else
+        _wkb_unsupported(geomcode)
     end
 end
 
 # ## Writing
-# Little-endian ISO WKB, emitted into an exactly-sized preallocated buffer.
+# Little-endian ISO WKB, emitted into an exactly-sized buffer.  Each value goes out as a
+# `reinterpret`ed byte tuple, the one spelling of the stores that LLVM merges into one.
 
-@inline function _put_u8!(p0::Ptr{UInt8}, pos::Int, v::UInt8)
-    unsafe_store!(p0 + pos, v)
+@inline function _put_u8!(out::Vector{UInt8}, pos::Int, v::UInt8)
+    @inbounds out[pos+1] = v
     return pos + 1
 end
-@inline function _put_u32!(p0::Ptr{UInt8}, pos::Int, v::UInt32)
-    unsafe_store!(Ptr{UInt32}(p0 + pos), htol(v))
+@inline function _put_u32!(out::Vector{UInt8}, pos::Int, v::UInt32)
+    t = reinterpret(NTuple{4,UInt8}, htol(v))
+    @inbounds for k in 1:4
+        out[pos+k] = t[k]
+    end
     return pos + 4
 end
-@inline function _put_f64!(p0::Ptr{UInt8}, pos::Int, v::Float64)
-    unsafe_store!(Ptr{UInt64}(p0 + pos), htol(reinterpret(UInt64, v)))
+@inline function _put_f64!(out::Vector{UInt8}, pos::Int, v::Float64)
+    t = reinterpret(NTuple{8,UInt8}, htol(reinterpret(UInt64, v)))
+    @inbounds for k in 1:8
+        out[pos+k] = t[k]
+    end
     return pos + 8
 end
 
@@ -240,26 +251,26 @@ function _multipolygon_wkb_size(mp)
     return sz
 end
 
-function _write_polygon!(p0::Ptr{UInt8}, pos::Int, poly)
-    pos = _put_u8!(p0, pos, 0x01)                     # little-endian
-    pos = _put_u32!(p0, pos, UInt32(3))               # Polygon
-    pos = _put_u32!(p0, pos, UInt32(GI.ngeom(poly)))
+function _write_polygon!(out::Vector{UInt8}, pos::Int, poly)
+    pos = _put_u8!(out, pos, 0x01)                     # little-endian
+    pos = _put_u32!(out, pos, UInt32(3))               # Polygon
+    pos = _put_u32!(out, pos, UInt32(GI.ngeom(poly)))
     for ring in GI.getgeom(poly)
-        pos = _put_u32!(p0, pos, UInt32(GI.npoint(ring)))
+        pos = _put_u32!(out, pos, UInt32(GI.npoint(ring)))
         for pt in GI.getpoint(ring)
-            pos = _put_f64!(p0, pos, Float64(GI.x(pt)))
-            pos = _put_f64!(p0, pos, Float64(GI.y(pt)))
+            pos = _put_f64!(out, pos, Float64(GI.x(pt)))
+            pos = _put_f64!(out, pos, Float64(GI.y(pt)))
         end
     end
     return pos
 end
 
-function _write_multipolygon!(p0::Ptr{UInt8}, pos::Int, mp)
-    pos = _put_u8!(p0, pos, 0x01)                     # little-endian
-    pos = _put_u32!(p0, pos, UInt32(6))               # MultiPolygon
-    pos = _put_u32!(p0, pos, UInt32(GI.ngeom(mp)))
+function _write_multipolygon!(out::Vector{UInt8}, pos::Int, mp)
+    pos = _put_u8!(out, pos, 0x01)                     # little-endian
+    pos = _put_u32!(out, pos, UInt32(6))               # MultiPolygon
+    pos = _put_u32!(out, pos, UInt32(GI.ngeom(mp)))
     for poly in GI.getgeom(mp)
-        pos = _write_polygon!(p0, pos, poly)
+        pos = _write_polygon!(out, pos, poly)
     end
     return pos
 end
@@ -280,10 +291,10 @@ function write_wkb(geom)
         throw(WKBWriteError("only 2D geometries can be written, but this geometry has Z and/or M coordinates"))
     if t isa GI.PolygonTrait
         out = Vector{UInt8}(undef, _polygon_wkb_size(geom))
-        GC.@preserve out _write_polygon!(pointer(out), 0, geom)
+        _write_polygon!(out, 0, geom)
     else
         out = Vector{UInt8}(undef, _multipolygon_wkb_size(geom))
-        GC.@preserve out _write_multipolygon!(pointer(out), 0, geom)
+        _write_multipolygon!(out, 0, geom)
     end
     return out
 end

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -4,43 +4,24 @@ export parse_wkb, write_wkb
 #=
 ## What is this?
 
-A dependency-light, single-pass reader and writer for **Well-Known Binary (WKB)**
-restricted to polygonal geometry (`Polygon` and `MultiPolygon`).  It exists to move
-geometry in and out of C libraries (s2geography's C API, LibGEOS) as `geoarrow.wkb`
-(standard ISO WKB) during differential-validation testing, without pulling in a full
-WKB stack.
-
-* [`parse_wkb`](@ref) reads a byte buffer and returns a `GI.Polygon` or `GI.MultiPolygon`
-  whose rings are `Vector{Tuple{Float64,Float64}}` — the same nested-tuple representation
-  `GO.tuples` produces, so results compare `==` coordinate-exact against it.
-* [`write_wkb`](@ref) serializes any GeoInterface `PolygonTrait`/`MultiPolygonTrait`
-  geometry to little-endian ISO WKB.
-
-Parsing is the hot path (results come back from C as WKB), so the reader is a single
-pass over the buffer using pointer loads — no `IOBuffer`, no per-value `read`, no
-intermediate geometry objects.  Every count is validated against the remaining buffer
-length *before* any allocation, so a truncated or hostile buffer throws a clean error
-instead of segfaulting or OOMing on a giant preallocation.
+A single-pass codec for 2D polygonal **Well-Known Binary**.  [`parse_wkb`](@ref) returns
+a `GI.Polygon`/`GI.MultiPolygon` whose rings are `Vector{Tuple{Float64,Float64}}`, equal
+to `GO.tuples` output; [`write_wkb`](@ref) emits little-endian ISO WKB.
 
 ## WKB layout (ISO)
 
-Each geometry is: a **byte-order** byte (`0x00` big-endian/XDR, `0x01` little-endian/NDR),
-a `UInt32` **type code**, then a type-specific payload.  A `MultiPolygon` payload is a
-`UInt32` count followed by full sub-geometries — **each carrying its own byte-order byte
-and type code**, so mixed endianness within one buffer is legal and handled.
-
-Dimensionality is detected two ways and rejected (2D only): ISO codes (`type + 1000` Z,
-`+ 2000` M, `+ 3000` ZM) and EWKB high-bit flags (`0x80000000` Z, `0x40000000` M).  The
-EWKB SRID flag (`0x20000000`) is accepted and its 4-byte SRID skipped.
+A geometry is a **byte-order** byte (`0x00` big-endian, `0x01` little-endian), a `UInt32`
+**type code**, then a payload.  A `MultiPolygon` payload is a `UInt32` count followed by
+whole sub-geometries, each with its own byte-order byte and type code.  Z/M dimensions are
+encoded either in the ISO type code (`type + 1000` Z, `+ 2000` M, `+ 3000` ZM) or in EWKB
+flag bits (`0x80000000` Z, `0x40000000` M), and are rejected here; the EWKB SRID flag
+(`0x20000000`) is accepted and its 4-byte payload skipped.
 =#
 
 import GeoInterface as GI
 
-# Concrete geometry types.  These match exactly what `GO.tuples` returns for 2D
-# polygonal geometry, so `parse_wkb(...) == GO.tuples(geom)` holds structurally.
-# Building them through the inner constructors (rather than the public `GI.Polygon`
-# etc.) skips validation and, crucially, works for empty rings/polygons/multipolygons
-# (the public constructors call `first(geom)` and throw on empty input).
+# Concrete types matching `GO.tuples` output.  Their inner constructors skip validation
+# and accept empty rings, polygons and multipolygons.
 const _WKBLinearRing = GI.LinearRing{false,false,Vector{Tuple{Float64,Float64}},Nothing,Nothing}
 const _WKBPolygon = GI.Polygon{false,false,Vector{_WKBLinearRing},Nothing,Nothing}
 const _WKBMultiPolygon = GI.MultiPolygon{false,false,Vector{_WKBPolygon},Nothing,Nothing}
@@ -69,10 +50,9 @@ end
 @noinline _wkb_mp_child(code) =
     throw(ArgumentError("A MultiPolygon element must be a Polygon (3), but found WKB type $(code) ($(_wkb_type_name(code)))"))
 
-# ## Low-level reads.
-# `p0` points at byte 1; `pos` is a 0-based byte offset; `n` is the buffer length.
-# `ltoh`/`ntoh` make endianness host-independent: little-endian data goes through
-# `ltoh`, big-endian through `ntoh`, each a no-op or `bswap` depending on host.
+# ## Low-level reads
+# `p0` points at byte 1, `pos` is a 0-based offset from it, `n` is the buffer length.
+# `ltoh`/`ntoh` decode little-/big-endian data on either host.
 
 @inline function _read_u8(p0::Ptr{UInt8}, pos::Int, n::Int)
     pos + 1 <= n || _wkb_truncated(1, n - pos)
@@ -177,8 +157,8 @@ function parse_wkb(bytes::AbstractVector{UInt8})
     end
 end
 
-# ## Writing.
-# Little-endian ISO WKB.  `htol` maps host order to little-endian (a no-op or `bswap`).
+# ## Writing
+# Little-endian ISO WKB, emitted into an exactly-sized preallocated buffer.
 
 @inline function _put_u8!(p0::Ptr{UInt8}, pos::Int, v::UInt8)
     unsafe_store!(p0 + pos, v)

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -1,5 +1,5 @@
 # # Fast WKB codec for polygonal geometry
-export parse_wkb, write_wkb
+export parse_wkb, write_wkb, WKBParseError, WKBWriteError
 
 #=
 ## What is this?
@@ -38,17 +38,68 @@ function _wkb_type_name(code::Integer)
     "unknown"
 end
 
-# Cold error paths, kept out of the hot loop.
-@noinline _wkb_truncated(need, have) =
-    throw(ArgumentError("Truncated WKB buffer: need $(need) more byte(s) but only $(have) remain"))
-@noinline _wkb_bad_order(b) =
-    throw(ArgumentError("Invalid WKB byte-order flag $(Int(b)); expected 0 (big-endian) or 1 (little-endian)"))
-@noinline _wkb_zm(rawtype) =
-    throw(ArgumentError("parse_wkb supports 2D geometries only, but WKB type code $(Int(rawtype)) declares Z and/or M coordinates"))
-@noinline _wkb_unsupported(code) =
-    throw(ArgumentError("parse_wkb only supports Polygon (3) and MultiPolygon (6); found WKB type $(code) ($(_wkb_type_name(code)))"))
-@noinline _wkb_mp_child(code) =
-    throw(ArgumentError("A MultiPolygon element must be a Polygon (3), but found WKB type $(code) ($(_wkb_type_name(code)))"))
+"""
+    abstract type WKBParseError <: Exception
+
+Supertype of every error [`parse_wkb`](@ref) throws on malformed input: `WKBTruncatedError`,
+`WKBByteOrderError`, `WKBDimensionError`, `WKBUnsupportedTypeError`, `WKBMultiPolygonElementError`.
+"""
+abstract type WKBParseError <: Exception end
+
+"""
+    WKBWriteError <: Exception
+
+Error thrown by [`write_wkb`](@ref) for geometry it cannot serialize, i.e. anything that
+is not a 2D `Polygon` or `MultiPolygon`.
+"""
+struct WKBWriteError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, e::WKBWriteError) = print(io, "WKBWriteError: ", e.msg)
+
+# A field runs past the end of the buffer.
+struct WKBTruncatedError <: WKBParseError
+    needed::Int
+    available::Int
+end
+Base.showerror(io::IO, e::WKBTruncatedError) = print(io,
+    "WKBTruncatedError: need $(e.needed) more byte(s) but only $(e.available) remain")
+
+# The byte-order flag is neither 0x00 (big-endian) nor 0x01 (little-endian).
+struct WKBByteOrderError <: WKBParseError
+    flag::UInt8
+end
+Base.showerror(io::IO, e::WKBByteOrderError) = print(io,
+    "WKBByteOrderError: byte-order flag $(Int(e.flag)) is neither 0 (big-endian) nor 1 (little-endian)")
+
+# The type code declares Z and/or M coordinates, in either the ISO or the EWKB encoding.
+struct WKBDimensionError <: WKBParseError
+    rawtype::UInt32
+end
+Base.showerror(io::IO, e::WKBDimensionError) = print(io,
+    "WKBDimensionError: type code $(Int(e.rawtype)) declares Z and/or M coordinates, but only 2D is supported")
+
+# The top-level geometry is neither a Polygon nor a MultiPolygon.
+struct WKBUnsupportedTypeError <: WKBParseError
+    code::Int
+end
+Base.showerror(io::IO, e::WKBUnsupportedTypeError) = print(io,
+    "WKBUnsupportedTypeError: type $(e.code) ($(_wkb_type_name(e.code))) is not Polygon (3) or MultiPolygon (6)")
+
+# A MultiPolygon holds a sub-geometry that is not a Polygon.
+struct WKBMultiPolygonElementError <: WKBParseError
+    code::Int
+end
+Base.showerror(io::IO, e::WKBMultiPolygonElementError) = print(io,
+    "WKBMultiPolygonElementError: a MultiPolygon element must be a Polygon (3), but found type " *
+    "$(e.code) ($(_wkb_type_name(e.code)))")
+
+# Cold throw paths, kept out of the inlined readers.
+@noinline _wkb_truncated(need, have) = throw(WKBTruncatedError(need, have))
+@noinline _wkb_bad_order(b) = throw(WKBByteOrderError(b))
+@noinline _wkb_zm(rawtype) = throw(WKBDimensionError(rawtype))
+@noinline _wkb_unsupported(code) = throw(WKBUnsupportedTypeError(code))
+@noinline _wkb_mp_child(code) = throw(WKBMultiPolygonElementError(code))
 
 # ## Low-level reads
 # `p0` points at byte 1, `pos` is a 0-based offset from it, `n` is the buffer length.
@@ -138,7 +189,7 @@ Only 2D `Polygon` (type 3) and `MultiPolygon` (type 6) are supported, including 
 ones.  Big-endian and little-endian buffers are both handled, as is mixed endianness
 across the sub-geometries of a `MultiPolygon`.  The EWKB SRID flag is accepted and the
 SRID ignored; any Z/M dimension (ISO or EWKB flavor) throws.  Malformed or truncated
-buffers throw an `ArgumentError` rather than crashing.
+buffers throw a [`WKBParseError`](@ref) rather than crashing.
 """
 function parse_wkb(bytes::AbstractVector{UInt8})
     n = length(bytes)
@@ -218,20 +269,21 @@ end
 
 Serialize a 2D GeoInterface `PolygonTrait` or `MultiPolygonTrait` geometry to
 little-endian ISO WKB (type 3 / 6).  Doubles are written bit-for-bit; the output buffer
-is preallocated from an exact size computation.  Throws `ArgumentError` for any other
-geometry.
+is preallocated from an exact size computation.  Any other geometry, and any geometry
+carrying Z or M coordinates, throws a [`WKBWriteError`](@ref).
 """
 function write_wkb(geom)
     t = GI.trait(geom)
+    (t isa GI.PolygonTrait || t isa GI.MultiPolygonTrait) ||
+        throw(WKBWriteError("only Polygon and MultiPolygon geometries can be written, got trait $(t)"))
+    (GI.is3d(geom) || GI.ismeasured(geom)) &&
+        throw(WKBWriteError("only 2D geometries can be written, but this geometry has Z and/or M coordinates"))
     if t isa GI.PolygonTrait
         out = Vector{UInt8}(undef, _polygon_wkb_size(geom))
         GC.@preserve out _write_polygon!(pointer(out), 0, geom)
-        return out
-    elseif t isa GI.MultiPolygonTrait
+    else
         out = Vector{UInt8}(undef, _multipolygon_wkb_size(geom))
         GC.@preserve out _write_multipolygon!(pointer(out), 0, geom)
-        return out
-    else
-        throw(ArgumentError("write_wkb only supports Polygon and MultiPolygon geometries, got trait $(t)"))
     end
+    return out
 end

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -91,27 +91,20 @@ struct WKBMultiPolygonElementError <: WKBParseError
     code::Int
 end
 Base.showerror(io::IO, e::WKBMultiPolygonElementError) = print(io,
-    "WKBMultiPolygonElementError: a MultiPolygon element must be a Polygon (3), but found type " *
+    "WKBMultiPolygonElementError: a MultiPolygon element must be a Polygon (code 3), but found code " *
     "$(e.code) ($(_wkb_type_name(e.code)))")
-
-# Cold throw paths, kept out of the inlined readers.
-@noinline _wkb_truncated(need, have) = throw(WKBTruncatedError(need, have))
-@noinline _wkb_bad_order(b) = throw(WKBByteOrderError(b))
-@noinline _wkb_zm(rawtype) = throw(WKBDimensionError(rawtype))
-@noinline _wkb_unsupported(code) = throw(WKBUnsupportedTypeError(code))
-@noinline _wkb_mp_child(code) = throw(WKBMultiPolygonElementError(code))
 
 # ## Low-level reads
 # `pos` is a 0-based offset into `bytes`, `n` is the buffer length.  Values are assembled
 # little-endian-first and `bswap`ped for big-endian input, so decoding is host-independent.
 
 @inline function _read_u8(bytes, pos::Int, n::Int)
-    pos + 1 <= n || _wkb_truncated(1, n - pos)
+    pos + 1 <= n || throw(WKBTruncatedError(1, n - pos))
     return @inbounds(bytes[pos+1]), pos + 1
 end
 
 @inline function _read_u32(bytes, pos::Int, n::Int, le::Bool)
-    pos + 4 <= n || _wkb_truncated(4, n - pos)
+    pos + 4 <= n || throw(WKBTruncatedError(4, n - pos))
     v = @inbounds(UInt32(bytes[pos+1])       | UInt32(bytes[pos+2]) << 8 |
                   UInt32(bytes[pos+3]) << 16 | UInt32(bytes[pos+4]) << 24)
     return (le ? v : bswap(v)), pos + 4
@@ -129,7 +122,7 @@ end
 # Read a geometry header (byte order + type + optional SRID); return `(geomcode, le, pos)`.
 @inline function _read_header(bytes, pos::Int, n::Int)
     order, pos = _read_u8(bytes, pos, n)
-    le = order == 0x01 ? true : order == 0x00 ? false : _wkb_bad_order(order)
+    le = order == 0x01 ? true : order == 0x00 ? false : throw(WKBByteOrderError(order))
     rawtype, pos = _read_u32(bytes, pos, n, le)
     has_z    = (rawtype & 0x80000000) != 0
     has_m    = (rawtype & 0x40000000) != 0
@@ -137,7 +130,7 @@ end
     base = rawtype & 0x1fffffff          # strip the three EWKB flag bits
     isodim  = base ÷ UInt32(1000)        # ISO Z/M encoding lives in the thousands digit
     geomcode = base % UInt32(1000)
-    (has_z || has_m || isodim != 0) && _wkb_zm(rawtype)
+    (has_z || has_m || isodim != 0) && throw(WKBDimensionError(rawtype))
     if has_srid
         _, pos = _read_u32(bytes, pos, n, le)   # accept and discard the 4-byte SRID
     end
@@ -149,13 +142,13 @@ end
     nrings32, pos = _read_u32(bytes, pos, n, le)
     nrings = Int(nrings32)
     # Each ring is at least its own 4-byte point count; bound the allocation first.
-    Int64(pos) + Int64(nrings) * 4 <= n || _wkb_truncated(nrings * 4, n - pos)
+    Int64(pos) + Int64(nrings) * 4 <= n || throw(WKBTruncatedError(nrings * 4, n - pos))
     rings = Vector{_WKBLinearRing}(undef, nrings)
     @inbounds for r in 1:nrings
         npts32, pos = _read_u32(bytes, pos, n, le)
         npts = Int(npts32)
         need = Int64(npts) * 16
-        Int64(pos) + need <= n || _wkb_truncated(need, n - pos)
+        Int64(pos) + need <= n || throw(WKBTruncatedError(need, n - pos))
         coords = Vector{Tuple{Float64,Float64}}(undef, npts)
         for i in 1:npts
             x, pos = _read_f64(bytes, pos, le)
@@ -172,11 +165,11 @@ end
     ngeoms32, pos = _read_u32(bytes, pos, n, le)
     ngeoms = Int(ngeoms32)
     # Each sub-polygon is at least order(1) + type(4) + nrings(4) = 9 bytes.
-    Int64(pos) + Int64(ngeoms) * 9 <= n || _wkb_truncated(ngeoms * 9, n - pos)
+    Int64(pos) + Int64(ngeoms) * 9 <= n || throw(WKBTruncatedError(ngeoms * 9, n - pos))
     polys = Vector{_WKBPolygon}(undef, ngeoms)
     @inbounds for g in 1:ngeoms
         geomcode, le2, pos = _read_header(bytes, pos, n)   # per-element byte order + type
-        geomcode == 3 || _wkb_mp_child(geomcode)
+        geomcode == 3 || throw(WKBMultiPolygonElementError(geomcode))
         poly, pos = _read_polygon_body(bytes, pos, n, le2)
         polys[g] = poly
     end
@@ -208,7 +201,7 @@ function parse_wkb(bytes::AbstractVector{UInt8})
         mp, _ = _read_multipolygon_body(bytes, pos, n, le)
         return mp
     else
-        _wkb_unsupported(geomcode)
+        throw(WKBUnsupportedTypeError(geomcode))
     end
 end
 

--- a/GeometryOpsTestHelpers/src/wkb.jl
+++ b/GeometryOpsTestHelpers/src/wkb.jl
@@ -41,16 +41,9 @@ import GeoInterface as GI
 # Building them through the inner constructors (rather than the public `GI.Polygon`
 # etc.) skips validation and, crucially, works for empty rings/polygons/multipolygons
 # (the public constructors call `first(geom)` and throw on empty input).
-const _WKBRing  = Vector{Tuple{Float64,Float64}}
-const _WKBLinRing = GI.LinearRing{false,false,_WKBRing,Nothing,Nothing}
-const _WKBRings = Vector{_WKBLinRing}
-const _WKBPoly  = GI.Polygon{false,false,_WKBRings,Nothing,Nothing}
-const _WKBPolys = Vector{_WKBPoly}
-const _WKBMPoly = GI.MultiPolygon{false,false,_WKBPolys,Nothing,Nothing}
-
-@inline _wkb_linearring(coords::_WKBRing) = _WKBLinRing(coords, nothing, nothing)
-@inline _wkb_polygon(rings::_WKBRings) = _WKBPoly(rings, nothing, nothing)
-@inline _wkb_multipolygon(polys::_WKBPolys) = _WKBMPoly(polys, nothing, nothing)
+const _WKBLinearRing = GI.LinearRing{false,false,Vector{Tuple{Float64,Float64}},Nothing,Nothing}
+const _WKBPolygon = GI.Polygon{false,false,Vector{_WKBLinearRing},Nothing,Nothing}
+const _WKBMultiPolygon = GI.MultiPolygon{false,false,Vector{_WKBPolygon},Nothing,Nothing}
 
 # WKB integer type codes -> human names, for error messages.
 function _wkb_type_name(code::Integer)
@@ -122,7 +115,7 @@ end
     nrings = Int(nrings32)
     # Each ring is at least its own 4-byte point count; bound the allocation first.
     Int64(pos) + Int64(nrings) * 4 <= n || _wkb_truncated(nrings * 4, n - pos)
-    rings = Vector{_WKBLinRing}(undef, nrings)
+    rings = Vector{_WKBLinearRing}(undef, nrings)
     @inbounds for r in 1:nrings
         npts32, pos = _read_u32(p0, pos, n, le)
         npts = Int(npts32)
@@ -134,9 +127,9 @@ end
             y, pos = _read_f64(p0, pos, le)
             coords[i] = (x, y)
         end
-        rings[r] = _wkb_linearring(coords)
+        rings[r] = _WKBLinearRing(coords, nothing, nothing)
     end
-    return _wkb_polygon(rings), pos
+    return _WKBPolygon(rings, nothing, nothing), pos
 end
 
 # Parse a MultiPolygon body (header already consumed); return `(multipolygon, pos)`.
@@ -145,14 +138,14 @@ end
     ngeoms = Int(ngeoms32)
     # Each sub-polygon is at least order(1) + type(4) + nrings(4) = 9 bytes.
     Int64(pos) + Int64(ngeoms) * 9 <= n || _wkb_truncated(ngeoms * 9, n - pos)
-    polys = Vector{_WKBPoly}(undef, ngeoms)
+    polys = Vector{_WKBPolygon}(undef, ngeoms)
     @inbounds for g in 1:ngeoms
         geomcode, le2, pos = _read_header(p0, pos, n)   # per-element byte order + type
         geomcode == 3 || _wkb_mp_child(geomcode)
         poly, pos = _read_polygon_body(p0, pos, n, le2)
         polys[g] = poly
     end
-    return _wkb_multipolygon(polys), pos
+    return _WKBMultiPolygon(polys, nothing, nothing), pos
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ end
 
 @safetestset "Types" begin include("types.jl") end
 @safetestset "Primitives" begin include("primitives.jl") end
+@safetestset "WKB codec" begin include("wkb.jl") end
 
 # Utils
 @safetestset "Utils" begin include("utils/utils.jl") end

--- a/test/wkb.jl
+++ b/test/wkb.jl
@@ -1,0 +1,316 @@
+using Test
+import GeometryOps as GO
+import GeoInterface as GI
+import LibGEOS as LG
+import Random
+import NaturalEarth
+using GeometryOpsTestHelpers
+using GeometryOpsTestHelpers: parse_wkb, write_wkb
+
+# LibGEOS is the reference codec.  High-level API only (raw GEOS C calls abort the process).
+const CTX = LG.get_global_context()
+lg_wkb(g) = LG.writegeom(GI.convert(LG, g), LG.WKBWriter(CTX), CTX)
+
+# Count vertices in a (multi)polygon, for ns/vertex reporting.
+function nverts(geom)
+    t = GI.trait(geom)
+    if t isa GI.PolygonTrait
+        return sum(GI.npoint, GI.getgeom(geom); init = 0)
+    elseif t isa GI.MultiPolygonTrait
+        return sum(nverts, GI.getgeom(geom); init = 0)
+    else
+        return 0
+    end
+end
+
+# ------------------------------------------------------------------
+# Structure-aware little-endian -> big-endian converter, used to build
+# big-endian and mixed-endianness fixtures from our own writer output.
+# (Test-only helper; correctness over speed.)
+mutable struct _Cur
+    buf::Vector{UInt8}
+    pos::Int   # 1-based
+end
+_r_u8!(c) = (v = c.buf[c.pos]; c.pos += 1; v)
+_r_u32le!(c) = (v = reinterpret(UInt32, c.buf[c.pos:c.pos+3])[1]; c.pos += 4; v)
+_r_8!(c) = (v = c.buf[c.pos:c.pos+7]; c.pos += 8; v)
+_be32(v::UInt32) = reverse(reinterpret(UInt8, [v]))
+
+function _swap_geom!(c::_Cur, out::Vector{UInt8})
+    order = _r_u8!(c)
+    @assert order == 0x01 "converter expects little-endian input"
+    push!(out, 0x00)                       # emit big-endian
+    typ = _r_u32le!(c)
+    append!(out, _be32(typ))
+    code = typ % 1000
+    if code == 3
+        nrings = _r_u32le!(c); append!(out, _be32(nrings))
+        for _ in 1:nrings
+            npts = _r_u32le!(c); append!(out, _be32(npts))
+            for _ in 1:(npts * 2)
+                append!(out, reverse(_r_8!(c)))
+            end
+        end
+    elseif code == 6
+        ngeoms = _r_u32le!(c); append!(out, _be32(ngeoms))
+        for _ in 1:ngeoms
+            _swap_geom!(c, out)
+        end
+    else
+        error("test converter only handles polygon/multipolygon")
+    end
+    return out
+end
+to_be(le::Vector{UInt8}) = _swap_geom!(_Cur(le, 1), UInt8[])
+
+# ------------------------------------------------------------------
+# Fixtures
+unit_square = GI.Polygon([[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]])
+two_holes = GI.Polygon([
+    [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)],
+    [(1.0, 1.0), (1.0, 2.0), (2.0, 2.0), (2.0, 1.0), (1.0, 1.0)],
+    [(5.0, 5.0), (5.0, 6.0), (6.0, 6.0), (6.0, 5.0), (5.0, 5.0)],
+])
+mp_holes = GI.MultiPolygon([
+    [[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)],
+     [(2.0, 2.0), (2.0, 4.0), (4.0, 4.0), (4.0, 2.0), (2.0, 2.0)]],
+    [[(20.0, 20.0), (23.0, 20.0), (23.0, 23.0), (20.0, 20.0)]],
+])
+# Coordinates that stress floating-point round-tripping.
+stress_vals = [
+    (1 / 3, 1e-300),
+    (-0.0, 0.0),
+    (nextfloat(0.0), floatmax(Float64)),
+    (prevfloat(0.0), 1.7976931348623157e308),
+    (1 / 3, 1e-300),
+]
+stress_poly = GI.Polygon([stress_vals])
+
+@testset "Round trip: fixtures (both directions)" begin
+    for (name, g) in [
+        ("unit square", unit_square),
+        ("two holes", two_holes),
+        ("multipolygon with holes", mp_holes),
+        ("float stress", stress_poly),
+    ]
+        @testset "$name" begin
+            # LibGEOS-written WKB -> parse_wkb == GO.tuples(g)
+            @test parse_wkb(lg_wkb(g)) == GO.tuples(g)
+            # write_wkb(g) -> LibGEOS parse, coordinate-exact
+            @test GO.tuples(LG.readgeom(write_wkb(g))) == GO.tuples(g)
+            # our writer round trip
+            @test parse_wkb(write_wkb(g)) == GO.tuples(g)
+            # our writer is byte-identical to LibGEOS' (LE ISO)
+            @test write_wkb(g) == lg_wkb(g)
+        end
+    end
+end
+
+@testset "Bit-level float exactness" begin
+    g = parse_wkb(write_wkb(stress_poly))
+    pts = collect(GI.getpoint(GI.getexterior(g)))
+    for (pt, v) in zip(pts, stress_vals)
+        @test reinterpret(UInt64, GI.x(pt)) == reinterpret(UInt64, v[1])
+        @test reinterpret(UInt64, GI.y(pt)) == reinterpret(UInt64, v[2])
+    end
+    # And through LibGEOS (binary, so exact)
+    g2 = parse_wkb(lg_wkb(stress_poly))
+    pts2 = collect(GI.getpoint(GI.getexterior(g2)))
+    for (pt, v) in zip(pts2, stress_vals)
+        @test reinterpret(UInt64, GI.x(pt)) == reinterpret(UInt64, v[1])
+        @test reinterpret(UInt64, GI.y(pt)) == reinterpret(UInt64, v[2])
+    end
+end
+
+@testset "Empty geometries" begin
+    # Empty multipolygon (LibGEOS can represent this one).
+    emp_wkb = lg_wkb(GI.MultiPolygon([[[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]]]))
+    emp = parse_wkb(UInt8[1, 6, 0, 0, 0, 0, 0, 0, 0])
+    @test GI.trait(emp) isa GI.MultiPolygonTrait
+    @test GI.ngeom(emp) == 0
+    @test write_wkb(emp) == UInt8[1, 6, 0, 0, 0, 0, 0, 0, 0]
+    @test parse_wkb(write_wkb(emp)) == emp
+    # LibGEOS agrees an empty multipolygon is 9 bytes.
+    empty_mp_lg = LG.readgeom(UInt8[1, 6, 0, 0, 0, 0, 0, 0, 0])
+    @test LG.writegeom(empty_mp_lg, LG.WKBWriter(CTX), CTX) == UInt8[1, 6, 0, 0, 0, 0, 0, 0, 0]
+
+    # Empty polygon (LibGEOS' GI.convert can't build this, so test our codec directly).
+    ep = parse_wkb(UInt8[1, 3, 0, 0, 0, 0, 0, 0, 0])
+    @test GI.trait(ep) isa GI.PolygonTrait
+    @test GI.ngeom(ep) == 0
+    @test write_wkb(ep) == UInt8[1, 3, 0, 0, 0, 0, 0, 0, 0]
+    @test parse_wkb(write_wkb(ep)) == ep
+end
+
+@testset "Degenerate but parseable rings" begin
+    # Rings with too few points to be valid, and unclosed — still valid WKB.
+    for coords in ([(1.0, 2.0)], [(1.0, 2.0), (3.0, 4.0)], Tuple{Float64,Float64}[])
+        rings = Vector{Tuple{Float64,Float64}}[coords]
+        w = UInt8[]
+        push!(w, 0x01)
+        append!(w, reinterpret(UInt8, [htol(UInt32(3))]))
+        append!(w, reinterpret(UInt8, [htol(UInt32(1))]))          # 1 ring
+        append!(w, reinterpret(UInt8, [htol(UInt32(length(coords)))]))
+        for (x, y) in coords
+            append!(w, reinterpret(UInt8, [htol(reinterpret(UInt64, x))]))
+            append!(w, reinterpret(UInt8, [htol(reinterpret(UInt64, y))]))
+        end
+        g = parse_wkb(w)
+        @test GI.npoint(GI.getexterior(g)) == length(coords)
+        @test write_wkb(g) == w    # exact re-serialization
+    end
+end
+
+@testset "Big-endian and mixed endianness" begin
+    for g in (unit_square, two_holes, mp_holes)
+        le = write_wkb(g)
+        be = to_be(le)
+        @test be[1] == 0x00                     # confirm we built a big-endian buffer
+        @test parse_wkb(be) == parse_wkb(le)
+        @test parse_wkb(be) == GO.tuples(g)
+    end
+
+    # Mixed-endianness multipolygon: sub-polygon 1 little-endian, sub-polygon 2 big-endian.
+    poly1 = GI.Polygon([[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]])
+    poly2 = GI.Polygon([[(5.0, 5.0), (6.0, 5.0), (6.0, 6.0), (5.0, 5.0)]])
+    mixed = UInt8[]
+    push!(mixed, 0x01)                                        # LE multipolygon header
+    append!(mixed, reinterpret(UInt8, [htol(UInt32(6))]))
+    append!(mixed, reinterpret(UInt8, [htol(UInt32(2))]))
+    append!(mixed, write_wkb(poly1))                         # LE sub-polygon
+    append!(mixed, to_be(write_wkb(poly2)))                  # BE sub-polygon
+    expected = GI.MultiPolygon([
+        [[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]],
+        [[(5.0, 5.0), (6.0, 5.0), (6.0, 6.0), (5.0, 5.0)]],
+    ])
+    @test parse_wkb(mixed) == GO.tuples(expected)
+end
+
+@testset "EWKB SRID accepted and ignored" begin
+    g = GI.Polygon([[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]])
+    le = write_wkb(g)
+    typ = reinterpret(UInt32, le[2:5])[1]
+    out = UInt8[le[1]]
+    append!(out, reinterpret(UInt8, [htol(typ | 0x20000000)]))   # set SRID flag
+    append!(out, reinterpret(UInt8, [htol(UInt32(4326))]))       # SRID payload
+    append!(out, le[6:end])
+    @test parse_wkb(out) == GO.tuples(g)
+end
+
+@testset "Z / M dimensions rejected" begin
+    g = GI.Polygon([[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]])
+    le = write_wkb(g)
+    # ISO PolygonZ (1003)
+    iso = copy(le); iso[2:5] = reinterpret(UInt8, [htol(UInt32(1003))])
+    @test_throws ArgumentError parse_wkb(iso)
+    # ISO PolygonM (2003) and PolygonZM (3003)
+    for code in (2003, 3003)
+        b = copy(le); b[2:5] = reinterpret(UInt8, [htol(UInt32(code))])
+        @test_throws ArgumentError parse_wkb(b)
+    end
+    # EWKB Z / M flag bits
+    for flag in (0x80000000, 0x40000000, 0xc0000000)
+        b = copy(le); b[2:5] = reinterpret(UInt8, [htol(UInt32(3) | flag)])
+        @test_throws ArgumentError parse_wkb(b)
+    end
+end
+
+@testset "Unsupported types and malformed buffers throw cleanly" begin
+    # Point / LineString / MultiPoint / MultiLineString / GeometryCollection
+    for code in (1, 2, 4, 5, 7)
+        b = UInt8[0x01]
+        append!(b, reinterpret(UInt8, [htol(UInt32(code))]))
+        append!(b, reinterpret(UInt8, [htol(UInt32(0))]))
+        @test_throws ArgumentError parse_wkb(b)
+    end
+    # empty buffer / truncated header / truncated count / truncated coords
+    @test_throws ArgumentError parse_wkb(UInt8[])
+    @test_throws ArgumentError parse_wkb(UInt8[1, 3])
+    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0])          # no ring count
+    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0, 1, 0, 0, 0])  # ring count but no point count
+    # absurd counts must not OOM / segfault
+    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
+    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0, 1, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
+    @test_throws ArgumentError parse_wkb(UInt8[1, 6, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
+    # bad byte-order flag
+    @test_throws ArgumentError parse_wkb(UInt8[2, 3, 0, 0, 0, 0, 0, 0, 0])
+    # multipolygon whose element is not a polygon
+    bad_mp = UInt8[0x01]
+    append!(bad_mp, reinterpret(UInt8, [htol(UInt32(6))]))
+    append!(bad_mp, reinterpret(UInt8, [htol(UInt32(1))]))
+    append!(bad_mp, UInt8[0x01])
+    append!(bad_mp, reinterpret(UInt8, [htol(UInt32(1))]))   # a Point inside the MultiPolygon
+    append!(bad_mp, reinterpret(UInt8, [htol(reinterpret(UInt64, 0.0))]))
+    append!(bad_mp, reinterpret(UInt8, [htol(reinterpret(UInt64, 0.0))]))
+    @test_throws ArgumentError parse_wkb(bad_mp)
+    # write_wkb rejects non-polygonal geometry
+    @test_throws ArgumentError write_wkb(GI.Point(1.0, 2.0))
+    @test_throws ArgumentError write_wkb(GI.LineString([(0.0, 0.0), (1.0, 1.0)]))
+end
+
+@testset "Seeded fuzz vs LibGEOS" begin
+    Random.seed!(0xC0FFEE)
+    rndcoord() = rand() * 200 - 100
+    function rndring()
+        k = rand(3:7)
+        pts = [(rndcoord(), rndcoord()) for _ in 1:k]
+        push!(pts, pts[1])   # close the ring, keep it valid for GEOS (>= 4 pts)
+        return pts
+    end
+    rndpoly() = GI.Polygon([rndring() for _ in 1:rand(1:3)])
+    rndmpoly() = GI.MultiPolygon([[rndring() for _ in 1:rand(1:3)] for _ in 1:rand(1:3)])
+
+    for _ in 1:250
+        g = rndpoly()
+        @test parse_wkb(write_wkb(g)) == g                         # our codec self-consistency
+        @test parse_wkb(lg_wkb(g)) == GO.tuples(g)                 # LibGEOS write -> our parse
+        @test GO.tuples(LG.readgeom(write_wkb(g))) == GO.tuples(g) # our write -> LibGEOS parse
+    end
+    for _ in 1:150
+        g = rndmpoly()
+        @test parse_wkb(write_wkb(g)) == g
+        @test parse_wkb(lg_wkb(g)) == GO.tuples(g)
+        @test GO.tuples(LG.readgeom(write_wkb(g))) == GO.tuples(g)
+    end
+end
+
+@testset "Natural Earth round trip + benchmark" begin
+    countries = try
+        NaturalEarth.naturalearth("admin_0_countries", 110)
+    catch e
+        @info "Skipping Natural Earth WKB tests (data unavailable)" exception = e
+        nothing
+    end
+    if countries !== nothing
+        geoms = [g for g in countries.geometry if GI.trait(g) isa Union{GI.PolygonTrait,GI.MultiPolygonTrait}]
+        @test length(geoms) > 100
+
+        lgbufs = [lg_wkb(g) for g in geoms]
+        for (g, buf) in zip(geoms, lgbufs)
+            @test parse_wkb(buf) == GO.tuples(g)                        # both directions,
+            @test GO.tuples(LG.readgeom(write_wkb(g))) == GO.tuples(g)  # coordinate-exact
+        end
+
+        # --- Benchmark: ns/vertex, ours vs LibGEOS.readgeom + GO.tuples ---
+        totalverts = sum(nverts, geoms)
+        tupgeoms = [parse_wkb(b) for b in lgbufs]   # tuple geometries, the harness' write input
+
+        parse_mine() = (for b in lgbufs; parse_wkb(b); end; nothing)
+        parse_lg() = (for b in lgbufs; GO.tuples(LG.readgeom(b)); end; nothing)
+        wr = LG.WKBWriter(CTX)
+        lggeoms = [GI.convert(LG, g) for g in geoms]
+        write_mine() = (for g in tupgeoms; write_wkb(g); end; nothing)
+        write_lg() = (for lg in lggeoms; LG.writegeom(lg, wr, CTX); end; nothing)
+
+        parse_mine(); parse_lg(); write_mine(); write_lg()   # warmup / compile
+        tpm = minimum(@elapsed(parse_mine()) for _ in 1:10)
+        tpl = minimum(@elapsed(parse_lg()) for _ in 1:10)
+        twm = minimum(@elapsed(write_mine()) for _ in 1:10)
+        twl = minimum(@elapsed(write_lg()) for _ in 1:10)
+
+        @info "WKB benchmark (Natural Earth 110m countries)" nfeatures = length(geoms) totalverts
+        @info "parse ns/vertex" parse_wkb = tpm / totalverts * 1e9 libgeos_readgeom_tuples = tpl / totalverts * 1e9 speedup = tpl / tpm
+        @info "write ns/vertex" write_wkb = twm / totalverts * 1e9 libgeos_wkbwriter = twl / totalverts * 1e9 speedup = twl / twm
+        @test tpm > 0   # sanity: benchmark actually ran
+    end
+end

--- a/test/wkb.jl
+++ b/test/wkb.jl
@@ -5,7 +5,9 @@ import LibGEOS as LG
 import Random
 import NaturalEarth
 using GeometryOpsTestHelpers
-using GeometryOpsTestHelpers: parse_wkb, write_wkb
+using GeometryOpsTestHelpers: parse_wkb, write_wkb, WKBParseError, WKBWriteError
+using GeometryOpsTestHelpers: WKBTruncatedError, WKBByteOrderError, WKBDimensionError,
+                              WKBUnsupportedTypeError, WKBMultiPolygonElementError
 
 # LibGEOS is the reference codec.  High-level API only (raw GEOS C calls abort the process).
 const CTX = LG.get_global_context()
@@ -202,16 +204,16 @@ end
     le = write_wkb(g)
     # ISO PolygonZ (1003)
     iso = copy(le); iso[2:5] = reinterpret(UInt8, [htol(UInt32(1003))])
-    @test_throws ArgumentError parse_wkb(iso)
+    @test_throws WKBDimensionError parse_wkb(iso)
     # ISO PolygonM (2003) and PolygonZM (3003)
     for code in (2003, 3003)
         b = copy(le); b[2:5] = reinterpret(UInt8, [htol(UInt32(code))])
-        @test_throws ArgumentError parse_wkb(b)
+        @test_throws WKBDimensionError parse_wkb(b)
     end
     # EWKB Z / M flag bits
     for flag in (0x80000000, 0x40000000, 0xc0000000)
         b = copy(le); b[2:5] = reinterpret(UInt8, [htol(UInt32(3) | flag)])
-        @test_throws ArgumentError parse_wkb(b)
+        @test_throws WKBDimensionError parse_wkb(b)
     end
 end
 
@@ -221,19 +223,19 @@ end
         b = UInt8[0x01]
         append!(b, reinterpret(UInt8, [htol(UInt32(code))]))
         append!(b, reinterpret(UInt8, [htol(UInt32(0))]))
-        @test_throws ArgumentError parse_wkb(b)
+        @test_throws WKBUnsupportedTypeError parse_wkb(b)
     end
     # empty buffer / truncated header / truncated count / truncated coords
-    @test_throws ArgumentError parse_wkb(UInt8[])
-    @test_throws ArgumentError parse_wkb(UInt8[1, 3])
-    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0])          # no ring count
-    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0, 1, 0, 0, 0])  # ring count but no point count
+    @test_throws WKBTruncatedError parse_wkb(UInt8[])
+    @test_throws WKBTruncatedError parse_wkb(UInt8[1, 3])
+    @test_throws WKBTruncatedError parse_wkb(UInt8[1, 3, 0, 0, 0])          # no ring count
+    @test_throws WKBTruncatedError parse_wkb(UInt8[1, 3, 0, 0, 0, 1, 0, 0, 0])  # ring count but no point count
     # absurd counts must not OOM / segfault
-    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
-    @test_throws ArgumentError parse_wkb(UInt8[1, 3, 0, 0, 0, 1, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
-    @test_throws ArgumentError parse_wkb(UInt8[1, 6, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
+    @test_throws WKBTruncatedError parse_wkb(UInt8[1, 3, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
+    @test_throws WKBTruncatedError parse_wkb(UInt8[1, 3, 0, 0, 0, 1, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
+    @test_throws WKBTruncatedError parse_wkb(UInt8[1, 6, 0, 0, 0, 0xff, 0xff, 0xff, 0xff])
     # bad byte-order flag
-    @test_throws ArgumentError parse_wkb(UInt8[2, 3, 0, 0, 0, 0, 0, 0, 0])
+    @test_throws WKBByteOrderError parse_wkb(UInt8[2, 3, 0, 0, 0, 0, 0, 0, 0])
     # multipolygon whose element is not a polygon
     bad_mp = UInt8[0x01]
     append!(bad_mp, reinterpret(UInt8, [htol(UInt32(6))]))
@@ -242,10 +244,38 @@ end
     append!(bad_mp, reinterpret(UInt8, [htol(UInt32(1))]))   # a Point inside the MultiPolygon
     append!(bad_mp, reinterpret(UInt8, [htol(reinterpret(UInt64, 0.0))]))
     append!(bad_mp, reinterpret(UInt8, [htol(reinterpret(UInt64, 0.0))]))
-    @test_throws ArgumentError parse_wkb(bad_mp)
+    @test_throws WKBMultiPolygonElementError parse_wkb(bad_mp)
+    # every parse failure is catchable through the shared supertype
+    @test_throws WKBParseError parse_wkb(UInt8[])
+    @test_throws WKBParseError parse_wkb(UInt8[2, 3, 0, 0, 0, 0, 0, 0, 0])
+    for T in (WKBTruncatedError, WKBByteOrderError, WKBDimensionError,
+              WKBUnsupportedTypeError, WKBMultiPolygonElementError)
+        @test T <: WKBParseError
+    end
+    # showerror is defined for each of them, and mentions the offending value
+    @test occursin("only 1 remain", sprint(showerror, WKBTruncatedError(4, 1)))
+    @test occursin("2", sprint(showerror, WKBByteOrderError(0x02)))
+    @test occursin("1003", sprint(showerror, WKBDimensionError(UInt32(1003))))
+    @test occursin("LineString", sprint(showerror, WKBUnsupportedTypeError(2)))
+    @test occursin("Point", sprint(showerror, WKBMultiPolygonElementError(1)))
+
     # write_wkb rejects non-polygonal geometry
-    @test_throws ArgumentError write_wkb(GI.Point(1.0, 2.0))
-    @test_throws ArgumentError write_wkb(GI.LineString([(0.0, 0.0), (1.0, 1.0)]))
+    @test_throws WKBWriteError write_wkb(GI.Point(1.0, 2.0))
+    @test_throws WKBWriteError write_wkb(GI.LineString([(0.0, 0.0), (1.0, 1.0)]))
+end
+
+@testset "write_wkb rejects Z / M geometry" begin
+    # The reader rejects Z/M loudly, so the writer must not silently drop it.
+    polyz = GI.Polygon([[(0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 2.0), (0.0, 0.0, 1.0)]])
+    @test GI.is3d(polyz)
+    @test_throws WKBWriteError write_wkb(polyz)
+    mpz = GI.MultiPolygon([[[(0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 2.0), (0.0, 0.0, 1.0)]]])
+    @test GI.is3d(mpz)
+    @test_throws WKBWriteError write_wkb(mpz)
+    # XYM (measured but not 3D) is dropped just as silently, so it throws too.
+    polym = GI.Polygon{false,true}([[(0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 2.0), (0.0, 0.0, 1.0)]])
+    @test GI.ismeasured(polym) && !GI.is3d(polym)
+    @test_throws WKBWriteError write_wkb(polym)
 end
 
 @testset "Seeded fuzz vs LibGEOS" begin

--- a/test/wkb.jl
+++ b/test/wkb.jl
@@ -4,6 +4,7 @@ import GeoInterface as GI
 import LibGEOS as LG
 import Random
 import NaturalEarth
+import OffsetArrays
 using GeometryOpsTestHelpers
 using GeometryOpsTestHelpers: parse_wkb, write_wkb, WKBParseError, WKBWriteError
 using GeometryOpsTestHelpers: WKBTruncatedError, WKBByteOrderError, WKBDimensionError,
@@ -276,6 +277,25 @@ end
     polym = GI.Polygon{false,true}([[(0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 2.0), (0.0, 0.0, 1.0)]])
     @test GI.ismeasured(polym) && !GI.is3d(polym)
     @test_throws WKBWriteError write_wkb(polym)
+end
+
+# A deliberately non-strided byte vector: `parse_wkb` may only index into its input.
+struct _IndexedBytes <: AbstractVector{UInt8}
+    v::Vector{UInt8}
+end
+Base.size(b::_IndexedBytes) = size(b.v)
+Base.getindex(b::_IndexedBytes, i::Int) = b.v[i]
+
+@testset "Any one-based `AbstractVector{UInt8}` parses" begin
+    for g in (unit_square, two_holes, mp_holes)
+        buf = write_wkb(g)
+        @test parse_wkb(view(buf, :)) == GO.tuples(g)                 # SubArray
+        @test parse_wkb(view(vcat(buf, buf), 1:length(buf))) == GO.tuples(g)
+        @test parse_wkb(codeunits(String(copy(buf)))) == GO.tuples(g) # Base.CodeUnits
+        @test parse_wkb(_IndexedBytes(buf)) == GO.tuples(g)           # not strided at all
+    end
+    # Offset axes are rejected rather than silently misread.
+    @test_throws ArgumentError parse_wkb(OffsetArrays.OffsetVector(write_wkb(unit_square), -1))
 end
 
 @testset "Seeded fuzz vs LibGEOS" begin

--- a/test/wkb.jl
+++ b/test/wkb.jl
@@ -361,9 +361,12 @@ end
         @info "WKB benchmark (Natural Earth 110m countries)" nfeatures = length(geoms) totalverts
         @info "parse ns/vertex" parse_wkb = tpm / totalverts * 1e9 libgeos_readgeom_tuples = tpl / totalverts * 1e9 speedup = tpl / tpm
         @info "write ns/vertex" write_wkb = twm / totalverts * 1e9 libgeos_wkbwriter = twl / totalverts * 1e9 speedup = twl / twm
-        # Being faster than LibGEOS is the reason this codec exists.  The measured
-        # margin is ~60x on parse and ~20x on write, so this cannot trip on CI noise.
-        @test tpm < tpl
-        @test twm < twl
+        # Being faster than LibGEOS is the reason this codec exists (~55x parse, ~15x
+        # write uninstrumented).  Coverage instruments our Julia but not GEOS' C, which
+        # costs the writer ~38x and inverts the comparison, so only assert without it.
+        if Base.JLOptions().code_coverage == 0
+            @test tpm < tpl
+            @test twm < twl
+        end
     end
 end

--- a/test/wkb.jl
+++ b/test/wkb.jl
@@ -341,6 +341,9 @@ end
         @info "WKB benchmark (Natural Earth 110m countries)" nfeatures = length(geoms) totalverts
         @info "parse ns/vertex" parse_wkb = tpm / totalverts * 1e9 libgeos_readgeom_tuples = tpl / totalverts * 1e9 speedup = tpl / tpm
         @info "write ns/vertex" write_wkb = twm / totalverts * 1e9 libgeos_wkbwriter = twl / totalverts * 1e9 speedup = twl / twm
-        @test tpm > 0   # sanity: benchmark actually ran
+        # Being faster than LibGEOS is the reason this codec exists.  The measured
+        # margin is ~60x on parse and ~20x on write, so this cannot trip on CI noise.
+        @test tpm < tpl
+        @test twm < twl
     end
 end


### PR DESCRIPTION
Adds a fast, dependency-light WKB codec for polygonal geometry to **GeometryOpsTestHelpers**: `parse_wkb` and `write_wkb`. Independent of the relateng/overlayng stack — targets `main` directly.

## Why

The upcoming differential-validation harnesses exchange geometry with C libraries as WKB (s2geography's C API speaks `geoarrow.wkb`; LibGEOS speaks WKB natively). WKB is the right interchange for differential testing — binary doubles round-trip bit-exactly, with no text-precision hazards — but the parse side is hot and shouldn't pay LibGEOS object-tree costs, and the helpers shouldn't grow a full WKB-stack dependency for two geometry types.

## What's here

`GeometryOpsTestHelpers/src/wkb.jl` (~150 SLOC):

- `parse_wkb(bytes)` → `GI.Polygon`/`GI.MultiPolygon` with `Vector{Tuple{Float64,Float64}}` rings — the exact `GO.tuples` representation (built through inner constructors, so results compare `==` coordinate-exact and empty geometries construct cleanly). Single pass with pointer loads (no `IOBuffer`, no per-value `read`); both byte orders, including **mixed endianness across multipolygon elements** (each element carries its own header, per spec); EWKB SRID accepted and skipped; Z/M (ISO thousands-digit or EWKB flag bits) rejected with a clear error; every count validated against the remaining buffer **before** allocation, so truncated or hostile buffers (e.g. a `0xFFFFFFFF` ring count) throw a clean `ArgumentError` instead of segfaulting or OOM-ing.
- `write_wkb(geom)` → little-endian ISO WKB from any GeoInterface `PolygonTrait`/`MultiPolygonTrait` geometry: exact size computed up front, pointer stores, doubles bit-for-bit. Byte-identical to LibGEOS's writer output for LE ISO polygons/multipolygons (asserted in tests).

Scope is deliberately polygonal: types 3 and 6 only; anything else throws an `ArgumentError` naming the type found.

## Validation

`test/wkb.jl` (1,640 assertions): coordinate-exact round-trips in both directions against LibGEOS (unit square, multi-hole polygons, multipolygons, empties, degenerate rings, float-stress values checked via `reinterpret(UInt64, …)` bit equality); 1,200 seeded-fuzz checks (400 random geometries × cross-checks); big-endian and mixed-endianness fixtures; EWKB SRID/Z/M fixtures; malformed-buffer cases; and a data-availability-gated Natural Earth round-trip of all 177 110m countries.

## Why not just depend on WellKnownGeometry.jl?

That was measured rather than assumed (WKG v0.2.6, Julia 1.12.6, canonical input bytes produced by the LibGEOS C writer). The comparison is like-for-like: both sides start at a byte buffer and end at the identical concrete tuple representation, and WKG is credited with its own README-recommended `GI.coordinates` traversal rather than the `GO.tuples` route (whose indexed access hits an O(i²) accessor path in WKG and would look worse still — 2.92 ms on NE 110m).

| corpus | operation | this codec | WellKnownGeometry | LibGEOS |
|---|---|---|---|---|
| NE 110m (10,654 v) | parse | **16.9 µs** (1.6 ns/v) | 511 µs (48 ns/v) | 995 µs (93 ns/v) |
| NE 10m Canada (68,193 v) | parse | **35.8 µs** (0.5 ns/v) | 3.05 ms (45 ns/v) | 5.58 ms (82 ns/v) |
| unit square | parse | **21.6 ns** | 658 ns | 668 ns |
| NE 110m | write | **14.3 µs** | 267 µs | 241 µs |
| NE 10m Canada | write | **28.3 µs** (3 allocs) | 14.9 ms (866 MB churn) | 1.01 ms |

Parse is 30–85× faster, write 11–525×; allocations are 6× smaller and 20× fewer on parse. A control run — `GO.tuples` on an *already-materialized* geometry — shows the traversal floor is only 0.1–2% of WKG's time in every regime, so the gap is decoder cost, not GeometryOps overhead. (Corollary: `parse_wkb` from bytes is 2.3× faster than `GO.tuples` on the equivalent in-memory geometry, so routing through any non-native reader would cost more than this entire decode.) There is also a capability gap: WKG rejects big-endian WKB outright, which this codec supports along with mixed-endian multipolygons.

Cross-validation against WKG at the same time: all 435 Natural Earth countries (110m + 10m, 548,471 vertices) parse coordinate-identically under both, and this writer's output is **byte-for-byte identical to both WKG's and GEOS's** — plus 2,000 fuzz polygons, special floats (−0.0, NaN payloads, denormals) bit-exact, and all six malformed-input classes throwing cleanly.

## Test plan

- [x] CI green on the tip `33b09d525` (full package suite, 5 Julia matrices) — run 29553267374, all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

