### PR TITLE
Add a `Spherical` kernel for `segmentize`

### DIFF
--- a/src/transformations/segmentize.jl
+++ b/src/transformations/segmentize.jl
@@ -186,7 +186,8 @@ This is useful for plotting geometries with a limited number of vertices, or for
 ## Arguments
 - `method::Manifold = Planar()`: The method to use for segmentizing the geometry.  At the moment, [`Planar`](@ref) (assumes a flat plane), [`Spherical`](@ref) (assumes geometry on a sphere and interpolates along great circles) and [`Geodesic`](@ref) (assumes geometry on the ellipsoidal Earth and uses Vincenty's formulae) are available.
 - `geom`: The geometry to segmentize.  Must be a `LineString`, `LinearRing`, `Polygon`, `MultiPolygon`, or `GeometryCollection`, or some vector or table of those.
-- `max_distance::Real`: The maximum distance between vertices in the geometry.  **Beware: for `Planar`, this is in the units of the geometry, but for `Geodesic` and `Spherical` it's in units of the radius of the sphere.**  So under the default `Spherical()` radius `max_distance` is in metres, and under `Spherical(; radius = 1)` it is in radians.
+- `max_distance::Real`: The maximum distance between vertices in the geometry.  
+  For `Planar` manifolds, this is in the units of the geometry.  For `Spherical` and `Geodesic`, this is in the units of the manifold (the units of the radius of the sphere/ellipsoid).  By default this is meters.
 
 `Spherical` and `Geodesic` both assume that the input geometry is in lon/lat coordinates, in degrees.
 

--- a/src/transformations/segmentize.jl
+++ b/src/transformations/segmentize.jl
@@ -47,13 +47,28 @@ axislegend(a; position = :lt)
 f
 ```
 
-There are two methods available for segmentizing geometries at the moment, 
+There are three methods available for segmentizing geometries at the moment,
 and you can invoke them by passing the relevant [`Manifold`](@ref):
 
 ```@docs; canonical=false
 Planar
+Spherical
 Geodesic
 ```
+
+[`Spherical`](@ref) interpolates along the great circle joining each pair of points, so it
+sits between [`Planar`](@ref) and [`Geodesic`](@ref): it accounts for the curvature of the
+Earth, but treats it as a sphere rather than an ellipsoid.  A spherical segmentization is
+*not* a refinement of the planar one — the great circle joining two points on the same
+parallel bows poleward of that parallel:
+
+```@example segmentize
+parallel = GI.LineString([(-50.0, 52.0), (50.0, 52.0)])
+collect(GI.getpoint(GO.segmentize(GO.Spherical(), parallel; max_distance = 3_500_000)))
+```
+
+The added midpoint sits at 63.3°N, over 11° north of the 52°N parallel that `Planar` would
+have interpolated along.
 
 ## Benchmark
 
@@ -169,9 +184,11 @@ Segmentize a geometry by adding extra vertices to the geometry so that no segmen
 This is useful for plotting geometries with a limited number of vertices, or for ensuring that a geometry is not too "coarse" for a given application.
 
 ## Arguments
-- `method::Manifold = Planar()`: The method to use for segmentizing the geometry.  At the moment, only [`Planar`](@ref) (assumes a flat plane) and [`Geodesic`](@ref) (assumes geometry on the ellipsoidal Earth and uses Vincenty's formulae) are available.
+- `method::Manifold = Planar()`: The method to use for segmentizing the geometry.  At the moment, [`Planar`](@ref) (assumes a flat plane), [`Spherical`](@ref) (assumes geometry on a sphere and interpolates along great circles) and [`Geodesic`](@ref) (assumes geometry on the ellipsoidal Earth and uses Vincenty's formulae) are available.
 - `geom`: The geometry to segmentize.  Must be a `LineString`, `LinearRing`, `Polygon`, `MultiPolygon`, or `GeometryCollection`, or some vector or table of those.
-- `max_distance::Real`: The maximum distance between vertices in the geometry.  **Beware: for `Planar`, this is in the units of the geometry, but for `Geodesic` and `Spherical` it's in units of the radius of the sphere.**
+- `max_distance::Real`: The maximum distance between vertices in the geometry.  **Beware: for `Planar`, this is in the units of the geometry, but for `Geodesic` and `Spherical` it's in units of the radius of the sphere.**  So under the default `Spherical()` radius `max_distance` is in metres, and under `Spherical(; radius = 1)` it is in radians.
+
+`Spherical` and `Geodesic` both assume that the input geometry is in lon/lat coordinates, in degrees.
 
 Returns a geometry of similar type to the input geometry, but resampled.
 """
@@ -181,7 +198,7 @@ end
 
 # allow three-arg method as well, just in case
 segmentize(geom, max_distance::Real; threaded = False()) = segmentize(Planar(), geom, max_distance; threaded)
-segmentize(method::Manifold, geom, max_distance::Real; threaded = False()) = segmentize(Planar(), geom; max_distance, threaded)
+segmentize(method::Manifold, geom, max_distance::Real; threaded = False()) = segmentize(method, geom; max_distance, threaded)
 
 # generic implementation
 function segmentize(method::Manifold, geom; max_distance, threaded::Union{Bool, BoolsAsTypes} = False())
@@ -232,6 +249,31 @@ function _fill_linear_kernel!(::Planar, new_coords::Vector, x1, y1, x2, y2; max_
     push!(new_coords, (x2, y2))
     return nothing
 end
+#=
+The spherical kernel walks the great circle joining the two points, instead of the
+straight line between them in lon/lat space.  `slerp` gives us equally spaced points
+along that great circle, so we only have to decide how many of them to place.
+
+`max_distance` is an arc length in units of `method.radius`: the angle subtended at the
+centre of the sphere, `Ω`, times the radius.  So it's metres under the default (mean
+Earth) radius, and radians under `Spherical(; radius = 1)`.
+=#
+function _fill_linear_kernel!(method::Spherical, new_coords::Vector, x1, y1, x2, y2; max_distance)
+    a = UnitSphereFromGeographic()((x1, y1))
+    b = UnitSphereFromGeographic()((x2, y2))
+    distance = spherical_distance(a, b) * method.radius
+    if distance > max_distance
+        n_segments = ceil(Int, distance / max_distance)
+        for i in 1:(n_segments - 1)
+            push!(new_coords, GeographicFromUnitSphere()(slerp(a, b, i / n_segments)))
+        end
+    end
+    # End the line with the original coordinate,
+    # to avoid any multiplication errors.
+    push!(new_coords, (x2, y2))
+    return nothing
+end
+
 #=
 
 !!! note

--- a/test/transformations/segmentize.jl
+++ b/test/transformations/segmentize.jl
@@ -2,6 +2,9 @@ using Test
 using Proj
 import GeometryOps as GO
 import GeoInterface as GI
+import LibGEOS as LG
+import ArchGDAL as AG
+import GeometryBasics as GB
 using GeometryOpsTestHelpers
 
 @testset "Segmentation on multiple geometry levels" begin
@@ -28,6 +31,23 @@ using GeometryOpsTestHelpers
         # Now test multilinestrings
         @test GO.segmentize($mls; max_distance = 0.5) isa GI.MultiLineString
         @test GI.ngeom(GO.segmentize($mls; max_distance = 0.5)) == 3
+    end
+
+    @testset_implementations "SphericalSegments" begin
+        @test GO.segmentize(GO.Spherical(), $ls; max_distance = 0.5*900) isa GI.LineString
+        if GI.trait($lr) isa GI.LinearRingTrait
+            @test GO.segmentize(GO.Spherical(), $lr; max_distance = 0.5*900) isa GI.LinearRing
+        end
+        # Test that linear rings are closed after segmentization
+        segmentized_ring = GO.segmentize(GO.Spherical(), $lr; max_distance = 0.5*900)
+        @test GI.getpoint(segmentized_ring, 1) == GI.getpoint(segmentized_ring, GI.npoint(segmentized_ring))
+        @test GO.segmentize(GO.Spherical(), $p; max_distance = 0.5*900) isa GI.Polygon
+        @test GO.segmentize(GO.Spherical(), $mp; max_distance = 0.5*900) isa GI.MultiPolygon
+        @test GI.ngeom(GO.segmentize(GO.Spherical(), $mp; max_distance = 0.5*900)) == 3
+
+        # Now test multilinestrings
+        @test GO.segmentize(GO.Spherical(), $mls; max_distance = 0.5*900) isa GI.MultiLineString
+        @test GI.ngeom(GO.segmentize(GO.Spherical(), $mls; max_distance = 0.5*900)) == 3
     end
 
     @testset_implementations "GeodesicSegments" begin
@@ -64,5 +84,75 @@ lr = GI.LinearRing([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
 @testset_implementations "Geodesic" begin
     for max_distance in exp10.(LinRange(log10(0.01), log10(1), 10)) .* 900
         @test_nowarn segmentized = GO.segmentize(GO.Geodesic(), $lr; max_distance)
+    end
+end
+
+@testset "Spherical" begin
+    # A segment along the 52°N parallel.  The great circle joining its endpoints bows
+    # poleward of the parallel itself, which is the whole difference from `Planar`.
+    parallel = GI.LineString([(-50.0, 52.0), (50.0, 52.0)])
+    # The endpoints are ~0.982 radians apart, so on the unit sphere a `max_distance` of
+    # 0.6 splits the arc into exactly two segments, i.e. one new point at the midpoint.
+    unit_sphere = GO.Spherical(; radius = 1)
+
+    @testset "Great circle midpoint" begin
+        segmentized = GO.segmentize(unit_sphere, parallel; max_distance = 0.6)
+        @test GI.npoint(segmentized) == 3
+        midpoint = GI.getpoint(segmentized, 2)
+        # The great-circle midpoint of (±λ, φ) sits at atand(tand(φ) / cosd(λ)).
+        @test GI.x(midpoint) ≈ 0.0 atol = 1e-9
+        @test GI.y(midpoint) ≈ atand(tand(52) / cosd(50)) # ≈ 63.33°N
+        # ...which is well poleward of the parallel a `Planar` segmentization follows.
+        @test GI.y(midpoint) - 52 > 11
+        planar = GO.segmentize(GO.Planar(), parallel; max_distance = 60)
+        @test all(==(52.0), GI.y.(GI.getpoint(planar)))
+    end
+
+    @testset "Endpoints are preserved exactly" begin
+        segmentized = GO.segmentize(unit_sphere, parallel; max_distance = 0.01)
+        @test GI.getpoint(segmentized, 1) == (-50.0, 52.0)
+        @test GI.getpoint(segmentized, GI.npoint(segmentized)) == (50.0, 52.0)
+    end
+
+    @testset "`max_distance` is in units of the radius" begin
+        Ω = GO.UnitSpherical.spherical_distance(
+            GO.UnitSpherical.UnitSphereFromGeographic()((-50.0, 52.0)),
+            GO.UnitSpherical.UnitSphereFromGeographic()((50.0, 52.0)),
+        )
+        for max_distance in exp10.(LinRange(log10(0.01), log10(1), 10))
+            segmentized = GO.segmentize(unit_sphere, parallel; max_distance)
+            @test GI.npoint(segmentized) == ceil(Int, Ω / max_distance) + 1
+            # The same arc, on a sphere of radius R, needs `max_distance * R` to split
+            # into the same number of segments.
+            radius = 6371000
+            scaled = GO.segmentize(GO.Spherical(; radius), parallel; max_distance = max_distance * radius)
+            @test GI.npoint(scaled) == GI.npoint(segmentized)
+            @test collect(GI.getpoint(scaled)) == collect(GI.getpoint(segmentized))
+        end
+    end
+
+    @testset "No segment exceeds `max_distance`" begin
+        max_distance = 0.1
+        segmentized = GO.segmentize(unit_sphere, parallel; max_distance)
+        points = GO.UnitSpherical.UnitSphereFromGeographic().(GI.getpoint(segmentized))
+        for (a, b) in zip(points, Iterators.drop(points, 1))
+            @test GO.UnitSpherical.spherical_distance(a, b) <= max_distance + 1e-12
+        end
+    end
+
+    @testset "The three-argument form keeps the manifold" begin
+        @test collect(GI.getpoint(GO.segmentize(unit_sphere, parallel, 0.6))) ==
+            collect(GI.getpoint(GO.segmentize(unit_sphere, parallel; max_distance = 0.6)))
+    end
+
+    @testset "Short segments are left alone" begin
+        # Nothing is added when the arc is already shorter than `max_distance`.
+        short = GI.LineString([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
+        segmentized = GO.segmentize(unit_sphere, short; max_distance = 1)
+        @test collect(GI.getpoint(segmentized)) == [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+        # Repeated points are also fine (zero-length arcs).
+        degenerate = GI.LineString([(1.0, 2.0), (1.0, 2.0)])
+        @test collect(GI.getpoint(GO.segmentize(unit_sphere, degenerate; max_distance = 0.001))) ==
+            [(1.0, 2.0), (1.0, 2.0)]
     end
 end


### PR DESCRIPTION
Closes #461.

`_segmentize` dispatches on `Union{Planar, Spherical}` and the docstring documents `max_distance` for `Spherical`, but only the `Planar` (in `src`) and `Geodesic` (in `GeometryOpsProjExt`) kernels were ever written — so `segmentize(Spherical(), geom; max_distance)` threw a `MethodError`.

```julia
julia> import GeometryOps as GO, GeoInterface as GI

julia> GO.segmentize(GO.Spherical(), GI.LineString([(-50.0, 52.0), (50.0, 52.0)]); max_distance = 3_500_000)
```

Before: `MethodError: no method matching _fill_linear_kernel!(::Spherical{Float64}, ...)`.
After:

```
GeoInterface.Wrappers.LineString([(-50.0, 52.0), (-7.087e-15, 63.334), (50.0, 52.0)])
```

## What's here

- **`_fill_linear_kernel!(::Spherical, ...)`** — walks the great circle joining each pair of points via `slerp`, which was already in `UnitSpherical`. It mirrors the `Planar` kernel: `ceil(Int, distance / max_distance)` equal segments, and the segment ends on the *original* coordinate rather than an interpolated one.

  `max_distance` is an arc length in units of `Spherical.radius` — the subtended angle `Ω` times the radius — so it's metres under the default (mean Earth) radius and radians under `Spherical(; radius = 1)`. That's what the existing docstring already promised.

- **A fix for the three-argument form.** `segmentize(method::Manifold, geom, max_distance)` dropped `method` and always called through with `Planar()`, so `segmentize(Spherical(), geom, 1000)` silently returned a planar segmentization. Noticed while writing the tests for the above; it's a one-word fix with a test.

- **Docs.** `Spherical` is added to the manifold list in the literate header and to the `segmentize` docstring's `method` argument, with a worked example of the poleward bow and a note that `max_distance` is in radius units.

## Tests

The interesting property is the one the issue calls out: the great circle between two points on the same parallel bows *poleward* of that parallel, so a spherical segmentization is not a refinement of the planar one. The midpoint of `(-50, 52)`–`(50, 52)` lands at `atand(tand(52) / cosd(50))` ≈ 63.33°N, 11.33° off the parallel.

Beyond that: endpoints are preserved exactly, `npoint` matches `ceil(Ω / max_distance) + 1`, results are invariant under scaling `radius` and `max_distance` together, no output segment exceeds `max_distance`, short and zero-length arcs are left alone, and rings stay closed. The existing `@testset_implementations` blocks now cover `Spherical` alongside `Planar` and `Geodesic`, and the test file imports LibGEOS/ArchGDAL/GeometryBasics so those macros actually run against all four implementations rather than GeoInterface alone.

Full local test suite passes (`Segmentize` 266/266).

🤖 Generated with [Claude Code](https://claude.com/claude-code)