### PR TITLE
Let a prepared geometry stand in for the A geometry in `RelateNG`

### DIFF
--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -236,6 +236,12 @@ dispatching to the old engines (design D4).
 DE-9IM `T*F**FFF*` sense), which can differ from the structural equality
 the two-argument `GO.equals` implements only in exotic cases (both
 treat rotated/reversed rings and repeated points as equal).
+
+These rebuild the A side on every call. When one geometry is queried many
+times, [`prepare`](@ref) it: a `PreparedRelate` may be passed as `g1` to
+any of these (it flows through `relate_predicate`, which reuses it rather
+than rebuilding), or the two-argument prepared forms `GO.covers(prep, b)`
+may be used directly. See the prepared-mode section below.
 ==========================================================================#
 "This functionality is experimental and may change at any time."
 intersects(alg::RelateNG, g1, g2) = relate_predicate(alg, pred_intersects(), g1, g2)
@@ -623,7 +629,7 @@ branches.
 ==========================================================================#
 
 """
-    PreparedRelate{ALG, RG, SS, T}
+    PreparedRelate{ALG, G, RG, SS, T}
 
 This functionality is experimental and may change at any time.
 
@@ -632,6 +638,11 @@ topological relationships against a single geometry `a` (the "prepared
 mode" of JTS `RelateNG.prepare`). Holds:
 
 - `alg`: the [`RelateNG`](@ref) algorithm configuration,
+- `input`: the A geometry exactly as passed to [`prepare`](@ref). Held
+  because `geom_a` below is *manifold-specific* — its cached extents are
+  the interaction bounds of `alg`'s manifold (3D on `Spherical`), so it
+  cannot be re-prepared under a different one; the raw input can. Costs
+  nothing: the wrapper tree already shares the input's linework,
 - `geom_a`: the A-side [`RelateGeometry`](@ref), constructed with
   `is_prepared = true` and with its lazy locator/unique-points caches
   forced,
@@ -650,9 +661,10 @@ Construct with [`prepare`](@ref); evaluate with [`relate`](@ref) /
     `RelateGeometry` (edge re-extraction, element-id counter). Use one
     `PreparedRelate` per thread.
 """
-struct PreparedRelate{ALG <: RelateNG, RG <: RelateGeometry,
+struct PreparedRelate{ALG <: RelateNG, G, RG <: RelateGeometry,
         SS <: AbstractVector{<:RelateSegmentString}, T <: Union{Nothing, RTree}}
     alg::ALG
+    input::G
     geom_a::RG
     segs_a::SS
     edge_tree::T
@@ -733,7 +745,7 @@ function prepare(alg::RelateNG, a;
     #-- force the lazy caches that repeated evaluations reuse
     _get_locator(geom_a)
     get_dimension_real(geom_a) == DIM_P && get_unique_points(geom_a)
-    return PreparedRelate(alg, geom_a, segs_a, edge_tree)
+    return PreparedRelate(alg, a, geom_a, segs_a, edge_tree)
 end
 
 # The manifold-dependent `validate` default of `prepare` (see its docstring
@@ -742,6 +754,86 @@ end
 # default.
 _prepare_validate_default(::Spherical) = true
 _prepare_validate_default(::Manifold) = false
+
+"""
+    prepare(alg::RelateNG, p::PreparedRelate; validate = <manifold-dependent>)::PreparedRelate
+
+This functionality is experimental and may change at any time.
+
+`prepare` is idempotent: preparing an already-prepared geometry under an
+algorithm it is already valid for returns it *unchanged*. This is what lets
+a `PreparedRelate` be passed as the A geometry to any `RelateNG` entry
+point — [`relate`](@ref), [`relate_predicate`](@ref), and the named
+predicates `covers(alg, a, b)` etc. — without rebuilding the cached
+structures on every call.
+
+Three cases, in order of cost:
+
+1. `alg` agrees with the algorithm `p` was prepared under: `p` is returned
+   as-is, at no cost.
+2. Only `alg.accelerator` differs: the [`RelateGeometry`](@ref) and the
+   segment strings — the expensive parts — are reused, and only the
+   accelerator-derived edge index is rebuilt (or dropped) to honour the
+   requested strategy. The accelerator cannot change the *answer*, only how
+   the same segment-pair set is enumerated, so this never invalidates the
+   cache.
+3. `manifold`, `boundary_rule` or `exact` differ: these are baked into the
+   prepared `RelateGeometry` and its locators, and they change the answer,
+   so the cache cannot be reused — the geometry is prepared afresh from
+   `p`'s source geometry, at the full cost of [`prepare`](@ref).
+
+!!! warning
+    Case 3 is a full rebuild. Preparing under one manifold and querying
+    under another — `prep = prepare(RelateNG(Spherical()), a)` followed by
+    `covers(RelateNG(), prep, b)` in a loop — silently pays that cost on
+    every call, which is exactly what `prepare` exists to avoid. Prepare
+    under the algorithm you intend to query with.
+
+`validate` applies only to case 3, the rebuild; a reused prepared geometry
+keeps whatever validation state it was built with.
+"""
+function prepare(alg::RelateNG, p::PreparedRelate;
+        validate::Bool = _prepare_validate_default(GeometryOpsCore.manifold(alg)))
+    if _prepared_geometry_settings_agree(alg, p.alg)
+        alg.accelerator == p.alg.accelerator && return p
+        #-- accelerator-only difference: keep the geometry and its segment
+        #-- strings, swap the index the new accelerator asks for
+        return PreparedRelate(alg, p.input, p.geom_a, p.segs_a,
+            _build_prepared_edge_index(GeometryOpsCore.manifold(alg), alg.accelerator, p.segs_a))
+    end
+    #-- rebuild from the raw input, never from `p.geom_a.geom`: the latter
+    #-- carries extents cached as *this* manifold's interaction bounds
+    #-- (3D on `Spherical`), which another manifold would silently reuse
+    #-- as its own and prune against
+    return prepare(alg, p.input; validate)
+end
+
+# The settings baked into a prepared `RelateGeometry` (and its locators),
+# i.e. the ones a prepared instance cannot be reused across. `accelerator`
+# is deliberately absent: it only selects how the segment-pair set is
+# enumerated, never the answer, and `prepare` above swaps the index instead
+# of rebuilding the geometry when it is the only difference.
+_prepared_geometry_settings_agree(alg1::RelateNG, alg2::RelateNG) =
+    _manifolds_agree(alg1.manifold, alg2.manifold) &&
+    alg1.boundary_rule == alg2.boundary_rule &&
+    alg1.exact == alg2.exact
+
+#=
+Manifold agreement. `Manifold`s define no `==` of their own, so `==` falls
+back to `===` (egal), i.e. field-wise *bit* equality. That is exactly right
+for the singleton `Planar()`, and for the common case of two manifolds
+built the same way, but too strict for the parametric manifolds, whose
+numeric fields can differ in type while denoting the same space:
+`Spherical(radius = 1)` and `Spherical(radius = 1.0)` are not `===`. Those
+are compared parameter-by-parameter with numeric `==` instead; anything
+else (including a manifold type this file does not know about) falls back
+to the strict comparison, which errs toward reporting a difference.
+=#
+_manifolds_agree(m1::Manifold, m2::Manifold) = m1 == m2
+_manifolds_agree(m1::Spherical, m2::Spherical) =
+    m1.radius == m2.radius && m1.oriented == m2.oriented
+_manifolds_agree(m1::Geodesic, m2::Geodesic) =
+    m1.semimajor_axis == m2.semimajor_axis && m1.inv_flattening == m2.inv_flattening
 
 #=
 The validation join: enumerate extent-interacting segment pairs within the
@@ -917,6 +1009,150 @@ satisfies the predicate. Port of the instance method
 """
 relate_predicate(p::PreparedRelate, predicate::TopologyPredicate, b) =
     evaluate!(p.alg, p.geom_a, b, predicate, p)
+
+"""
+    relate_predicate(alg::RelateNG, predicate::TopologyPredicate, p::PreparedRelate, b)::Bool
+
+This functionality is experimental and may change at any time.
+
+The A-geometry-is-already-prepared form of the unprepared entry point:
+`p` is passed through [`prepare`](@ref), which returns it unchanged when
+`alg` is the algorithm it was prepared under, so the cached A side is
+reused instead of rebuilt.
+
+This is the single method through which every `RelateNG` entry point
+accepts a `PreparedRelate` as its A geometry — `relate(alg, p, b)`,
+`relate(alg, p, b, im_pattern)` and the named predicates
+`covers(alg, p, b)` etc. all forward here — so all of them reuse the
+prepared structures rather than rebuilding A on every call.
+
+!!! note
+    Predicates are mutable accumulators — pass a freshly constructed one
+    (e.g. `pred_intersects()`) per evaluation.
+"""
+relate_predicate(alg::RelateNG, predicate::TopologyPredicate, p::PreparedRelate, b) =
+    relate_predicate(prepare(alg, p), predicate, b)
+
+#==========================================================================
+## Prepared-mode named predicates
+
+The prepared counterparts of the named-predicate block above. The prepared
+geometry is always the A side, so `covers(p, b)` reads exactly like
+`covers(alg, a, b)` for the `alg` and `a` that `p` was prepared from.
+
+These two-argument forms exist because the two-argument `GO.covers(a, b)`
+etc. dispatch to the *old* engines (design D4); only these methods and the
+`f(alg, p, b)` forms above route a prepared A side into RelateNG.
+==========================================================================#
+
+# The shared tail of the prepared named-predicate docstrings below.
+const _PREPARED_PREDICATE_DOC = """
+This functionality is experimental and may change at any time.
+
+The prepared-mode counterpart of the unprepared `f(alg::RelateNG, a, b)`
+method: it reuses the structures [`prepare`](@ref) cached on the A side
+(the point locators, the unfiltered A segment strings and the segment index
+over them, plus — on `Spherical` — the ring validation). Calling the
+unprepared form in a loop over many `b` rebuilds all of that on *every*
+call, which is exactly the cost [`prepare`](@ref) exists to amortize (a
+spherical prepare build is on the order of 100 ms; a planar one ~600 µs).
+
+`f(alg, p, b)` is equivalent whenever `alg` is the algorithm `p` was
+prepared under; see [`prepare`](@ref) for what happens when it is not.
+"""
+
+"""
+    intersects(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry intersects `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+intersects(p::PreparedRelate, b) = relate_predicate(p, pred_intersects(), b)
+
+"""
+    disjoint(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry is disjoint from `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+disjoint(p::PreparedRelate, b)   = relate_predicate(p, pred_disjoint(), b)
+
+"""
+    contains(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry contains `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+contains(p::PreparedRelate, b)   = relate_predicate(p, pred_contains(), b)
+
+"""
+    within(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry is within `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+within(p::PreparedRelate, b)     = relate_predicate(p, pred_within(), b)
+
+"""
+    covers(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry covers `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+covers(p::PreparedRelate, b)     = relate_predicate(p, pred_covers(), b)
+
+"""
+    coveredby(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry is covered by `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+coveredby(p::PreparedRelate, b)  = relate_predicate(p, pred_coveredby(), b)
+
+"""
+    crosses(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry crosses `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+crosses(p::PreparedRelate, b)    = relate_predicate(p, pred_crosses(), b)
+
+"""
+    overlaps(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry overlaps `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+overlaps(p::PreparedRelate, b)   = relate_predicate(p, pred_overlaps(), b)
+
+"""
+    touches(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry touches `b`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+touches(p::PreparedRelate, b)    = relate_predicate(p, pred_touches(), b)
+
+"""
+    equals(p::PreparedRelate, b)::Bool
+
+Tests whether the prepared geometry is *topologically* equal to `b` (the
+DE-9IM `T*F**FFF*` sense, `pred_equalstopo`), matching
+`equals(alg::RelateNG, a, b)` rather than the structural two-argument
+`equals`.
+
+$(_PREPARED_PREDICATE_DOC)
+"""
+equals(p::PreparedRelate, b)     = relate_predicate(p, pred_equalstopo(), b)
 
 # Whether to prebuild the A-side segment tree, mirroring the dispatch of
 # `process_edge_intersections!` + `_select_edge_set_accelerator`: an explicit

--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -237,10 +237,8 @@ DE-9IM `T*F**FFF*` sense), which can differ from the structural equality
 the two-argument `GO.equals` implements only in exotic cases (both
 treat rotated/reversed rings and repeated points as equal).
 
-These rebuild the A side on every call. When one geometry is queried many
-times, [`prepare`](@ref) it and pass the `PreparedRelate` as `g1`: it
-flows through `relate_predicate` below, which reuses the cached structures
-rather than rebuilding them.
+These rebuild the A side on every call; pass a [`prepare`](@ref)d `g1` to
+reuse it instead.
 ==========================================================================#
 "This functionality is experimental and may change at any time."
 intersects(alg::RelateNG, g1, g2) = relate_predicate(alg, pred_intersects(), g1, g2)
@@ -637,11 +635,9 @@ topological relationships against a single geometry `a` (the "prepared
 mode" of JTS `RelateNG.prepare`). Holds:
 
 - `alg`: the [`RelateNG`](@ref) algorithm configuration,
-- `input`: the A geometry exactly as passed to [`prepare`](@ref). Held
-  because `geom_a` below is *manifold-specific* — its cached extents are
-  the interaction bounds of `alg`'s manifold (3D on `Spherical`), so it
-  cannot be re-prepared under a different one; the raw input can. Costs
-  nothing: the wrapper tree already shares the input's linework,
+- `input`: the A geometry as passed to [`prepare`](@ref), which re-prepares
+  from it under a different `alg` (`geom_a` below caches `alg`'s manifold's
+  extents, so it cannot serve another),
 - `geom_a`: the A-side [`RelateGeometry`](@ref), constructed with
   `is_prepared = true` and with its lazy locator/unique-points caches
   forced,
@@ -759,32 +755,15 @@ _prepare_validate_default(::Manifold) = false
 
 This functionality is experimental and may change at any time.
 
-`prepare` is idempotent: under the algorithm `p` was prepared with, `p`
-itself is returned, at no cost. This is what lets a `PreparedRelate` be
-passed as the A geometry to any `RelateNG` entry point — [`relate`](@ref),
-[`relate_predicate`](@ref), and the named predicates `covers(alg, a, b)`
-etc. — without rebuilding the cached structures on every call.
-
-Under any other `alg` the geometry is prepared afresh from `p`'s input, at
-the full cost of [`prepare`](@ref) — every setting of `RelateNG` is baked
-into either the prepared `RelateGeometry` and its locators or the edge
-index built over the segment strings.
-
-!!! warning
-    That rebuild is paid on *every* call: preparing under one algorithm and
-    querying under another — `prep = prepare(RelateNG(Spherical()), a)`
-    followed by `covers(RelateNG(), prep, b)` in a loop — is exactly what
-    `prepare` exists to avoid. Prepare under the algorithm you query with.
-
-`validate` applies only to the rebuild; a reused prepared geometry keeps
-whatever validation state it was built with.
+Returns `p` under the algorithm it was prepared with, so a `PreparedRelate`
+can be passed as the A geometry to any `RelateNG` entry point. Under any
+other `alg` — every setting is baked into the prepared structures — it is
+prepared afresh from `p.input`, at the full cost of [`prepare`](@ref) on
+every call, so prepare under the algorithm you query with. `validate`
+applies only to that rebuild.
 """
 prepare(alg::RelateNG, p::PreparedRelate;
         validate::Bool = _prepare_validate_default(GeometryOpsCore.manifold(alg))) =
-    #-- rebuild from the raw input, never from `p.geom_a.geom`: the latter
-    #-- carries extents cached as *this* manifold's interaction bounds
-    #-- (3D on `Spherical`), which another manifold would silently reuse
-    #-- as its own and prune against
     alg == p.alg ? p : prepare(alg, p.input; validate)
 
 #=
@@ -962,11 +941,8 @@ satisfies the predicate. Port of the instance method
 relate_predicate(p::PreparedRelate, predicate::TopologyPredicate, b) =
     evaluate!(p.alg, p.geom_a, b, predicate, p)
 
-# A `PreparedRelate` stands in for the A geometry at every `RelateNG` entry
-# point: `relate(alg, p, b)`, `relate(alg, p, b, im_pattern)` and the named
-# predicates `covers(alg, p, b)` etc. all forward here, and `prepare` returns
-# `p` itself under the algorithm it was prepared with, so the cached A side is
-# reused instead of rebuilt.
+# The prepared A side at the algorithm entry points: `relate` and the named
+# predicates all forward here, so this is the only method they need.
 relate_predicate(alg::RelateNG, predicate::TopologyPredicate, p::PreparedRelate, b) =
     relate_predicate(prepare(alg, p), predicate, b)
 

--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -238,10 +238,9 @@ the two-argument `GO.equals` implements only in exotic cases (both
 treat rotated/reversed rings and repeated points as equal).
 
 These rebuild the A side on every call. When one geometry is queried many
-times, [`prepare`](@ref) it: a `PreparedRelate` may be passed as `g1` to
-any of these (it flows through `relate_predicate`, which reuses it rather
-than rebuilding), or the two-argument prepared forms `GO.covers(prep, b)`
-may be used directly. See the prepared-mode section below.
+times, [`prepare`](@ref) it and pass the `PreparedRelate` as `g1`: it
+flows through `relate_predicate` below, which reuses the cached structures
+rather than rebuilding them.
 ==========================================================================#
 "This functionality is experimental and may change at any time."
 intersects(alg::RelateNG, g1, g2) = relate_predicate(alg, pred_intersects(), g1, g2)
@@ -760,80 +759,33 @@ _prepare_validate_default(::Manifold) = false
 
 This functionality is experimental and may change at any time.
 
-`prepare` is idempotent: preparing an already-prepared geometry under an
-algorithm it is already valid for returns it *unchanged*. This is what lets
-a `PreparedRelate` be passed as the A geometry to any `RelateNG` entry
-point — [`relate`](@ref), [`relate_predicate`](@ref), and the named
-predicates `covers(alg, a, b)` etc. — without rebuilding the cached
-structures on every call.
+`prepare` is idempotent: under the algorithm `p` was prepared with, `p`
+itself is returned, at no cost. This is what lets a `PreparedRelate` be
+passed as the A geometry to any `RelateNG` entry point — [`relate`](@ref),
+[`relate_predicate`](@ref), and the named predicates `covers(alg, a, b)`
+etc. — without rebuilding the cached structures on every call.
 
-Three cases, in order of cost:
-
-1. `alg` agrees with the algorithm `p` was prepared under: `p` is returned
-   as-is, at no cost.
-2. Only `alg.accelerator` differs: the [`RelateGeometry`](@ref) and the
-   segment strings — the expensive parts — are reused, and only the
-   accelerator-derived edge index is rebuilt (or dropped) to honour the
-   requested strategy. The accelerator cannot change the *answer*, only how
-   the same segment-pair set is enumerated, so this never invalidates the
-   cache.
-3. `manifold`, `boundary_rule` or `exact` differ: these are baked into the
-   prepared `RelateGeometry` and its locators, and they change the answer,
-   so the cache cannot be reused — the geometry is prepared afresh from
-   `p`'s source geometry, at the full cost of [`prepare`](@ref).
+Under any other `alg` the geometry is prepared afresh from `p`'s input, at
+the full cost of [`prepare`](@ref) — every setting of `RelateNG` is baked
+into either the prepared `RelateGeometry` and its locators or the edge
+index built over the segment strings.
 
 !!! warning
-    Case 3 is a full rebuild. Preparing under one manifold and querying
-    under another — `prep = prepare(RelateNG(Spherical()), a)` followed by
-    `covers(RelateNG(), prep, b)` in a loop — silently pays that cost on
-    every call, which is exactly what `prepare` exists to avoid. Prepare
-    under the algorithm you intend to query with.
+    That rebuild is paid on *every* call: preparing under one algorithm and
+    querying under another — `prep = prepare(RelateNG(Spherical()), a)`
+    followed by `covers(RelateNG(), prep, b)` in a loop — is exactly what
+    `prepare` exists to avoid. Prepare under the algorithm you query with.
 
-`validate` applies only to case 3, the rebuild; a reused prepared geometry
-keeps whatever validation state it was built with.
+`validate` applies only to the rebuild; a reused prepared geometry keeps
+whatever validation state it was built with.
 """
-function prepare(alg::RelateNG, p::PreparedRelate;
-        validate::Bool = _prepare_validate_default(GeometryOpsCore.manifold(alg)))
-    if _prepared_geometry_settings_agree(alg, p.alg)
-        alg.accelerator == p.alg.accelerator && return p
-        #-- accelerator-only difference: keep the geometry and its segment
-        #-- strings, swap the index the new accelerator asks for
-        return PreparedRelate(alg, p.input, p.geom_a, p.segs_a,
-            _build_prepared_edge_index(GeometryOpsCore.manifold(alg), alg.accelerator, p.segs_a))
-    end
+prepare(alg::RelateNG, p::PreparedRelate;
+        validate::Bool = _prepare_validate_default(GeometryOpsCore.manifold(alg))) =
     #-- rebuild from the raw input, never from `p.geom_a.geom`: the latter
     #-- carries extents cached as *this* manifold's interaction bounds
     #-- (3D on `Spherical`), which another manifold would silently reuse
     #-- as its own and prune against
-    return prepare(alg, p.input; validate)
-end
-
-# The settings baked into a prepared `RelateGeometry` (and its locators),
-# i.e. the ones a prepared instance cannot be reused across. `accelerator`
-# is deliberately absent: it only selects how the segment-pair set is
-# enumerated, never the answer, and `prepare` above swaps the index instead
-# of rebuilding the geometry when it is the only difference.
-_prepared_geometry_settings_agree(alg1::RelateNG, alg2::RelateNG) =
-    _manifolds_agree(alg1.manifold, alg2.manifold) &&
-    alg1.boundary_rule == alg2.boundary_rule &&
-    alg1.exact == alg2.exact
-
-#=
-Manifold agreement. `Manifold`s define no `==` of their own, so `==` falls
-back to `===` (egal), i.e. field-wise *bit* equality. That is exactly right
-for the singleton `Planar()`, and for the common case of two manifolds
-built the same way, but too strict for the parametric manifolds, whose
-numeric fields can differ in type while denoting the same space:
-`Spherical(radius = 1)` and `Spherical(radius = 1.0)` are not `===`. Those
-are compared parameter-by-parameter with numeric `==` instead; anything
-else (including a manifold type this file does not know about) falls back
-to the strict comparison, which errs toward reporting a difference.
-=#
-_manifolds_agree(m1::Manifold, m2::Manifold) = m1 == m2
-_manifolds_agree(m1::Spherical, m2::Spherical) =
-    m1.radius == m2.radius && m1.oriented == m2.oriented
-_manifolds_agree(m1::Geodesic, m2::Geodesic) =
-    m1.semimajor_axis == m2.semimajor_axis && m1.inv_flattening == m2.inv_flattening
+    alg == p.alg ? p : prepare(alg, p.input; validate)
 
 #=
 The validation join: enumerate extent-interacting segment pairs within the
@@ -1010,149 +962,13 @@ satisfies the predicate. Port of the instance method
 relate_predicate(p::PreparedRelate, predicate::TopologyPredicate, b) =
     evaluate!(p.alg, p.geom_a, b, predicate, p)
 
-"""
-    relate_predicate(alg::RelateNG, predicate::TopologyPredicate, p::PreparedRelate, b)::Bool
-
-This functionality is experimental and may change at any time.
-
-The A-geometry-is-already-prepared form of the unprepared entry point:
-`p` is passed through [`prepare`](@ref), which returns it unchanged when
-`alg` is the algorithm it was prepared under, so the cached A side is
-reused instead of rebuilt.
-
-This is the single method through which every `RelateNG` entry point
-accepts a `PreparedRelate` as its A geometry — `relate(alg, p, b)`,
-`relate(alg, p, b, im_pattern)` and the named predicates
-`covers(alg, p, b)` etc. all forward here — so all of them reuse the
-prepared structures rather than rebuilding A on every call.
-
-!!! note
-    Predicates are mutable accumulators — pass a freshly constructed one
-    (e.g. `pred_intersects()`) per evaluation.
-"""
+# A `PreparedRelate` stands in for the A geometry at every `RelateNG` entry
+# point: `relate(alg, p, b)`, `relate(alg, p, b, im_pattern)` and the named
+# predicates `covers(alg, p, b)` etc. all forward here, and `prepare` returns
+# `p` itself under the algorithm it was prepared with, so the cached A side is
+# reused instead of rebuilt.
 relate_predicate(alg::RelateNG, predicate::TopologyPredicate, p::PreparedRelate, b) =
     relate_predicate(prepare(alg, p), predicate, b)
-
-#==========================================================================
-## Prepared-mode named predicates
-
-The prepared counterparts of the named-predicate block above. The prepared
-geometry is always the A side, so `covers(p, b)` reads exactly like
-`covers(alg, a, b)` for the `alg` and `a` that `p` was prepared from.
-
-These two-argument forms exist because the two-argument `GO.covers(a, b)`
-etc. dispatch to the *old* engines (design D4); only these methods and the
-`f(alg, p, b)` forms above route a prepared A side into RelateNG.
-==========================================================================#
-
-# The shared tail of the prepared named-predicate docstrings below.
-const _PREPARED_PREDICATE_DOC = """
-This functionality is experimental and may change at any time.
-
-The prepared-mode counterpart of the unprepared `f(alg::RelateNG, a, b)`
-method: it reuses the structures [`prepare`](@ref) cached on the A side
-(the point locators, the unfiltered A segment strings and the segment index
-over them, plus — on `Spherical` — the ring validation). Calling the
-unprepared form in a loop over many `b` rebuilds all of that on *every*
-call, which is exactly the cost [`prepare`](@ref) exists to amortize (a
-spherical prepare build is on the order of 100 ms; a planar one ~600 µs).
-
-`f(alg, p, b)` is equivalent whenever `alg` is the algorithm `p` was
-prepared under; see [`prepare`](@ref) for what happens when it is not.
-"""
-
-"""
-    intersects(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry intersects `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-intersects(p::PreparedRelate, b) = relate_predicate(p, pred_intersects(), b)
-
-"""
-    disjoint(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry is disjoint from `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-disjoint(p::PreparedRelate, b)   = relate_predicate(p, pred_disjoint(), b)
-
-"""
-    contains(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry contains `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-contains(p::PreparedRelate, b)   = relate_predicate(p, pred_contains(), b)
-
-"""
-    within(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry is within `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-within(p::PreparedRelate, b)     = relate_predicate(p, pred_within(), b)
-
-"""
-    covers(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry covers `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-covers(p::PreparedRelate, b)     = relate_predicate(p, pred_covers(), b)
-
-"""
-    coveredby(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry is covered by `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-coveredby(p::PreparedRelate, b)  = relate_predicate(p, pred_coveredby(), b)
-
-"""
-    crosses(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry crosses `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-crosses(p::PreparedRelate, b)    = relate_predicate(p, pred_crosses(), b)
-
-"""
-    overlaps(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry overlaps `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-overlaps(p::PreparedRelate, b)   = relate_predicate(p, pred_overlaps(), b)
-
-"""
-    touches(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry touches `b`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-touches(p::PreparedRelate, b)    = relate_predicate(p, pred_touches(), b)
-
-"""
-    equals(p::PreparedRelate, b)::Bool
-
-Tests whether the prepared geometry is *topologically* equal to `b` (the
-DE-9IM `T*F**FFF*` sense, `pred_equalstopo`), matching
-`equals(alg::RelateNG, a, b)` rather than the structural two-argument
-`equals`.
-
-$(_PREPARED_PREDICATE_DOC)
-"""
-equals(p::PreparedRelate, b)     = relate_predicate(p, pred_equalstopo(), b)
 
 # Whether to prebuild the A-side segment tree, mirroring the dispatch of
 # `process_edge_intersections!` + `_select_edge_set_accelerator`: an explicit

--- a/test/methods/relateng/relate_ng.jl
+++ b/test/methods/relateng/relate_ng.jl
@@ -1004,13 +1004,13 @@ end
 end
 
 # =========================================================================
-# Prepared-mode named predicates, and prepared A sides at the algorithm
-# entry points. `prepare` is idempotent, so a `PreparedRelate` stands in for
-# the A geometry anywhere a raw geometry can — `GO.covers(alg, prep, b)`
-# reuses the prepared structures instead of rebuilding A on every call.
+# A prepared A side at the algorithm entry points. `prepare` is idempotent,
+# so a `PreparedRelate` stands in for the A geometry anywhere a raw geometry
+# can — `GO.covers(alg, prep, b)` reuses the prepared structures instead of
+# rebuilding A on every call.
 # =========================================================================
 
-@testset "PreparedNamedPredicates" begin
+@testset "PreparedAGeometry" begin
     a = GI.Polygon([[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0), (0.0, 0.0)]])
     #-- B geometries hitting the true and false cases of every named predicate
     bs = (
@@ -1031,12 +1031,11 @@ end
     @testset "$(nameof(typeof(m))) manifold" for m in (GO.Planar(), GO.Spherical())
         alg = GO.RelateNG(m)
         prep = GO.prepare(alg, a)
+        #-- every named predicate takes the prepared A side
         for f in preds, b in bs
-            expected = f(alg, a, b)
-            @test f(prep, b) == expected       #-- two-argument prepared form
-            @test f(alg, prep, b) == expected  #-- prepared A side at the alg entry point
+            @test f(alg, prep, b) == f(alg, a, b)
         end
-        #-- the general entry points accept a prepared A side too
+        #-- as do the general entry points
         for b in bs
             @test GO.relate(alg, prep, b) == GO.relate(prep, b) == GO.relate(alg, a, b)
             @test GO.relate(alg, prep, b, "T*T***T**") == GO.relate(alg, a, b, "T*T***T**")
@@ -1048,45 +1047,19 @@ end
     @testset "prepare is idempotent, and re-prepares on a settings change" begin
         palg = GO.RelateNG()
         prep = GO.prepare(palg, a)
-        #-- matching settings: the very same instance comes back, untouched
+        #-- the same algorithm: the very same instance comes back, untouched
         @test GO.prepare(palg, prep) === prep
         @test GO.prepare(GO.RelateNG(GO.Planar()), prep) === prep
-        #-- numerically equal manifold parameters of differing types still match
-        sprep = GO.prepare(GO.RelateNG(GO.Spherical(radius = 1.0)), a)
-        @test GO.prepare(GO.RelateNG(GO.Spherical(radius = 1)), sprep) === sprep
-        #-- settings baked into the prepared geometry force a rebuild
+        #-- any settings change rebuilds
         for alg2 in (GO.RelateNG(GO.Spherical()),
                 GO.RelateNG(; boundary_rule = GO.EndpointBoundary()),
-                GO.RelateNG(; exact = GO.GeometryOpsCore.False()))
+                GO.RelateNG(; exact = GO.GeometryOpsCore.False()),
+                GO.RelateNG(; accelerator = GO.NestedLoop()))
             rebuilt = GO.prepare(alg2, prep)
             @test rebuilt !== prep
             @test rebuilt.geom_a !== prep.geom_a
             @test rebuilt.alg == alg2
         end
-    end
-
-    @testset "an accelerator change swaps only the edge index" begin
-        #-- 64 segments >= threshold, so AutoAccelerator prebuilds a tree
-        n = 64
-        coords = [(5 + 4 * cospi(2k / n), 5 + 4 * sinpi(2k / n)) for k in 0:(n - 1)]
-        push!(coords, coords[1])
-        big = GI.Polygon([coords])
-        auto = GO.RelateNG()
-        nested = GO.RelateNG(; accelerator = GO.NestedLoop())
-        prep = GO.prepare(auto, big)
-        @test prep.edge_tree !== nothing
-
-        swapped = GO.prepare(nested, prep)
-        @test swapped !== prep
-        @test swapped.geom_a === prep.geom_a   #-- the expensive parts are reused
-        @test swapped.segs_a === prep.segs_a
-        @test swapped.edge_tree === nothing    #-- the requested strategy is honoured
-        @test swapped.alg == nested
-        @test GO.prepare(auto, swapped).edge_tree !== nothing  #-- and back again
-
-        b = GI.Polygon([[(4.0, 4.0), (11.0, 4.0), (11.0, 11.0), (4.0, 11.0), (4.0, 4.0)]])
-        @test GO.covers(nested, prep, b) == GO.covers(auto, big, b)
-        @test GO.relate(nested, prep, b) == GO.relate(auto, big, b)
     end
 
     @testset "a prepared A side follows the algorithm actually passed" begin
@@ -1111,8 +1084,8 @@ end
         @test GO.touches(epalg, mls, junction) == true
 
         m2prep = GO.prepare(m2alg, mls)
-        @test GO.touches(m2prep, junction) == false            #-- the prepared rule
-        @test GO.touches(epalg, m2prep, junction) == true      #-- the rule passed in
+        @test GO.touches(m2alg, m2prep, junction) == false   #-- the prepared rule
+        @test GO.touches(epalg, m2prep, junction) == true    #-- the rule passed in
         @test GO.relate(epalg, m2prep, junction) == GO.relate(epalg, mls, junction)
     end
 end

--- a/test/methods/relateng/relate_ng.jl
+++ b/test/methods/relateng/relate_ng.jl
@@ -1002,3 +1002,117 @@ end
         @test_throws ArgumentError GO.prepare(palg, ring_crossed; validate = true)
     end
 end
+
+# =========================================================================
+# Prepared-mode named predicates, and prepared A sides at the algorithm
+# entry points. `prepare` is idempotent, so a `PreparedRelate` stands in for
+# the A geometry anywhere a raw geometry can — `GO.covers(alg, prep, b)`
+# reuses the prepared structures instead of rebuilding A on every call.
+# =========================================================================
+
+@testset "PreparedNamedPredicates" begin
+    a = GI.Polygon([[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0), (0.0, 0.0)]])
+    #-- B geometries hitting the true and false cases of every named predicate
+    bs = (
+        GI.Polygon([[(2.0, 2.0), (6.0, 2.0), (6.0, 6.0), (2.0, 6.0), (2.0, 2.0)]]),           # overlaps
+        GI.Polygon([[(1.0, 1.0), (2.0, 1.0), (2.0, 2.0), (1.0, 2.0), (1.0, 1.0)]]),           # within a
+        GI.Polygon([[(-1.0, -1.0), (5.0, -1.0), (5.0, 5.0), (-1.0, 5.0), (-1.0, -1.0)]]),     # contains a
+        GI.Polygon([[(10.0, 10.0), (12.0, 10.0), (12.0, 12.0), (10.0, 12.0), (10.0, 10.0)]]), # disjoint
+        GI.Polygon([[(4.0, 0.0), (8.0, 0.0), (8.0, 4.0), (4.0, 4.0), (4.0, 0.0)]]),           # touches
+        GI.Polygon([[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0), (0.0, 0.0)]]),           # equal
+        GI.LineString([(-1.0, 2.0), (5.0, 2.0)]),                                             # crosses
+        GI.LineString([(-2.0, -2.0), (-1.0, -2.0)]),                                          # disjoint line
+        GI.Point((2.0, 2.0)),                                                                 # interior point
+        GI.Point((20.0, 20.0)),                                                               # exterior point
+    )
+    preds = (GO.intersects, GO.disjoint, GO.contains, GO.within, GO.covers,
+        GO.coveredby, GO.crosses, GO.overlaps, GO.touches, GO.equals)
+
+    @testset "$(nameof(typeof(m))) manifold" for m in (GO.Planar(), GO.Spherical())
+        alg = GO.RelateNG(m)
+        prep = GO.prepare(alg, a)
+        for f in preds, b in bs
+            expected = f(alg, a, b)
+            @test f(prep, b) == expected       #-- two-argument prepared form
+            @test f(alg, prep, b) == expected  #-- prepared A side at the alg entry point
+        end
+        #-- the general entry points accept a prepared A side too
+        for b in bs
+            @test GO.relate(alg, prep, b) == GO.relate(prep, b) == GO.relate(alg, a, b)
+            @test GO.relate(alg, prep, b, "T*T***T**") == GO.relate(alg, a, b, "T*T***T**")
+            @test GO.relate_predicate(alg, GO.pred_covers(), prep, b) ==
+                GO.relate_predicate(alg, GO.pred_covers(), a, b)
+        end
+    end
+
+    @testset "prepare is idempotent, and re-prepares on a settings change" begin
+        palg = GO.RelateNG()
+        prep = GO.prepare(palg, a)
+        #-- matching settings: the very same instance comes back, untouched
+        @test GO.prepare(palg, prep) === prep
+        @test GO.prepare(GO.RelateNG(GO.Planar()), prep) === prep
+        #-- numerically equal manifold parameters of differing types still match
+        sprep = GO.prepare(GO.RelateNG(GO.Spherical(radius = 1.0)), a)
+        @test GO.prepare(GO.RelateNG(GO.Spherical(radius = 1)), sprep) === sprep
+        #-- settings baked into the prepared geometry force a rebuild
+        for alg2 in (GO.RelateNG(GO.Spherical()),
+                GO.RelateNG(; boundary_rule = GO.EndpointBoundary()),
+                GO.RelateNG(; exact = GO.GeometryOpsCore.False()))
+            rebuilt = GO.prepare(alg2, prep)
+            @test rebuilt !== prep
+            @test rebuilt.geom_a !== prep.geom_a
+            @test rebuilt.alg == alg2
+        end
+    end
+
+    @testset "an accelerator change swaps only the edge index" begin
+        #-- 64 segments >= threshold, so AutoAccelerator prebuilds a tree
+        n = 64
+        coords = [(5 + 4 * cospi(2k / n), 5 + 4 * sinpi(2k / n)) for k in 0:(n - 1)]
+        push!(coords, coords[1])
+        big = GI.Polygon([coords])
+        auto = GO.RelateNG()
+        nested = GO.RelateNG(; accelerator = GO.NestedLoop())
+        prep = GO.prepare(auto, big)
+        @test prep.edge_tree !== nothing
+
+        swapped = GO.prepare(nested, prep)
+        @test swapped !== prep
+        @test swapped.geom_a === prep.geom_a   #-- the expensive parts are reused
+        @test swapped.segs_a === prep.segs_a
+        @test swapped.edge_tree === nothing    #-- the requested strategy is honoured
+        @test swapped.alg == nested
+        @test GO.prepare(auto, swapped).edge_tree !== nothing  #-- and back again
+
+        b = GI.Polygon([[(4.0, 4.0), (11.0, 4.0), (11.0, 11.0), (4.0, 11.0), (4.0, 4.0)]])
+        @test GO.covers(nested, prep, b) == GO.covers(auto, big, b)
+        @test GO.relate(nested, prep, b) == GO.relate(auto, big, b)
+    end
+
+    @testset "a prepared A side follows the algorithm actually passed" begin
+        palg = GO.RelateNG()
+        salg = GO.RelateNG(GO.Spherical())
+        pprep = GO.prepare(palg, a)
+        sprep = GO.prepare(salg, a)
+        for b in bs
+            @test GO.covers(salg, pprep, b) == GO.covers(salg, a, b)
+            @test GO.covers(palg, sprep, b) == GO.covers(palg, a, b)
+            @test GO.relate(salg, pprep, b) == GO.relate(salg, a, b)
+            @test GO.relate(palg, sprep, b) == GO.relate(palg, a, b)
+        end
+
+        #-- the boundary node rules genuinely disagree at a valence-2 node:
+        #-- Mod2 reads it as interior, EndpointBoundary as boundary
+        mls = GI.MultiLineString([[(0.0, 0.0), (1.0, 0.0)], [(1.0, 0.0), (2.0, 0.0)]])
+        junction = GI.Point((1.0, 0.0))
+        m2alg = GO.RelateNG()
+        epalg = GO.RelateNG(; boundary_rule = GO.EndpointBoundary())
+        @test GO.touches(m2alg, mls, junction) == false
+        @test GO.touches(epalg, mls, junction) == true
+
+        m2prep = GO.prepare(m2alg, mls)
+        @test GO.touches(m2prep, junction) == false            #-- the prepared rule
+        @test GO.touches(epalg, m2prep, junction) == true      #-- the rule passed in
+        @test GO.relate(epalg, m2prep, junction) == GO.relate(epalg, mls, junction)
+    end
+end


### PR DESCRIPTION
## Motivation

`RelateNG`'s named predicates — `GO.covers(alg, a, b)` and the other nine — rebuild the A side on every call. A user who had already `prepare`d the A geometry had no way to hand it to them: `covers(RelateNG(...), prep, poly)` was a `MethodError`, so the only prepared spelling was

```julia
prep = GO.prepare(GO.RelateNG(GO.Spherical()), texas)
for poly in polys
    GO.relate_predicate(prep, GO.pred_covers(), poly)   # the only prepared spelling
end
```

and the natural thing

```julia
for poly in polys
    GO.covers(GO.RelateNG(GO.Spherical()), texas, poly)  # rebuilds texas on every call
end
```

silently rebuilt the whole prepared structure — point locators, edge index, spherical ring validation, on the order of 100 ms — on *every* call, defeating `prepare` entirely.

## After

```julia
prep = GO.prepare(GO.RelateNG(GO.Spherical()), texas)
for poly in polys
    GO.covers(GO.RelateNG(GO.Spherical()), prep, poly)
end
```

A `PreparedRelate` now stands in for the A geometry at every `RelateNG` entry point, so a call site already written against `covers(alg, a, b)` can swap a prepared `a` in without any other change:

```julia
GO.relate(alg, prep, b)
GO.relate(alg, prep, b, "T*T***T**")
GO.relate_predicate(alg, GO.pred_covers(), prep, b)
GO.covers(alg, prep, b)                                  # …and the other nine
```

## What this adds

Two methods:

1. **`prepare(alg, p::PreparedRelate)` is idempotent** — it returns `p` itself when `alg == p.alg`, and otherwise prepares afresh from `p`'s input geometry. Every `RelateNG` setting is baked into either the prepared `RelateGeometry` and its locators (`manifold`, `boundary_rule`, `exact`) or the index built over the segment strings (`accelerator`), so a mismatched algorithm cannot reuse the cache.

2. **`relate_predicate(alg, pred, p::PreparedRelate, b)`** — the single dispatch point. `relate`, the pattern form and all ten named predicates already forward to `relate_predicate`, so they need no methods of their own.

## One structural change

`PreparedRelate` gained an `input` field holding the geometry exactly as passed to `prepare`. The rebuild path needs it: `geom_a.geom` is an extent-cached wrapper tree whose cached extents are *that* manifold's interaction bounds (3-D on `Spherical`), and re-preparing it under a different manifold silently reuses those as planar boxes. That produced wrong answers — `covers` returning `false` where it should return `true` — until the cross-manifold tests caught it. Holding the input costs nothing: the wrapper tree already shares the input's linework.

## Tests

Added to `test/methods/relateng/relate_ng.jl`:

- all ten named predicates as `f(alg, prep, b)` against `f(alg, a, b)` over ten B geometries covering each predicate's true and false cases, on both `Planar()` and `Spherical()`, plus the `relate`, pattern and `relate_predicate` forms;
- `prepare` idempotence (`===` identity), and rebuild on a change to each of `manifold`, `boundary_rule`, `exact` and `accelerator`;
- cross-algorithm queries returning the answer the *passed* algorithm defines, including a `Mod2Boundary` vs `EndpointBoundary` case where the two rules genuinely disagree (a valence-2 node of a `MultiLineString`).

No existing behaviour changed, no new names exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
