### PR TITLE
Add spatialtree to get existing tree, or create one

### DIFF
--- a/ext/GeometryOpsFlexiJoinsExt/GeometryOpsFlexiJoinsExt.jl
+++ b/ext/GeometryOpsFlexiJoinsExt/GeometryOpsFlexiJoinsExt.jl
@@ -52,7 +52,7 @@ function FlexiJoins.findmatchix(::FlexiJoins.Mode.Tree, cond::FlexiJoins.ByPred{
     # We extract the relevant columns using cond.Lf and cond.Rf.
     tree === nothing && return Int[]
     left_geom = cond.Lf(a)
-    (left_geom === nothing || ismissing(left_geom) || isnothing(GI.extent(left_geom))) && return Int[]
+    (isnothing(left_geom) || ismissing(left_geom) || GI.isempty(left_geom)) && return Int[]
     idxs = query(tree, left_geom)
     intersecting_idxs = filter!(idxs) do idx
         cond.pred(cond.Lf(a), cond.Rf(B[idx]))

--- a/ext/GeometryOpsFlexiJoinsExt/GeometryOpsFlexiJoinsExt.jl
+++ b/ext/GeometryOpsFlexiJoinsExt/GeometryOpsFlexiJoinsExt.jl
@@ -13,7 +13,9 @@ using GeometryOps
 using FlexiJoins
 
 import GeometryOps as GO, GeoInterface as GI
-using SortTileRecursiveTree, Tables
+import GeometryOps.SpatialTreeInterface: spatialtree
+using GeometryOps.SpatialTreeInterface: query, isspatialtree
+using Tables
 
 
 # This module defines the FlexiJoins APIs for GeometryOps' boolean comparison functions, taken from DE-9IM.
@@ -35,12 +37,23 @@ FlexiJoins.supports_mode(::FlexiJoins.Mode.Tree, ::FlexiJoins.ByPred{F}, datas) 
 
 # In theory, one could extract the tree from e.g a GeoPackage or some future GeoDataFrame.
 
-FlexiJoins.prepare_for_join(::FlexiJoins.Mode.Tree, X, cond::FlexiJoins.ByPred{<: GO_DE9IM_FUNCS}) = (X, SortTileRecursiveTree.STRtree(map(cond.Rf, X)))
-function FlexiJoins.findmatchix(::FlexiJoins.Mode.Tree, cond::FlexiJoins.ByPred{F}, ix_a, a, (B, tree)::Tuple, multi::typeof(identity)) where F <: GO_DE9IM_FUNCS
+function spatialtree(X, selector)
+    tree_or_geometries = selector(X)
+    tree_or_geometries === nothing && return nothing
+    ismissing(tree_or_geometries) && return nothing
+    isspatialtree(tree_or_geometries) && return tree_or_geometries
+    return spatialtree(tree_or_geometries)
+end
+
+FlexiJoins.prepare_for_join(::FlexiJoins.Mode.Tree, X, cond::FlexiJoins.ByPred{<: GO_DE9IM_FUNCS}) = (X, spatialtree(X, cond.Rf))
+function FlexiJoins.findmatchix(::FlexiJoins.Mode.Tree, cond::FlexiJoins.ByPred{F}, ix_a, a, (B, tree)::Tuple, multi::typeof(identity)) where F<:GO_DE9IM_FUNCS
     # Implementation note:
     # here, `a` is a row, and `b` is the full table.
     # We extract the relevant columns using cond.Lf and cond.Rf.
-    idxs = SortTileRecursiveTree.query(tree, cond.Lf(a))
+    tree === nothing && return Int[]
+    left_geom = cond.Lf(a)
+    (left_geom === nothing || ismissing(left_geom) || isnothing(GI.extent(left_geom))) && return Int[]
+    idxs = query(tree, left_geom)
     intersecting_idxs = filter!(idxs) do idx
         cond.pred(cond.Lf(a), cond.Rf(B[idx]))
     end

--- a/ext/GeometryOpsFlexiJoinsExt/GeometryOpsFlexiJoinsExt.jl
+++ b/ext/GeometryOpsFlexiJoinsExt/GeometryOpsFlexiJoinsExt.jl
@@ -37,7 +37,7 @@ FlexiJoins.supports_mode(::FlexiJoins.Mode.Tree, ::FlexiJoins.ByPred{F}, datas) 
 
 # In theory, one could extract the tree from e.g a GeoPackage or some future GeoDataFrame.
 
-function spatialtree(X, selector)
+function _spatialtree(X, selector)
     tree_or_geometries = selector(X)
     tree_or_geometries === nothing && return nothing
     ismissing(tree_or_geometries) && return nothing
@@ -45,7 +45,7 @@ function spatialtree(X, selector)
     return spatialtree(tree_or_geometries)
 end
 
-FlexiJoins.prepare_for_join(::FlexiJoins.Mode.Tree, X, cond::FlexiJoins.ByPred{<: GO_DE9IM_FUNCS}) = (X, spatialtree(X, cond.Rf))
+FlexiJoins.prepare_for_join(::FlexiJoins.Mode.Tree, X, cond::FlexiJoins.ByPred{<: GO_DE9IM_FUNCS}) = (X, _spatialtree(X, cond.Rf))
 function FlexiJoins.findmatchix(::FlexiJoins.Mode.Tree, cond::FlexiJoins.ByPred{F}, ix_a, a, (B, tree)::Tuple, multi::typeof(identity)) where F<:GO_DE9IM_FUNCS
     # Implementation note:
     # here, `a` is a row, and `b` is the full table.

--- a/src/utils/FlexibleRTrees/FlexibleRTrees.jl
+++ b/src/utils/FlexibleRTrees/FlexibleRTrees.jl
@@ -35,7 +35,7 @@ import GeoInterface as GI
 import Extents
 using StaticArrays: MVector
 
-import ..GeometryOps: Manifold
+import ..GeometryOps: Manifold, Planar
 
 export RTree, BulkLoadAlgorithm, STR, HPR, Unsorted, query
 

--- a/src/utils/FlexibleRTrees/interface.jl
+++ b/src/utils/FlexibleRTrees/interface.jl
@@ -1,7 +1,7 @@
 # # SpatialTreeInterface
 
 using ..SpatialTreeInterface
-import ..SpatialTreeInterface: isspatialtree, isleaf, nchild, getchild,
+import ..SpatialTreeInterface: spatialtree, isspatialtree, isleaf, nchild, getchild,
     child_indices_extents, depth_first_search
 
 """
@@ -84,4 +84,18 @@ function query(tree::RTree, geom)
     ext = GI.extent(geom)
     isnothing(ext) && throw(ArgumentError("no extent found on $(typeof(geom))"))
     return query(tree, ext)
+end
+
+function spatialtree(geometries)
+    valid = nonmissingtype(eltype(geometries))[]
+    positions = Int[]
+    for (i, geom) in enumerate(geometries)
+        if geom === nothing || ismissing(geom) || isnothing(GI.extent(geom))
+            continue
+        end
+        push!(valid, geom)
+        push!(positions, i)
+    end
+    isempty(valid) && return nothing
+    return RTree(STR(), valid; indices=positions)
 end

--- a/src/utils/FlexibleRTrees/interface.jl
+++ b/src/utils/FlexibleRTrees/interface.jl
@@ -90,7 +90,7 @@ function spatialtree(geometries)
     valid = nonmissingtype(eltype(geometries))[]
     positions = Int[]
     for (i, geom) in enumerate(geometries)
-        if geom === nothing || ismissing(geom) || isnothing(GI.extent(geom))
+        if geom === nothing || ismissing(geom)
             continue
         end
         push!(valid, geom)

--- a/src/utils/FlexibleRTrees/interface.jl
+++ b/src/utils/FlexibleRTrees/interface.jl
@@ -88,15 +88,14 @@ end
 
 spatialtree(geometries) = spatialtree(Planar(), geometries)
 function spatialtree(manifold::Manifold, geometries)
-    valid = nonmissingtype(eltype(geometries))[]
+    items = geometries isa AbstractVector ? geometries : collect(geometries)
     positions = Int[]
-    for (i, geom) in enumerate(geometries)
+    for (i, geom) in pairs(items)
         if (isnothing(geom) || ismissing(geom) || GI.isempty(geom))
             continue
         end
-        push!(valid, geom)
         push!(positions, i)
     end
-    isempty(valid) && return nothing
-    return RTree(manifold, STR(), valid; indices = positions)
+    isempty(positions) && return nothing
+    return RTree(manifold, STR(), items; indices = positions)
 end

--- a/src/utils/FlexibleRTrees/interface.jl
+++ b/src/utils/FlexibleRTrees/interface.jl
@@ -86,11 +86,11 @@ function query(tree::RTree, geom)
     return query(tree, ext)
 end
 
-function spatialtree(geometries)
+function spatialtree(geometries, manifold=nothing)  # to be made Planar()
     valid = nonmissingtype(eltype(geometries))[]
     positions = Int[]
     for (i, geom) in enumerate(geometries)
-        if geom === nothing || ismissing(geom)
+        if (isnothing(geom) || ismissing(geom) || GI.isempty(geom))
             continue
         end
         push!(valid, geom)

--- a/src/utils/FlexibleRTrees/interface.jl
+++ b/src/utils/FlexibleRTrees/interface.jl
@@ -86,7 +86,8 @@ function query(tree::RTree, geom)
     return query(tree, ext)
 end
 
-function spatialtree(geometries, manifold=nothing)  # to be made Planar()
+spatialtree(geometries) = spatialtree(Planar(), geometries)
+function spatialtree(manifold::Manifold, geometries)
     valid = nonmissingtype(eltype(geometries))[]
     positions = Int[]
     for (i, geom) in enumerate(geometries)
@@ -97,5 +98,5 @@ function spatialtree(geometries, manifold=nothing)  # to be made Planar()
         push!(positions, i)
     end
     isempty(valid) && return nothing
-    return RTree(STR(), valid; indices=positions)
+    return RTree(manifold, STR(), valid; indices = positions)
 end

--- a/src/utils/FlexibleRTrees/types.jl
+++ b/src/utils/FlexibleRTrees/types.jl
@@ -41,7 +41,7 @@ struct Unsorted <: BulkLoadAlgorithm end
 # ## The tree
 
 """
-    RTree(algorithm::BulkLoadAlgorithm, data; nodecapacity = 16, extents = nothing)
+    RTree(algorithm::BulkLoadAlgorithm, data; nodecapacity = 16, extents = nothing, indices = nothing)
 
 A packed R-tree over the extents of `data` (anything `GI.extent` accepts —
 geometries, or `Extents.Extent`s themselves), of any dimensionality, bulk
@@ -53,9 +53,15 @@ that carry no extent of their own, or extents computed in another coordinate
 space.  The tree takes ownership of the vector (`Unsorted` aliases it as the
 leaf level rather than copying).
 
+Pass a vector as `indices` (one per element of `data`, in order) to have
+queries report those indices instead of positions in `data` — for indexing a
+filtered subset of a larger collection, say one whose `missing` entries were
+dropped, while still addressing the collection it came from.
+
 The tree is flat and fully concrete: `levels[1]` is the coarsest level and
 `levels[end]` holds the leaf extents in packed order, with `indices` mapping
-each leaf slot back to its position in `data`.  Queries through
+each leaf slot back to its position in `data` (or, when `indices` was given,
+to the caller's index for that element).  Queries through
 SpatialTreeInterface therefore return indices into `data`, which the tree
 keeps as `tree.data` so hits map straight back to elements wherever the
 tree travels.
@@ -70,7 +76,8 @@ struct RTree{A <: BulkLoadAlgorithm, E <: Extents.Extent, D <: AbstractVector, I
 end
 
 function RTree(algorithm::A, data; nodecapacity::Int = 16,
-        extents::Union{Nothing, Vector{<:Extents.Extent}} = nothing) where A <: BulkLoadAlgorithm
+        extents::Union{Nothing, Vector{<:Extents.Extent}} = nothing,
+        indices::Union{Nothing, AbstractVector{Int}} = nothing) where A <: BulkLoadAlgorithm
     nodecapacity >= 2 || throw(ArgumentError("`nodecapacity` must be at least 2, got $nodecapacity"))
     items = data isa AbstractVector ? data : collect(data)
     isempty(items) && throw(ArgumentError("cannot build an `RTree` from an empty collection"))
@@ -82,23 +89,31 @@ function RTree(algorithm::A, data; nodecapacity::Int = 16,
             "`extents` must have one entry per element of `data`, got $(length(extents)) for $(length(items))"))
         extents
     end
+    isnothing(indices) || length(indices) == length(items) || throw(ArgumentError(
+        "`indices` must have one entry per element of `data`, got $(length(indices)) for $(length(items))"))
     perm = loadorder(algorithm, exts, nodecapacity)
     leaves = perm isa Base.OneTo ? exts : exts[perm]
     levels = _pack_levels(leaves, nodecapacity)
     total = reduce(Extents.union, levels[1])
-    return RTree(algorithm, nodecapacity, total, levels, perm, items)
+    leafindices = isnothing(indices) ? perm : indices[perm]
+    return RTree(algorithm, nodecapacity, total, levels, leafindices, items)
 end
 
 """
-    RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity = 16)
+    RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity = 16, indices = nothing)
 
 Build the tree over each element's extent *on the manifold `m`*, via
 `Extents.extent(m, x)`.  On `Spherical()` the leaves are the 3D Cartesian
 boxes of the elements as regions on the unit sphere, covering the arc bulge
 and enclosed poles that vertex extents miss.
 """
-RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity::Int = 16) =
-    RTree(algorithm, [Extents.extent(m, x) for x in data]; nodecapacity)
+function RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity::Int = 16,
+        indices::Union{Nothing, AbstractVector{Int}} = nothing)
+    items = data isa AbstractVector ? data : collect(data)
+    isempty(items) && throw(ArgumentError("cannot build an `RTree` from an empty collection"))
+    return RTree(algorithm, items; nodecapacity, indices,
+        extents = [Extents.extent(m, x) for x in items])
+end
 
 Extents.extent(tree::RTree) = tree.extent
 

--- a/src/utils/FlexibleRTrees/types.jl
+++ b/src/utils/FlexibleRTrees/types.jl
@@ -47,21 +47,21 @@ A packed R-tree over the extents of `data` (anything `GI.extent` accepts —
 geometries, or `Extents.Extent`s themselves), of any dimensionality, bulk
 loaded in the order chosen by `algorithm`.
 
-Pass a vector as `extents` (one per element of `data`, in order) to index
-`data` by precomputed extents instead of `GI.extent` — for payload elements
-that carry no extent of their own, or extents computed in another coordinate
-space.  The tree takes ownership of the vector (`Unsorted` aliases it as the
-leaf level rather than copying).
+Pass a vector as `indices` to index only `data[indices]`, leaving the rest of
+`data` out of the tree — for a collection only part of which can be indexed,
+say one with `missing` entries.  `data` stays whole, so queries still report
+positions in it.
 
-Pass a vector as `indices` (one per element of `data`, in order) to have
-queries report those indices instead of positions in `data` — for indexing a
-filtered subset of a larger collection, say one whose `missing` entries were
-dropped, while still addressing the collection it came from.
+Pass a vector as `extents` to index by precomputed extents instead of
+`GI.extent` — for payload elements that carry no extent of their own, or
+extents computed in another coordinate space.  One per indexed element, in
+order: per element of `data` normally, per element of `indices` alongside
+`indices`.  The tree takes ownership of the vector (`Unsorted` aliases it as
+the leaf level rather than copying).
 
 The tree is flat and fully concrete: `levels[1]` is the coarsest level and
 `levels[end]` holds the leaf extents in packed order, with `indices` mapping
-each leaf slot back to its position in `data` (or, when `indices` was given,
-to the caller's index for that element).  Queries through
+each leaf slot back to its position in `data`.  Queries through
 SpatialTreeInterface therefore return indices into `data`, which the tree
 keeps as `tree.data` so hits map straight back to elements wherever the
 tree travels.
@@ -80,17 +80,18 @@ function RTree(algorithm::A, data; nodecapacity::Int = 16,
         indices::Union{Nothing, AbstractVector{Int}} = nothing) where A <: BulkLoadAlgorithm
     nodecapacity >= 2 || throw(ArgumentError("`nodecapacity` must be at least 2, got $nodecapacity"))
     items = data isa AbstractVector ? data : collect(data)
-    isempty(items) && throw(ArgumentError("cannot build an `RTree` from an empty collection"))
+    isnothing(indices) || checkbounds(Bool, items, indices) || throw(ArgumentError(
+        "`indices` must all be indices into `data`, which has $(length(items)) elements"))
+    indexed = isnothing(indices) ? eachindex(items) : indices
+    isempty(indexed) && throw(ArgumentError("cannot build an `RTree` from an empty collection"))
     exts = if extents === nothing
-        E = typeof(GI.extent(first(items)))
-        E[GI.extent(x) for x in items]
+        E = typeof(GI.extent(items[first(indexed)]))
+        E[GI.extent(items[i]) for i in indexed]
     else
-        length(extents) == length(items) || throw(ArgumentError(
-            "`extents` must have one entry per element of `data`, got $(length(extents)) for $(length(items))"))
+        length(extents) == length(indexed) || throw(ArgumentError(
+            "`extents` must have one entry per indexed element, got $(length(extents)) for $(length(indexed))"))
         extents
     end
-    isnothing(indices) || length(indices) == length(items) || throw(ArgumentError(
-        "`indices` must have one entry per element of `data`, got $(length(indices)) for $(length(items))"))
     perm = loadorder(algorithm, exts, nodecapacity)
     leaves = perm isa Base.OneTo ? exts : exts[perm]
     levels = _pack_levels(leaves, nodecapacity)
@@ -110,9 +111,12 @@ and enclosed poles that vertex extents miss.
 function RTree(m::Manifold, algorithm::BulkLoadAlgorithm, data; nodecapacity::Int = 16,
         indices::Union{Nothing, AbstractVector{Int}} = nothing)
     items = data isa AbstractVector ? data : collect(data)
-    isempty(items) && throw(ArgumentError("cannot build an `RTree` from an empty collection"))
+    isnothing(indices) || checkbounds(Bool, items, indices) || throw(ArgumentError(
+        "`indices` must all be indices into `data`, which has $(length(items)) elements"))
+    indexed = isnothing(indices) ? eachindex(items) : indices
+    isempty(indexed) && throw(ArgumentError("cannot build an `RTree` from an empty collection"))
     return RTree(algorithm, items; nodecapacity, indices,
-        extents = [Extents.extent(m, x) for x in items])
+        extents = [Extents.extent(m, items[i]) for i in indexed])
 end
 
 Extents.extent(tree::RTree) = tree.extent

--- a/src/utils/SpatialTreeInterface/SpatialTreeInterface.jl
+++ b/src/utils/SpatialTreeInterface/SpatialTreeInterface.jl
@@ -9,6 +9,7 @@ import AbstractTrees
 # public isspatialtree, isleaf, getchild, nchild, child_indices_extents, node_extent
 export query
 export FlatNoTree
+export spatialtree
 
 # The spatial tree interface and its implementations are defined here.
 include("interface.jl")
@@ -23,6 +24,17 @@ include("depth_first_search.jl")
 # than two separate single-tree queries since it can prune branches in tandem as it
 # descends into the trees.
 include("dual_depth_first_search.jl")
+
+
+"""
+    spatialtree(geometries)
+
+Build a default packed STR RTree from an iterable of geometries.
+
+`missing` and `nothing` entries are skipped, as are values whose
+`GI.extent` is `nothing`. If no valid geometries remain, return `nothing`.
+"""
+spatialtree() = nothing
 
 
 """

--- a/src/utils/SpatialTreeInterface/SpatialTreeInterface.jl
+++ b/src/utils/SpatialTreeInterface/SpatialTreeInterface.jl
@@ -27,12 +27,14 @@ include("dual_depth_first_search.jl")
 
 
 """
-    spatialtree(geometries)
+    spatialtree([manifold::Manifold], geometries)
 
-Build a default packed STR RTree from an iterable of geometries.
+Build a default packed STR RTree from an iterable of geometries, over their
+extents on `manifold` (`Planar()` if not given).
 
-`missing` and `nothing` entries are skipped, as are values whose
-`GI.extent` is `nothing`. If no valid geometries remain, return `nothing`.
+`missing` and `nothing` entries are skipped, as are empty geometries.  Queries
+return indices into `geometries` regardless, so the skipped entries do not
+shift the answers.  If no valid geometries remain, return `nothing`.
 """
 spatialtree() = nothing
 

--- a/test/utils/FlexibleRTrees.jl
+++ b/test/utils/FlexibleRTrees.jl
@@ -65,6 +65,20 @@ end
     # covering the whole square, so extent-intersects finds it too.
     @test query(gtree, Extents.Extent(X = (0.9, 1.1), Y = (0.4, 0.6))) == [2, 3]
 
+    filtered_geometries = extents[[2, 4]]
+    @test query(RTree(STR(), filtered_geometries; indices = [2, 4]), filtered_geometries[1]) == [2]
+    @test_throws ArgumentError RTree(STR(), filtered_geometries; indices = [2])
+
+    iter_extents = Iterators.filter(_ -> true, filtered_geometries)
+    @test query(RTree(STR(), iter_extents), filtered_geometries[1]) == [1]
+
+    stateful_extents = [
+        Extents.Extent(X = (0.0, 1.0), Y = (0.0, 1.0)),
+        Extents.Extent(X = (2.0, 3.0), Y = (2.0, 3.0)),
+    ]
+    stateful = Iterators.Stateful(stateful_extents)
+    @test query(RTree(STR(), stateful), stateful_extents[2]) == [2]
+
     @test_throws ArgumentError RTree(STR(), Extents.Extent{(:X, :Y)}[])
     @test_throws ArgumentError RTree(STR(), random_extents(rng, 5, 2); nodecapacity = 1)
     @test occursin("RTree{HPR}", sprint(show, gtree))

--- a/test/utils/FlexibleRTrees.jl
+++ b/test/utils/FlexibleRTrees.jl
@@ -65,10 +65,17 @@ end
     # covering the whole square, so extent-intersects finds it too.
     @test query(gtree, Extents.Extent(X = (0.9, 1.1), Y = (0.4, 0.6))) == [2, 3]
 
-    filtered_geometries = extents[[2, 4]]
-    @test query(RTree(STR(), filtered_geometries; indices = [2, 4]), filtered_geometries[1]) == [2]
-    @test_throws ArgumentError RTree(STR(), filtered_geometries; indices = [2])
+    # `indices` indexes part of a collection, which stays whole as `tree.data`
+    partial = RTree(STR(), extents; indices = [2, 4])
+    @test query(partial, extents[2]) == [2]
+    @test partial.data === extents
+    # and nothing else is in the tree, however much the rest overlaps
+    @test query(partial, Extents.extent(partial)) == [2, 4]
+    @test_throws ArgumentError RTree(STR(), extents; indices = [2, length(extents) + 1])
+    @test_throws ArgumentError RTree(STR(), extents; indices = Int[])
+    @test_throws ArgumentError RTree(STR(), extents; indices = [2, 4], extents = extents)
 
+    filtered_geometries = extents[[2, 4]]
     iter_extents = Iterators.filter(_ -> true, filtered_geometries)
     @test query(RTree(STR(), iter_extents), filtered_geometries[1]) == [1]
 
@@ -160,4 +167,11 @@ end
     pt = RTree(GO.Planar(), HPR(), band)
     t = RTree(HPR(), band)
     @test pt.levels == t.levels && pt.indices == t.indices
+
+    # `indices` skips the unindexed elements, so `Extents.extent(m, ...)` is
+    # never asked for an extent they have no way to give
+    unindexable = vcat(Any[missing], geoms)
+    partial = RTree(GO.Spherical(), HPR(), unindexable; indices = 2:length(unindexable))
+    @test query(partial, pole_box) == [14]  # the cap, one along from before
+    @test partial.data === unindexable
 end

--- a/test/utils/SpatialTreeInterface.jl
+++ b/test/utils/SpatialTreeInterface.jl
@@ -226,9 +226,6 @@ end
 
     @test tree isa RTree{STR}
     @test query(tree, Extents.Extent(X = (-0.1, 1.1), Y = (-0.1, 1.1))) == [3, 5]
-    valid_point = (1.0, 1.0)
-    filtered_tree = spatialtree([1, valid_point])
-    @test query(filtered_tree, Extents.Extent(X = (0.5, 1.5), Y = (0.5, 1.5))) == [2]
     @test isnothing(spatialtree([missing, nothing, missing]))
 end
 

--- a/test/utils/SpatialTreeInterface.jl
+++ b/test/utils/SpatialTreeInterface.jl
@@ -227,6 +227,18 @@ end
     @test tree isa RTree{STR}
     @test query(tree, Extents.Extent(X = (-0.1, 1.1), Y = (-0.1, 1.1))) == [3, 5]
     @test isnothing(spatialtree([missing, nothing, missing]))
+
+    # the default is `Planar()`
+    @test query(spatialtree(GO.Planar(), geometries),
+        Extents.Extent(X = (-0.1, 1.1), Y = (-0.1, 1.1))) == [3, 5]
+
+    # `Spherical()` indexes the 3D regions on the unit sphere: the cap encloses
+    # the pole none of its vertices reach, and the skipped entries still do not
+    # shift the reported indices
+    cap = GI.Polygon([[(lon, 80.0) for lon in 0.0:30.0:360.0]])
+    spherical = spatialtree(GO.Spherical(), [missing, nothing, cap])
+    @test Extents.extent(spherical) isa Extents.Extent{(:X, :Y, :Z)}
+    @test query(spherical, Extents.Extent(X = (-0.01, 0.01), Y = (-0.01, 0.01), Z = (0.99, 1.0))) == [3]
 end
 
 # Test NaturalIndex implementation

--- a/test/utils/SpatialTreeInterface.jl
+++ b/test/utils/SpatialTreeInterface.jl
@@ -3,7 +3,8 @@ import GeometryOps as GO, GeoInterface as GI
 using GeometryOps.SpatialTreeInterface
 using GeometryOps.SpatialTreeInterface: isspatialtree, isleaf, getchild, nchild, child_indices_extents, node_extent
 using GeometryOps.SpatialTreeInterface: query, depth_first_search, dual_depth_first_search
-using GeometryOps.SpatialTreeInterface: FlatNoTree
+using GeometryOps.SpatialTreeInterface: FlatNoTree, spatialtree
+using GeometryOps.FlexibleRTrees: RTree, STR
 using GeometryOps.NaturalIndexing: NaturalIndex
 using Extents
 using SortTileRecursiveTree: STRtree
@@ -217,6 +218,18 @@ end
     test_dual_query_functionality(STRtree)
     test_geometry_support(STRtree)
     test_find_point_in_all_countries(STRtree)
+end
+
+@testset "spatialtree" begin
+    geometries = [missing, nothing, (0.0, 0.0), nothing, (1.0, 1.0)]
+    tree = spatialtree(geometries)
+
+    @test tree isa RTree{STR}
+    @test query(tree, Extents.Extent(X = (-0.1, 1.1), Y = (-0.1, 1.1))) == [3, 5]
+    valid_point = (1.0, 1.0)
+    filtered_tree = spatialtree([1, valid_point])
+    @test query(filtered_tree, Extents.Extent(X = (0.5, 1.5), Y = (0.5, 1.5))) == [2]
+    @test isnothing(spatialtree([missing, nothing, missing]))
 end
 
 # Test NaturalIndex implementation


### PR DESCRIPTION
for a given collection. Incomplete AI draft with some touches, to go together with a PR to GeoDataFrames (always creating a FlexibleRTree on reading). I would like to use that tree, but at the moment GO always creates it.

Probably `spatialtree` should get expanded to support creation of different trees? We probably need a short design session.

This also adds the ability to add a custom indices, because geometries in a vector can be missing/nothing.