### PR TITLE
Reduce the per-call B-side cost of prepared `RelateNG` queries

### DIFF
--- a/src/methods/extent.jl
+++ b/src/methods/extent.jl
@@ -91,11 +91,51 @@ function _spherical_region_extent(pts::Vector{<:UnitSpherical.UnitSphericalPoint
     end
     n < 3 && return ext
 
+    #=
+    Vertex-cap prefilter for the six axis queries below. If every vertex lies
+    within angle θ < 90° of the normalized vertex mass `c`, the ring's minor
+    arcs also stay inside the (geodesically convex) cap around `c` — for arc
+    points `w = α u + β v` with `α, β ≥ 0` and `α + β ≥ 1` (concavity of sin),
+    `w ⋅ c ≥ min(u ⋅ c, v ⋅ c)` — so the cap's complement is connected and
+    boundary-free, and containment is uniform across it: one query at a
+    probe point outside the cap answers for every axis point outside it. A
+    small ring (the common case) pays one O(n²) containment query instead
+    of six. The `cos θ > 0` requirement also excludes (near-)antipodal
+    edges, whose arc choice the cap bound would not survive. The probe is
+    taken orthogonal to `c` — outside any θ < 90° cap, and far from the
+    near-antipodal configurations (probe vs edge midpoints ≈ `c`) that
+    would push `robust_cross_product` onto its exact fallback.
+    =#
+    mass = pts[1]
+    for i in 2:n
+        mass += pts[i]
+    end
+    nc = norm(mass)
+    cap_ok = nc > 1e-6 * n
+    c = cap_ok ? UnitSpherical.UnitSphericalPoint(mass / nc) : first(pts)
+    costheta = 1.0
+    if cap_ok
+        for i in 1:n
+            costheta = min(costheta, pts[i] ⋅ c)
+        end
+        cap_ok = costheta > 1e-6
+    end
+    far = missing  # containment of the cap's complement, computed on demand
+
     lo = MVector(ext.X[1], ext.Y[1], ext.Z[1])
     hi = MVector(ext.X[2], ext.Y[2], ext.Z[2])
     for i in 1:3, s in (1.0, -1.0)
         q = UnitSpherical.UnitSphericalPoint(ntuple(j -> j == i ? s : 0.0, 3))
-        inside = UnitSpherical.spherical_ring_contains(pts, n, q)
+        inside = if cap_ok && q ⋅ c < costheta - 1e-9
+            if far === missing
+                e = SVector{3, Float64}(ntuple(j -> j == argmin(abs.(c)) ? 1.0 : 0.0, 3))
+                probe = UnitSpherical.UnitSphericalPoint(normalize(cross(SVector{3, Float64}(c), e)))
+                far = UnitSpherical.spherical_ring_contains(pts, n, probe)
+            end
+            far
+        else
+            UnitSpherical.spherical_ring_contains(pts, n, q)
+        end
         # nothing (undecidable) extends too; the box must never under-cover
         if inside === nothing || inside
             s > 0 ? (hi[i] = one(hi[i])) : (lo[i] = -one(lo[i]))

--- a/src/methods/geom_relations/relateng/kernel_spherical.jl
+++ b/src/methods/geom_relations/relateng/kernel_spherical.jl
@@ -1056,8 +1056,15 @@ end
 # regions — a CW hole must not become a complement region. Boxes get a few
 # ulps of padding so a vertex from another conversion path still prunes as
 # interacting.
-rk_interaction_bounds(m::Spherical, geom) =
-    _pad_bounds(_sph_interaction_extent(m, GI.trait(geom), geom))
+# A stored 3D `(X, Y, Z)` extent is returned as-is (the wrapper tree built
+# by `_relate_cache_extents`, or a user's own stamp — trusted to be in
+# kernel space, and for a polygon to be the REGION box, exactly as the
+# planar kernel trusts any stored extent). This is what lets a repeatedly
+# queried B geometry skip the region-extent recomputation per call.
+function rk_interaction_bounds(m::Spherical, geom)
+    _reusable_stored_extent(m, geom) && return geom.extent
+    return _pad_bounds(_sph_interaction_extent(m, GI.trait(geom), geom))
+end
 
 _sph_interaction_extent(m::Spherical, ::GI.AbstractPointTrait, geom) =
     GI.extent(_spherical_kernel_point(geom))

--- a/src/methods/geom_relations/relateng/relate_geometry.jl
+++ b/src/methods/geom_relations/relateng/relate_geometry.jl
@@ -164,10 +164,18 @@ function _relate_cache_extents(m::Manifold, trait::GI.AbstractPolygonTrait, poly
         return poly
     end
     rings = [_relate_cache_extents(m, GI.trait(r), r) for r in GI.getring(poly)]
-    ext = _union_stored_extents(m, rings)
+    ext = _polygon_cache_extent(m, poly, rings)
     ext === nothing && return poly
     return GI.geointerface_geomtype(trait)(rings; extent = ext, crs = GI.crs(poly))
 end
+
+# The extent stored on a polygon wrapper must be its interaction bounds, so
+# `rk_interaction_bounds` can read it back. On `Planar` the region box IS
+# the union of the ring boxes just stored on the wrapped rings; on
+# `Spherical` the region box also covers enclosed axis points, so it is
+# computed via the kernel (once, here — every later consult reads it).
+_polygon_cache_extent(m::Manifold, poly, rings) = _union_stored_extents(m, rings)
+_polygon_cache_extent(m::Spherical, poly, rings) = rk_interaction_bounds(m, poly)
 
 #-- collections (covers Multi* types too): recurse, union the child extents
 function _relate_cache_extents(m::Manifold, trait::GI.AbstractGeometryCollectionTrait, geom)

--- a/src/methods/geom_relations/relateng/relate_ng.jl
+++ b/src/methods/geom_relations/relateng/relate_ng.jl
@@ -970,10 +970,15 @@ _process_prepared_edges!(tc::TopologyComputer, segs_a, ::Nothing, edges_b) =
 
 # Tree path: the prebuilt A tree is dual-traversed against a per-call tree
 # over B's (envelope-filtered) segment extents — cf. the unprepared tree path
-# in `process_edge_intersections!`, which builds both trees per call.
+# in `process_edge_intersections!`, which builds both trees per call. Below
+# the accelerator threshold the per-call B tree costs more than it prunes:
+# each B segment queries the prepared A tree directly instead.
 function _process_prepared_edges!(tc::TopologyComputer, segs_a,
         tree_a::RTree, edges_b;
         m::Manifold = _manifold(tc), exact = _exact(tc))
+    if _total_segment_count(edges_b) < GEOMETRYOPS_NO_OPTIMIZE_EDGEINTERSECT_NUMVERTS
+        return _process_prepared_edges_small_b!(tc, segs_a, tree_a, edges_b; m, exact)
+    end
     tree_b = _relate_edge_index(m, edges_b)
     tree_b === nothing && return nothing
     SpatialTreeInterface.dual_depth_first_search(Extents.intersects, tree_a, tree_b) do ia, ib
@@ -983,6 +988,28 @@ function _process_prepared_edges!(tc::TopologyComputer, segs_a,
         #-- the Java noder's isDone() early-exit hook
         is_result_known(tc) && return Action(:full_return, nothing)
         return nothing
+    end
+    return nothing
+end
+
+# Small-B prepared path: no per-call B tree — each B segment's extent is a
+# single-tree query into the prebuilt A tree.
+function _process_prepared_edges_small_b!(tc::TopologyComputer, segs_a,
+        tree_a::RTree, edges_b;
+        m::Manifold = _manifold(tc), exact = _exact(tc))
+    for ssb in edges_b
+        for kb in 1:(length(ssb.pts) - 1)
+            bext = _segment_extent(m, ssb.pts[kb], ssb.pts[kb + 1])
+            SpatialTreeInterface.depth_first_search(
+                    Base.Fix1(Extents.intersects, bext), tree_a) do ia
+                (sa, ka) = tree_a.data[ia]
+                process_intersections!(tc, segs_a[sa], ka, ssb, kb; m, exact)
+                #-- the Java noder's isDone() early-exit hook
+                is_result_known(tc) && return Action(:full_return, nothing)
+                return nothing
+            end
+            is_result_known(tc) && return nothing
+        end
     end
     return nothing
 end

--- a/test/methods/relateng/spherical_end_to_end.jl
+++ b/test/methods/relateng/spherical_end_to_end.jl
@@ -10,6 +10,7 @@ using Test
 import GeometryOps as GO
 import GeometryOps: Spherical, RelateNG
 import GeoInterface as GI
+import Extents
 
 alg = RelateNG(; manifold = Spherical())
 
@@ -70,6 +71,58 @@ end
     for B in Bs
         @test GO.relate(prep, B) == GO.relate(loop, A, B)
     end
+end
+
+# #469: prepared mode against a B below the accelerator threshold takes the
+# no-B-tree path (each B segment is a single-tree query into the prepared A
+# tree); at or above the threshold the per-call B tree path is kept. Both
+# must agree with the unprepared engine, including when edge topology has to
+# be computed (a straddling B).
+@testset "prepared small-B path agrees with unprepared" begin
+    A = GI.Polygon([GI.LinearRing(
+        [(40cosd(t), 40sind(t)) for t in range(0, 360; length = 73)])])
+    prep = GO.prepare(alg, A)
+    loop = RelateNG(; manifold = Spherical(), accelerator = GO.NestedLoop())
+    cell(nv, r, lon, lat) = GI.Polygon([GI.LinearRing(
+        [(lon + r * cosd(t), lat + r * sind(t)) for t in range(0, 360; length = nv + 1)])])
+    for B in (
+        cell(6, 1.0, 3.0, 3.0),      # 6 segments: small-B path, deep inside
+        cell(6, 1.0, 40.0, 0.0),     # small-B path, straddling the boundary
+        cell(6, 1.0, 60.0, 0.0),     # small-B path, outside
+        cell(32, 1.0, 3.0, 3.0),     # at the threshold: per-call B tree path
+        cell(32, 2.0, 40.0, 0.0),    # B tree path, straddling
+    )
+        @test GO.relate(prep, B) == GO.relate(loop, A, B)
+    end
+end
+
+# #469: a B carrying kernel-space (X, Y, Z) extents at every level — here the
+# extent-cached wrapper tree a `RelateGeometry` builds — is reused as-is
+# (`_relate_cache_extents` returns it unchanged and `rk_interaction_bounds`
+# reads the stored boxes), skipping the per-call extent recomputation. A
+# stored lon/lat (X, Y) extent is in the wrong space and must be ignored.
+@testset "stored 3D extents on B are reused; lon/lat extents are not" begin
+    A = GI.Polygon([GI.LinearRing(
+        [(40cosd(t), 40sind(t)) for t in range(0, 360; length = 73)])])
+    prep = GO.prepare(alg, A)
+    ring = [(3.0 + cosd(t), 3.0 + sind(t)) for t in range(0, 360; length = 8)]
+    B = GI.Polygon([GI.LinearRing(ring)])
+
+    stamped = GO.RelateGeometry(GO.Spherical(), B; exact = GO.True()).geom
+    @test GI.extent(stamped) isa Extents.Extent{(:X, :Y, :Z)}
+    #-- an all-stamped tree is reused unchanged, extent included
+    rg = GO.RelateGeometry(GO.Spherical(), stamped; exact = GO.True())
+    @test rg.geom === stamped
+    @test GO.get_extent(rg) === GI.extent(stamped)
+    @test GO.relate(prep, stamped) == GO.relate(prep, B)
+
+    #-- a lon/lat extent fails the (X, Y, Z) reusability check: the extent is
+    #-- recomputed in kernel space and results are unaffected
+    llstamped = GI.Polygon([GI.LinearRing(ring)];
+        extent = Extents.Extent(X = (2.0, 4.0), Y = (2.0, 4.0)))
+    rgll = GO.RelateGeometry(GO.Spherical(), llstamped; exact = GO.True())
+    @test GO.get_extent(rgll) isa Extents.Extent{(:X, :Y, :Z)}
+    @test GO.relate(prep, llstamped) == GO.relate(prep, B)
 end
 
 # Ring winding must not change which region a polygon bounds: real-world data


### PR DESCRIPTION
Part of #469 — the per-call B-side rebuild in prepared mode.

## What this does

Profiling one prepared `relate_predicate(prep, pred_contains(), cell)` call on the issue's scenario (Spherical, 72-vertex prepared target, 32-vertex query cell, fresh predicate per call — note the issue's benchmark loop reuses one already-determined predicate, so its tables understate the true per-call cost, which is **85.5 KB / 90 µs** on `main`) shows the cost is not mainly the B data structures themselves:

- **~31 KB / 25 µs (91% of the B `RelateGeometry` build)**: the B polygon's region extent — `_spherical_region_extent` runs six axis-point enclosure queries through `spherical_ring_contains`, each O(n²) with allocating float predicates, on every call.
- **~34 KB**: `Rational{BigInt}`-lifted composite predicates in point location under `exact = True()` (not touched here; wants an S4-style float-filter ladder as follow-up).
- **2.6 KB / 0.6 µs**: the per-call RTree over B's segments, built unconditionally whenever A has a prepared tree.

Three changes:

1. **Vertex-cap prefilter for the region-extent axis queries** (`extent.jl`). If all ring vertices fit in a sub-hemisphere cap, the ring's arcs stay in the (geodesically convex) cap, so the cap's complement is boundary-free and containment is uniform across it: one probe query — taken orthogonal to the vertex mass, away from the near-antipodal configurations that push `robust_cross_product` onto its exact fallback — answers for every axis point outside the cap. Small rings pay one O(n²) query instead of six.
2. **Stored-extent reuse on `Spherical`** (`kernel_spherical.jl`, `relate_geometry.jl`). `rk_interaction_bounds(::Spherical)` now returns a stored `(X, Y, Z)` extent as-is, exactly as the planar kernel already trusts any stored extent, and the polygon wrapper built by `_relate_cache_extents` stores the region box (rather than the union of ring boxes) so the shortcut is sound. A B stamped with kernel-space extents at every level — e.g. the wrapper tree a previous `RelateGeometry` built — skips the extent recomputation entirely.
3. **No per-call B tree for small B** (`relate_ng.jl`). Below the existing accelerator threshold, each B segment is a single-tree query into the prebuilt A tree instead of building a fresh RTree over B per call.

## Measured (Apple M-series, Julia 1.12, fresh `pred_contains` per call)

| configuration | `main` @ 4e0c0d5 | this PR |
|---|---|---|
| raw B, default | 85.5 KB / 90 µs | 73.5 KB / 71 µs |
| raw B, `exact = False()` | 51.6 KB / 40 µs | 39.5 KB / 30 µs |
| pre-stamped B, default | no benefit | 50.6 KB / 26 µs |
| pre-stamped B, `exact = False()` | — | 16.7 KB / 8.8 µs |
| B `RelateGeometry` build alone | 34.5 KB / 27.5 µs | 22.5 KB / 15.4 µs raw · 176 B / 0.02 µs pre-stamped |

## Correctness

- Full RelateNG suite passes: 2202 engine, 6537 JTS XML conformance, 4022 S2 crossing conformance, 500 LibGEOS differential fuzz, allocation/type-stability.
- All 908 spherical extent tests pass (they cover the cap prefilter's tricky cases: dumbbell rings with zero net winding, super-hemisphere caps, CW complements under `oriented = true`, random cells vs axis points).
- New tests: prepared small-B and at-threshold paths against the unprepared engine (including straddling cells, so edge topology flows through the single-tree query path), stored-3D-extent reuse (wrapper identity + extent identity + result equality), and a wrong-space lon/lat stored extent being ignored.
- The issue's 441-cell MWE classifies identically before and after.

## Not addressed here (follow-ups for #469)

- The `BigInt` lifting in point location under `exact = True()` (~34 KB/call) — float-filter-first ladder, as was done for `rk_classify_intersection`.
- The residual scratch (segment extraction, locator shells, node dicts, ~17 KB) — the issue's proposed `workspace` argument.
- A public API for stamping a B geometry with kernel-space extents (today only internal wrappers get the fast path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)