### PR TITLE
Check all clip vertices in the spherical Sutherland-Hodgman containment fallback

### DIFF
--- a/src/methods/clipping/sutherland_hodgman.jl
+++ b/src/methods/clipping/sutherland_hodgman.jl
@@ -314,9 +314,14 @@ function _intersection_sutherland_hodgman(
         output = _sh_clip_to_edge_spherical(output, edge_start, edge_end, T)
     end
 
-    # Handle empty result - check if clip polygon is fully inside the original subject
+    # Handle empty result - check if clip polygon is fully inside the original subject.
+    # "Fully inside" needs EVERY clip vertex inside the subject, not just the first:
+    # one vertex lying on the subject's boundary is a graze, and `spherical_orient >= 0`
+    # counts the boundary as inside, so testing `clip_points[1]` alone credits every
+    # subject that merely touches that one vertex with the clip polygon's whole area.
     if isempty(output)
-        if !isempty(clip_points) && _point_in_convex_spherical_polygon(clip_points[1], original_subject)
+        if !isempty(clip_points) &&
+           all(p -> _point_in_convex_spherical_polygon(p, original_subject), clip_points)
             # Subject contains clip - return clip polygon
             result = copy(clip_points)
             push!(result, result[1])

--- a/test/methods/clipping/sutherland_hodgman.jl
+++ b/test/methods/clipping/sutherland_hodgman.jl
@@ -379,6 +379,39 @@ import GeoInterface as GI
             @test a_oh ≈ a_ho rtol = 1e-6
             @test 0 < a_oh < 0.1 * spherical_area(healpix)   # sliver, not the whole cell
         end
+
+        @testset "Grazing tiles are not handed the whole clip" begin
+            # The empty-output fallback returns the clip polygon when the subject
+            # contains it.  "Contains" needs EVERY clip vertex inside the subject:
+            # `spherical_orient >= 0` counts the boundary as inside, so testing only
+            # `clip_points[1]` credits every subject that merely touches that one
+            # vertex with the clip's whole area.
+            #
+            # Reaching the fallback at all takes a non-convex clip -- with a convex
+            # clip a grazing subject survives every half-space test and leaves a
+            # 1-2 point output, which the degenerate branch already zeroes.  So this
+            # is a graceful-degradation test for out-of-contract input (a cell that
+            # goes non-convex numerically, see #466): the answer may be wrong, but it
+            # must be wrong towards zero, never towards a whole fabricated cell.
+            clip = spherical_polygon([(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (10.0, 6.0), (0.0, 20.0)])
+
+            # Three convex, pairwise-disjoint tiles of the quadrants meeting at the
+            # clip ring's FIRST vertex (0, 0).  None overlaps the clip's interior.
+            tiles = [
+                spherical_polygon([(-5.0, -5.0), (0.0, -5.0), (0.0, 0.0), (-5.0, 0.0)]),  # SW
+                spherical_polygon([(0.0, -5.0), (5.0, -5.0), (5.0, 0.0), (0.0, 0.0)]),    # SE, shares the clip's south edge
+                spherical_polygon([(-5.0, 0.0), (0.0, 0.0), (0.0, 5.0), (-5.0, 5.0)]),    # NW, shares the clip's west edge
+            ]
+
+            alg = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+            clip_a = spherical_area(clip)
+            for tile in tiles
+                @test spherical_area(GO.intersection(alg, tile, clip)) < 1e-9 * clip_a
+            end
+            # Summed over the disjoint tiles this is what breaks conservative
+            # regridding: the total was 3x the clip's own area.
+            @test sum(spherical_area(GO.intersection(alg, tile, clip)) for tile in tiles) < 1e-9 * clip_a
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #467.

## The defect

When the spherical `_intersection_sutherland_hodgman` clips the subject down to
nothing, it falls back to asking whether the clip polygon was inside the subject
all along. That check only tested `clip_points[1]`:

```julia
if !isempty(clip_points) && _point_in_convex_spherical_polygon(clip_points[1], original_subject)
```

`_point_in_convex_spherical_polygon` uses `spherical_orient >= 0`, so the boundary
counts as inside. Any subject that merely *touches* the clip ring's first vertex
passed the test and was handed the clip polygon's entire area.

Instrumenting the three grazing tiles from the issue's MWE shows it directly —
for each one, `output = 0 pts` and the per-clip-vertex containment vector is
`[1, 0, 0, 0, 0]`. One vertex in, four out, whole clip returned. Summed over the
three disjoint tiles that is 3x the clip's own area; in the reported polar case
it is 145x, where every degenerate quad of a 216-column mesh shares the pole.

## The fix

Require every clip vertex to be inside:

```julia
if !isempty(clip_points) &&
   all(p -> _point_in_convex_spherical_polygon(p, original_subject), clip_points)
```

Two things I verified before landing this, both of which say it is free:

- **The branch is unreachable for valid input.** A sweep of 159600 convex-convex
  pairs hits the empty-output branch 158732 times and finds `clip_points[1]`
  inside the subject *zero* times. Re-running the sweep after the change gives an
  identical result, so this is a no-op in contract.
- **Genuine containment never reaches it anyway.** Ordinary Sutherland-Hodgman
  already returns the right answer when the clip is inside the subject — for a
  small quad inside a big one the output is 4 points, not empty. The branch's
  stated purpose is handled upstream.

It stays sound out of contract too: `_point_in_convex_spherical_polygon` on a
non-convex subject under-approximates (it answers about the half-space
intersection, a subset), so it cannot produce a false positive.

The cost is O(m) point tests instead of 1, on a branch that is already the slow
path. Only the spherical path has this fallback; the planar path has none.

## Test

Adds "Grazing tiles are not handed the whole clip". Written first: it failed 4/4,
at exactly 1.0x the clip area per tile and 3.0x summed, then passed.

One caveat worth flagging for review: as noted in #467, reaching the fallback at
all takes a **non-convex clip**, so the fixture is out-of-contract input — with a
convex clip a grazing subject survives every half-space test and leaves a 1-2
point output that the degenerate branch already zeroes. The test is therefore
framed as graceful degradation: the answer may be wrong, but it must be wrong
towards zero, never towards a whole fabricated cell. That is a realistic concern
rather than a contrived one, since a near-convex cell can go non-convex
numerically (see #466). If an out-of-contract fixture is unwanted in the suite,
the fix stands on the in-contract sweep alone and the test can be dropped.

## Verification

Full suite passes (`Testing GeometryOps tests passed`); Sutherland-Hodgman 69/69.
The issue's MWE now returns exactly `0.0` for all three tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
