### PR TITLE
Mark OverlayNG and RelateNG APIs as experimental

### DIFF
--- a/src/methods/clipping/overlayng/api.jl
+++ b/src/methods/clipping/overlayng/api.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayNG — the exact-arrangement overlay algorithm
 
 export OverlayNG, symdifference
@@ -107,6 +109,8 @@ ladder would be dead weight.
 """
     OverlayNG(; manifold = Planar(), exact = True(), point_type = ...)
     OverlayNG(manifold::Manifold; kwargs...)
+
+This functionality is experimental and may change at any time.
 
 The exact-arrangement overlay algorithm, a port of the JTS OverlayNG engine by
 Martin Davis, extended to the sphere.
@@ -321,14 +325,17 @@ _rebuilt_point_type(alg::OverlayNG, m::Manifold) =
 # driver. `intersection`, `union` and `difference` gain an `OverlayNG` method
 # beside their existing Foster–Hormann ones; `symdifference` is new.
 
+"This functionality is experimental and may change at any time."
 intersection(alg::OverlayNG, geom_a, geom_b; target = nothing) =
     _overlay_ng(alg.manifold, OVERLAY_INTERSECTION, geom_a, geom_b;
                 exact = alg.exact, point_type = alg.point_type, target)
 
+"This functionality is experimental and may change at any time."
 union(alg::OverlayNG, geom_a, geom_b; target = nothing) =
     _overlay_ng(alg.manifold, OVERLAY_UNION, geom_a, geom_b;
                 exact = alg.exact, point_type = alg.point_type, target)
 
+"This functionality is experimental and may change at any time."
 difference(alg::OverlayNG, geom_a, geom_b; target = nothing) =
     _overlay_ng(alg.manifold, OVERLAY_DIFFERENCE, geom_a, geom_b;
                 exact = alg.exact, point_type = alg.point_type, target)
@@ -336,6 +343,8 @@ difference(alg::OverlayNG, geom_a, geom_b; target = nothing) =
 """
     symdifference([alg::OverlayNG], geom_a, geom_b)
     symdifference(manifold::Manifold, geom_a, geom_b)
+
+This functionality is experimental and may change at any time.
 
 The symmetric difference of two geometries: everything that lies in exactly one
 of them, i.e. `union(difference(a, b), difference(b, a))`.

--- a/src/methods/clipping/overlayng/edge_source.jl
+++ b/src/methods/clipping/overlayng/edge_source.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # EdgeSourceInfo — per-ring/line source topology (port of JTS `EdgeSourceInfo`)
 #
 # Phase 2a of the OverlayNG port (design doc §2.7, §3 amendment 3). Records the

--- a/src/methods/clipping/overlayng/half_edge.jl
+++ b/src/methods/clipping/overlayng/half_edge.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Half-edge substrate — the winged-edge algebra (port of JTS `edgegraph/HalfEdge`)
 #
 # Phase 2a of the OverlayNG port (design doc §3). A port of

--- a/src/methods/clipping/overlayng/intersection_point_builder.jl
+++ b/src/methods/clipping/overlayng/intersection_point_builder.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # IntersectionPointBuilder — result points (port of JTS `IntersectionPointBuilder`)
 #
 # Phase 2b of the OverlayNG port (design doc §3). A port of

--- a/src/methods/clipping/overlayng/line_builder.jl
+++ b/src/methods/clipping/overlayng/line_builder.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # LineBuilder — result lines from the overlay graph (port of JTS `LineBuilder`)
 #
 # Phase 2b of the OverlayNG port (design doc §3). A port of

--- a/src/methods/clipping/overlayng/maximal_edge_ring.jl
+++ b/src/methods/clipping/overlayng/maximal_edge_ring.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Result ring linking — maximal rings, minimal-ring split, edge rings
 #
 # Phase 2b of the OverlayNG port (design doc §3). Ports two JTS files kept

--- a/src/methods/clipping/overlayng/noding/collect.jl
+++ b/src/methods/clipping/overlayng/noding/collect.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Stage 1 — collect (design §2.3)
 #
 # Enumerate candidate segment pairs (A × B) through the reused RelateNG edge

--- a/src/methods/clipping/overlayng/noding/emit.jl
+++ b/src/methods/clipping/overlayng/noding/emit.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Emission (design §2.6) — the only lossy step
 #
 # `node_point(arr, id)` realizes a node's OUTPUT coordinate on demand and caches

--- a/src/methods/clipping/overlayng/noding/node_identity.jl
+++ b/src/methods/clipping/overlayng/noding/node_identity.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Stage 3 — node identity (design §2.4)
 #
 # Two tiers, no canonical key. Tier 1 (egal `NodeKey` equality) already ran

--- a/src/methods/clipping/overlayng/noding/noded_arrangement.jl
+++ b/src/methods/clipping/overlayng/noding/noded_arrangement.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayNG noding substrate — the `NodedArrangement`
 #
 # Phase 1 of the OverlayNG port (design doc `2026-07-16-overlayng-noding-substrate.md`).

--- a/src/methods/clipping/overlayng/noding/split.jl
+++ b/src/methods/clipping/overlayng/noding/split.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Stages 2 + 4 — order and split (design §2.5, §2.1)
 #
 # For every parent segment of every string, order its interior nodes along the

--- a/src/methods/clipping/overlayng/overlay_graph.jl
+++ b/src/methods/clipping/overlayng/overlay_graph.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Overlay graph — edge merge, half-edge pairs, and the topology graph
 #
 # Phase 2a of the OverlayNG port (design doc §3). Consumes the phase-1

--- a/src/methods/clipping/overlayng/overlay_label.jl
+++ b/src/methods/clipping/overlayng/overlay_label.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayLabel — the per-edge topological label (port of JTS `OverlayLabel`)
 #
 # Phase 2a of the OverlayNG port (design doc `2026-07-16-overlayng-noding-substrate.md`,

--- a/src/methods/clipping/overlayng/overlay_labeller.jl
+++ b/src/methods/clipping/overlayng/overlay_labeller.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayLabeller — the five-pass edge labelling (port of JTS `OverlayLabeller`)
 #
 # Phase 2b of the OverlayNG port (design doc `2026-07-16-overlayng-noding-substrate.md`,

--- a/src/methods/clipping/overlayng/overlay_mixed_points.jl
+++ b/src/methods/clipping/overlayng/overlay_mixed_points.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayMixedPoints — point × (line | area) overlay (port of JTS `OverlayMixedPoints`)
 #
 # Phase 3 of the OverlayNG port (design doc §4). A port of

--- a/src/methods/clipping/overlayng/overlay_ng.jl
+++ b/src/methods/clipping/overlayng/overlay_ng.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayNG driver — the internal end-to-end overlay engine
 #
 # Phase 2b of the OverlayNG port (design doc §3, §4). Ties the phase-1 noding

--- a/src/methods/clipping/overlayng/overlay_points.jl
+++ b/src/methods/clipping/overlayng/overlay_points.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # OverlayPoints — point × point overlay (port of JTS `OverlayPoints`)
 #
 # Phase 3 of the OverlayNG port (design doc §4). A port of

--- a/src/methods/clipping/overlayng/polygon_builder.jl
+++ b/src/methods/clipping/overlayng/polygon_builder.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # PolygonBuilder — result polygons from the marked result-area edges
 #
 # Phase 2b of the OverlayNG port (design doc §3). A port of

--- a/src/methods/geom_relations/relateng/de9im.jl
+++ b/src/methods/geom_relations/relateng/de9im.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # DE-9IM matrix, location and dimension codes
 export DE9IM
 export Mod2Boundary, EndpointBoundary, MultivalentEndpointBoundary, MonovalentEndpointBoundary
@@ -78,6 +80,8 @@ end
 
 """
     DE9IM
+
+This functionality is experimental and may change at any time.
 
 An immutable DE-9IM intersection matrix. Entries are dimension codes
 (`DIM_FALSE`, `DIM_P`, `DIM_L`, `DIM_A`) stored row-major over
@@ -241,6 +245,8 @@ end
 """
     BoundaryNodeRule
 
+This functionality is experimental and may change at any time.
+
 Abstract supertype for rules deciding which endpoints of a linear geometry
 are on its boundary, given the number of line ends meeting at the point
 (port of JTS `BoundaryNodeRule`). Concrete rules are [`Mod2Boundary`](@ref)
@@ -253,6 +259,8 @@ abstract type BoundaryNodeRule end
 """
     Mod2Boundary()
 
+This functionality is experimental and may change at any time.
+
 The OGC SFS standard [`BoundaryNodeRule`](@ref) (and the RelateNG default):
 an endpoint is on the boundary iff an odd number of line ends meet it
 (the "Mod-2 rule"; JTS `Mod2BoundaryNodeRule`).
@@ -261,6 +269,8 @@ struct Mod2Boundary <: BoundaryNodeRule end
 
 """
     EndpointBoundary()
+
+This functionality is experimental and may change at any time.
 
 [`BoundaryNodeRule`](@ref) under which any endpoint of a line is on the
 boundary, regardless of how many line ends meet there (JTS
@@ -271,6 +281,8 @@ struct EndpointBoundary <: BoundaryNodeRule end
 """
     MultivalentEndpointBoundary()
 
+This functionality is experimental and may change at any time.
+
 [`BoundaryNodeRule`](@ref) under which an endpoint is on the boundary iff
 **more than one** line end meets it (JTS
 `MultiValentEndPointBoundaryNodeRule`).
@@ -279,6 +291,8 @@ struct MultivalentEndpointBoundary <: BoundaryNodeRule end
 
 """
     MonovalentEndpointBoundary()
+
+This functionality is experimental and may change at any time.
 
 [`BoundaryNodeRule`](@ref) under which an endpoint is on the boundary iff
 **exactly one** line end meets it (JTS

--- a/src/methods/geom_relations/relateng/edge_intersector.jl
+++ b/src/methods/geom_relations/relateng/edge_intersector.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG edge segment intersector
 #
 # Port of JTS `EdgeSegmentIntersector.java`: tests segments of

--- a/src/methods/geom_relations/relateng/indexed_point_in_area.jl
+++ b/src/methods/geom_relations/relateng/indexed_point_in_area.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG indexed point-in-area location
 #
 # Prepared-mode point-in-area locator for RelateNG (Task 22). This file holds

--- a/src/methods/geom_relations/relateng/kernel.jl
+++ b/src/methods/geom_relations/relateng/kernel.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateKernel API contract
 
 #=

--- a/src/methods/geom_relations/relateng/kernel_planar.jl
+++ b/src/methods/geom_relations/relateng/kernel_planar.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Planar RelateKernel
 
 #=

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Spherical RelateKernel
 #
 #=

--- a/src/methods/geom_relations/relateng/node_sections.jl
+++ b/src/methods/geom_relations/relateng/node_sections.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG node sections
 #
 # Ports of JTS `NodeSection.java` and `NodeSections.java`, in this order

--- a/src/methods/geom_relations/relateng/point_locator.jl
+++ b/src/methods/geom_relations/relateng/point_locator.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG point location
 #
 # Point-location machinery for RelateNG. This file holds the ports of three

--- a/src/methods/geom_relations/relateng/polygon_node_converter.jl
+++ b/src/methods/geom_relations/relateng/polygon_node_converter.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG polygon node converter
 #
 # Port of JTS `PolygonNodeConverter.java`. Method order parallels the Java

--- a/src/methods/geom_relations/relateng/relate_geometry.jl
+++ b/src/methods/geom_relations/relateng/relate_geometry.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG input geometry facade
 #
 # Ports of two tightly coupled JTS classes (JTS file boundaries preserved as

--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Relate
 
 export relate, RelateNG, prepare
@@ -103,6 +105,8 @@ Java counterpart. Idiom changes:
 """
     RelateNG{M <: Manifold, A <: IntersectionAccelerator, E, BR <: BoundaryNodeRule}
 
+This functionality is experimental and may change at any time.
+
 The next-generation DE-9IM topological-relationship algorithm, a port of the
 JTS RelateNG algorithm by Martin Davis. Capabilities:
 
@@ -163,6 +167,8 @@ GeometryOpsCore.manifold(alg::RelateNG) = alg.manifold
 """
     relate([alg::RelateNG], a, b)::DE9IM
 
+This functionality is experimental and may change at any time.
+
 Computes the [`DE9IM`](@ref) matrix for the topological relationship between
 geometries `a` and `b`.
 
@@ -177,6 +183,8 @@ relate(a, b) = relate(RelateNG(), a, b)
 
 """
     relate([alg::RelateNG], a, b, im_pattern::AbstractString)::Bool
+
+This functionality is experimental and may change at any time.
 
 Tests whether the topological relationship between geometries `a` and `b`
 matches the DE-9IM matrix pattern `im_pattern` (9 characters over
@@ -196,6 +204,8 @@ relate(alg::RelateNG, a, im_pattern::AbstractString) =
 
 """
     relate_predicate(alg::RelateNG, predicate::TopologyPredicate, a, b)::Bool
+
+This functionality is experimental and may change at any time.
 
 Tests whether the topological relationship between geometries `a` and `b`
 satisfies the given [`TopologyPredicate`](@ref). This is the core evaluation
@@ -227,15 +237,25 @@ DE-9IM `T*F**FFF*` sense), which can differ from the structural equality
 the two-argument `GO.equals` implements only in exotic cases (both
 treat rotated/reversed rings and repeated points as equal).
 ==========================================================================#
+"This functionality is experimental and may change at any time."
 intersects(alg::RelateNG, g1, g2) = relate_predicate(alg, pred_intersects(), g1, g2)
+"This functionality is experimental and may change at any time."
 disjoint(alg::RelateNG, g1, g2)   = relate_predicate(alg, pred_disjoint(), g1, g2)
+"This functionality is experimental and may change at any time."
 contains(alg::RelateNG, g1, g2)   = relate_predicate(alg, pred_contains(), g1, g2)
+"This functionality is experimental and may change at any time."
 within(alg::RelateNG, g1, g2)     = relate_predicate(alg, pred_within(), g1, g2)
+"This functionality is experimental and may change at any time."
 covers(alg::RelateNG, g1, g2)     = relate_predicate(alg, pred_covers(), g1, g2)
+"This functionality is experimental and may change at any time."
 coveredby(alg::RelateNG, g1, g2)  = relate_predicate(alg, pred_coveredby(), g1, g2)
+"This functionality is experimental and may change at any time."
 crosses(alg::RelateNG, g1, g2)    = relate_predicate(alg, pred_crosses(), g1, g2)
+"This functionality is experimental and may change at any time."
 overlaps(alg::RelateNG, g1, g2)   = relate_predicate(alg, pred_overlaps(), g1, g2)
+"This functionality is experimental and may change at any time."
 touches(alg::RelateNG, g1, g2)    = relate_predicate(alg, pred_touches(), g1, g2)
+"This functionality is experimental and may change at any time."
 equals(alg::RelateNG, g1, g2)     = relate_predicate(alg, pred_equalstopo(), g1, g2)
 
 #==========================================================================
@@ -605,6 +625,8 @@ branches.
 """
     PreparedRelate{ALG, RG, SS, T}
 
+This functionality is experimental and may change at any time.
+
 A prepared RelateNG instance for optimized repeated evaluation of
 topological relationships against a single geometry `a` (the "prepared
 mode" of JTS `RelateNG.prepare`). Holds:
@@ -638,6 +660,8 @@ end
 
 """
     prepare(alg::RelateNG, a; validate = <manifold-dependent>)::PreparedRelate
+
+This functionality is experimental and may change at any time.
 
 `prepare` is the generic entry point for prepared-geometry optimizations in
 GeometryOps; `RelateNG` is currently the only algorithm implementing it.
@@ -860,6 +884,8 @@ end
 """
     relate(p::PreparedRelate, b)::DE9IM
 
+This functionality is experimental and may change at any time.
+
 Computes the DE-9IM matrix for the topological relationship of the prepared
 geometry to `b`. Port of the instance method `RelateNG.evaluate(Geometry)`.
 """
@@ -872,6 +898,8 @@ end
 """
     relate(p::PreparedRelate, b, im_pattern::AbstractString)::Bool
 
+This functionality is experimental and may change at any time.
+
 Tests whether the topological relationship of the prepared geometry to `b`
 matches the DE-9IM pattern. Port of `RelateNG.evaluate(Geometry, String)`.
 """
@@ -880,6 +908,8 @@ relate(p::PreparedRelate, b, im_pattern::AbstractString) =
 
 """
     relate_predicate(p::PreparedRelate, predicate::TopologyPredicate, b)::Bool
+
+This functionality is experimental and may change at any time.
 
 Tests whether the topological relationship of the prepared geometry to `b`
 satisfies the predicate. Port of the instance method

--- a/src/methods/geom_relations/relateng/relate_node.jl
+++ b/src/methods/geom_relations/relateng/relate_node.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG node-edge topology
 #
 # Ports of JTS `RelateEdge.java` and `RelateNode.java`, in this order (JTS

--- a/src/methods/geom_relations/relateng/relate_predicates.jl
+++ b/src/methods/geom_relations/relateng/relate_predicates.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Named DE-9IM relate predicates
 #=
 Port of JTS `RelatePredicate.java` (the `IMPredicate` kinds — the

--- a/src/methods/geom_relations/relateng/topology_computer.jl
+++ b/src/methods/geom_relations/relateng/topology_computer.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # RelateNG topology computer
 #
 # Port of JTS `TopologyComputer.java` — the heart of the topology layer.

--- a/src/methods/geom_relations/relateng/topology_predicate.jl
+++ b/src/methods/geom_relations/relateng/topology_predicate.jl
@@ -1,3 +1,5 @@
+# NOTE: This functionality is experimental and may change at any time.
+
 # # Topology predicate framework
 #=
 Port of JTS `TopologyPredicate`, `BasicPredicate`, `IMPredicate`


### PR DESCRIPTION
## Summary

- Add the same one-line experimental notice to every OverlayNG and RelateNG source file.
- Surface the notice in the algorithm constructor and public API documentation, including prepared RelateNG and the exported DE-9IM/boundary-rule types.
- Keep the change documentation-only; runtime behavior is unchanged.

## Validation

- `git diff --check`
- Verified the diff contains only comments, docstrings, and blank separator lines.
- `julia --project=docs -e 'using GeometryOps; println("GeometryOps loaded")'`
