### PR TITLE
Add an `intersection_area` prototype

### DIFF
--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -151,6 +151,8 @@ include("methods/clipping/overlayng/overlay_mixed_points.jl")
 # OverlayNG public opt-in API (phase 3): the `OverlayNG{M}` algorithm + ops.
 include("methods/clipping/overlayng/api.jl")
 
+include("methods/clipping/intersection_area.jl")
+
 include("methods/orientation.jl")
 include("methods/polygonize.jl")
 include("methods/minimum_bounding_circle.jl")

--- a/src/methods/area.jl
+++ b/src/methods/area.jl
@@ -310,7 +310,10 @@ _naive_triangulated_spherical_polygon_area(::SphericalTriangleAreaMethod, ::Type
 # ## Ring area over a plain vector of points
 #
 # `intersection_area` measures the rings a clipping engine produced without wrapping them
-# in a geometry first, so these take a vector of points, closed or not.
+# in a geometry first, so these take a vector of points. `closed` says whether that vector
+# repeats its first point at the end — the caller knows, and it cannot be re-derived here:
+# the two ends of a sliver ring are legitimately close together, and no tolerance can tell
+# that apart from a closing point.
 #
 # They must stay term-for-term equivalent to `_signed_area` and
 # `_naive_triangulated_spherical_ring_area` above: that equality is exactly what makes
@@ -319,7 +322,7 @@ _naive_triangulated_spherical_polygon_area(::SphericalTriangleAreaMethod, ::Type
 
 # Shoelace, wrapping from the last point to the first. A repeated closing point contributes
 # a zero term, so closed and open rings both work.
-function _ring_area(::Planar, pts::AbstractVector, ::Type{T}) where T
+function _ring_area(::Planar, pts::AbstractVector, ::Type{T}; closed::Bool = true) where T
     n = length(pts)
     n < 3 && return zero(T)
     area = zero(T)
@@ -330,12 +333,15 @@ function _ring_area(::Planar, pts::AbstractVector, ::Type{T}) where T
 end
 
 # Signed unit-sphere area, by the same fan triangulation from the first vertex.
-function _ring_area(::Spherical, pts::AbstractVector, ::Type{T}) where T
+function _ring_area(::Spherical, pts::AbstractVector, ::Type{T}; closed::Bool = true) where T
     n = length(pts)
     n < 3 && return zero(T)
     p1 = UnitSphericalPoint(GI.PointTrait(), pts[1])
-    # Skip the closing point if the ring carries one
-    UnitSphericalPoint(GI.PointTrait(), pts[n]) ≈ p1 && (n -= 1)
+    #-- Drop the closing point. Only a ring the caller called closed has one: the `≈` is
+    #-- `isapprox`'s default `rtol` (~1.5e-8), which on an OPEN ring would swallow the last
+    #-- vertex of any sliver whose ends fall within that of each other — halving its area,
+    #-- or zeroing it outright once the remaining fan degenerates.
+    closed && UnitSphericalPoint(GI.PointTrait(), pts[n]) ≈ p1 && (n -= 1)
     n < 3 && return zero(T)
     area = zero(T)
     for i in 2:(n - 1)

--- a/src/methods/area.jl
+++ b/src/methods/area.jl
@@ -307,6 +307,48 @@ function _naive_triangulated_spherical_polygon_area(method::SphericalTriangleAre
 end
 _naive_triangulated_spherical_polygon_area(::SphericalTriangleAreaMethod, ::Type{T}, ::GI.PointTrait, point) where T = zero(T)
 
+# ## Ring area over a plain vector of points
+#
+# `intersection_area` measures the rings a clipping engine produced without wrapping them
+# in a geometry first, so these take a vector of points, closed or not.
+#
+# They must stay term-for-term equivalent to `_signed_area` and
+# `_naive_triangulated_spherical_ring_area` above: that equality is exactly what makes
+# `intersection_area(alg, a, b)` and `area(manifold(alg), intersection(alg, a, b))` agree
+# to the last bit. Change a formula there, change it here.
+
+# Shoelace, wrapping from the last point to the first. A repeated closing point contributes
+# a zero term, so closed and open rings both work.
+function _ring_area(::Planar, pts::AbstractVector, ::Type{T}) where T
+    n = length(pts)
+    n < 3 && return zero(T)
+    area = zero(T)
+    for i in 1:n
+        area += _area_component(pts[i], pts[mod1(i + 1, n)])
+    end
+    return T(area / 2)
+end
+
+# Signed unit-sphere area, by the same fan triangulation from the first vertex.
+function _ring_area(::Spherical, pts::AbstractVector, ::Type{T}) where T
+    n = length(pts)
+    n < 3 && return zero(T)
+    p1 = UnitSphericalPoint(GI.PointTrait(), pts[1])
+    # Skip the closing point if the ring carries one
+    UnitSphericalPoint(GI.PointTrait(), pts[n]) ≈ p1 && (n -= 1)
+    n < 3 && return zero(T)
+    area = zero(T)
+    for i in 2:(n - 1)
+        area += _spherical_triangle_area(Eriksson(), p1,
+            UnitSphericalPoint(GI.PointTrait(), pts[i]), UnitSphericalPoint(GI.PointTrait(), pts[i + 1]))
+    end
+    return T(area)
+end
+
+# The factor an area on the unit sphere is scaled by to reach the manifold's own units.
+_area_scale(::Planar) = 1
+_area_scale(m::Spherical) = m.radius^2
+
 # Main implementation for NaiveTriangulatedSphericalArea
 function area(alg::NaiveTriangulatedSphericalArea, geom, ::Type{T} = Float64; threaded=false, kwargs...) where T <: AbstractFloat
     unit_area = applyreduce(

--- a/src/methods/clipping/clipping_processor.jl
+++ b/src/methods/clipping/clipping_processor.jl
@@ -919,6 +919,61 @@ function _index_crossing_intrs!(alg::FosterHormannClipping{M, A}, a_list, b_list
     return
 end
 
+# Get type of polygons that will be made
+# TODO: Increase type options
+_get_poly_type(::Type{T}) where T =
+    GI.Polygon{false, false, Vector{GI.LinearRing{false, false, Vector{Tuple{T, T}}, Nothing, Nothing}}, Nothing, Nothing}
+
+#= What the tracer does with the vertices it walks is the only thing that separates
+building the result rings from measuring them, so that is the one thing it takes as a
+parameter. `_RingCollector` is the original behaviour - a point vector per ring, wrapped
+as a polygon. `_RingMeasurer` keeps a running ring area instead, which is what lets
+`intersection_area` trace without materializing a ring at all.
+
+Each sink owns a per-ring `state`: `_ring_start` opens a ring at its first vertex,
+`_ring_step` takes the next vertex and returns the new state, and `_ring_close!` folds the
+finished ring into the sink. =#
+struct _RingCollector{P}
+    polys::Vector{P}
+end
+_RingCollector(::Type{T}) where {T} = _RingCollector(Vector{_get_poly_type(T)}(undef, 0))
+
+_ring_start(::_RingCollector, pt) = [pt]
+_ring_step(::_RingCollector, pts, pt) = (push!(pts, pt); pts)
+_ring_close!(sink::_RingCollector, pts) = (push!(sink.polys, GI.Polygon([pts])); nothing)
+
+mutable struct _RingMeasurer{M <: Manifold, T}
+    manifold::M
+    area::T
+    nrings::Int   # `isempty(polys)` for the collector: whether the trace found anything
+end
+_RingMeasurer(m::M, ::Type{T}) where {M, T} = _RingMeasurer{M, T}(m, zero(T), 0)
+
+#-- state is (first vertex, previous vertex, running sum): both formulas below are
+#-- two-point recurrences, so the ring never has to exist all at once
+_ring_start(sink::_RingMeasurer{M, T}, pt) where {M, T} = (pt, pt, zero(T))
+_ring_step(sink::_RingMeasurer, (first_pt, prev, acc), pt) =
+    (first_pt, pt, acc + _ring_term(sink.manifold, first_pt, prev, pt))
+function _ring_close!(sink::_RingMeasurer, (first_pt, prev, acc))
+    sink.area += abs(_ring_total(sink.manifold, acc + _ring_term(sink.manifold, first_pt, prev, first_pt)))
+    sink.nrings += 1
+    return nothing
+end
+
+#-- the per-vertex terms of `_ring_area`'s two formulas (methods/area.jl), taken one
+#-- vertex at a time. Summed in the same order, they give the same answer. The spherical
+#-- one is untested: `FosterHormannClipping(Spherical())` is an ambiguous constructor call
+#-- today, so no spherical FH algorithm can be built to reach it.
+_ring_term(::Planar, first_pt, prev, pt) = _area_component(prev, pt)
+_ring_term(::Spherical, first_pt, prev, pt) = _spherical_triangle_area(Eriksson(),
+    UnitSphericalPoint(GI.PointTrait(), first_pt), UnitSphericalPoint(GI.PointTrait(), prev),
+    UnitSphericalPoint(GI.PointTrait(), pt))
+_ring_total(::Planar, acc) = acc / 2
+_ring_total(::Spherical, acc) = acc
+
+_trace_polynodes(alg::FosterHormannClipping, ::Type{T}, a_list, b_list, a_idx_list, f_step, poly_a, poly_b) where {T} =
+    _trace_polynodes!(_RingCollector(T), alg, T, a_list, b_list, a_idx_list, f_step, poly_a, poly_b).polys
+
 #=
     _trace_polynodes(::Type{T}, a_list, b_list, a_idx_list, f_step)::Vector{GI.Polygon}
 
@@ -937,11 +992,10 @@ A list of GeoInterface polygons is returned from this function.
 Note: `poly_a` and `poly_b` are temporary inputs used for debugging and can be removed
 eventually.
 =#
-function _trace_polynodes(alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b_list, a_idx_list, f_step, poly_a, poly_b) where {T, M, A}
+function _trace_polynodes!(sink, alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b_list, a_idx_list, f_step, poly_a, poly_b) where {T, M, A}
     n_a_pts, n_b_pts = length(a_list), length(b_list)
     total_pts = n_a_pts + n_b_pts
     n_cross_pts = length(a_idx_list)
-    return_polys = Vector{_get_poly_type(T)}(undef, 0)
     # Keep track of number of processed intersection points
     visited_pts = 0
     processed_pts = 0
@@ -959,7 +1013,7 @@ function _trace_polynodes(alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b
 
         # Set first point in polygon
         curr = curr_list[idx]
-        pt_list = [curr.point]
+        ring = _ring_start(sink, curr.point)
 
         curr_not_start = true
         while curr_not_start
@@ -975,9 +1029,9 @@ function _trace_polynodes(alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b
                 idx = (idx > curr_npoints) ? mod(idx, curr_npoints) : idx
                 idx = (idx == 0) ? curr_npoints : idx
 
-                # Get current node and add to pt_list
+                # Get current node and add to the ring
                 curr = curr_list[idx]
-                push!(pt_list, curr.point)
+                ring = _ring_step(sink, ring, curr.point)
                 if (curr.crossing || curr.endpoint != not_endpoint)
                     # Keep track of processed intersection points
                     same_status = curr.ent_exit == prev_status
@@ -996,15 +1050,10 @@ function _trace_polynodes(alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b
             idx = curr.neighbor
             curr = curr_list[idx]
         end
-        push!(return_polys, GI.Polygon([pt_list]))
+        _ring_close!(sink, ring)
     end
-    return return_polys
+    return sink
 end
-
-# Get type of polygons that will be made
-# TODO: Increase type options
-_get_poly_type(::Type{T}) where T =
-    GI.Polygon{false, false, Vector{GI.LinearRing{false, false, Vector{Tuple{T, T}}, Nothing, Nothing}}, Nothing, Nothing}
 
 #=
     _find_non_cross_orientation(a_list, b_list, a_poly, b_poly; exact)

--- a/src/methods/clipping/clipping_processor.jl
+++ b/src/methods/clipping/clipping_processor.jl
@@ -924,16 +924,50 @@ end
 _get_poly_type(::Type{T}) where T =
     GI.Polygon{false, false, Vector{GI.LinearRing{false, false, Vector{Tuple{T, T}}, Nothing, Nothing}}, Nothing, Nothing}
 
-#= What the tracer does with the vertices it walks is the only thing that separates
-building the result rings from measuring them, so that is the one thing it takes as a
-parameter. `_RingCollector` is the original behaviour - a point vector per ring, wrapped
-as a polygon. `_RingMeasurer` keeps a running ring area instead, which is what lets
-`intersection_area` trace without materializing a ring at all.
+#=
+    abstract type _RingSink
 
-Each sink owns a per-ring `state`: `_ring_start` opens a ring at its first vertex,
-`_ring_step` takes the next vertex and returns the new state, and `_ring_close!` folds the
-finished ring into the sink. =#
-struct _RingCollector{P}
+What `_trace_polynodes!` does with the vertices it walks. The traversal is the same
+whether the result rings are being built or only measured, so that difference is the one
+thing the tracer takes as a parameter.
+
+## Interface
+
+A sink is fed one ring at a time, in traversal order, and carries whatever per-ring
+working value it likes as `state` — the tracer creates it, threads it through, hands it
+back, and never inspects it. Three methods, all required:
+
+| method | returns | contract |
+|:-------|:--------|:---------|
+| `_ring_start(sink, pt)` | `state` | open a ring whose first vertex is `pt` |
+| `_ring_step(sink, state, pt)` | `state` | extend the ring by `pt` |
+| `_ring_close!(sink, state)` | `nothing` | fold the finished ring into `sink` |
+
+The ring closes on the vertex it opened with: `_ring_step` is called with the first vertex
+again before `_ring_close!`, so a sink that walks edges gets the closing edge for free and
+one that collects points gets a closed ring.
+
+A sink accumulates across rings and is read afterwards, so it is the mutable half of the
+pair; `state` is per-ring and may be immutable. Two implementations ship:
+`_RingCollector` (the result polygons) and `_RingMeasurer` (their total area).
+=#
+abstract type _RingSink end
+
+#-- Interface fallbacks. Without them a sink missing a method fails as a `MethodError` on
+#-- an internal call several frames into the tracer, which says nothing about what is
+#-- actually missing.
+_ring_start(sink::_RingSink, pt) = _ring_sink_incomplete(sink, "_ring_start(sink, pt)")
+_ring_step(sink::_RingSink, state, pt) = _ring_sink_incomplete(sink, "_ring_step(sink, state, pt)")
+_ring_close!(sink::_RingSink, state) = _ring_sink_incomplete(sink, "_ring_close!(sink, state)")
+
+_ring_sink_incomplete(sink, sig) = throw(ArgumentError(
+    "$(typeof(sink)) is a `_RingSink` but does not implement `$sig`. A ring sink must " *
+    "implement `_ring_start`, `_ring_step` and `_ring_close!` — see the interface note " *
+    "above `_RingSink` in clipping_processor.jl."))
+
+# The result polygons: a point vector per ring, wrapped as a polygon. The original — and
+# still the only — behaviour of `_trace_polynodes`.
+struct _RingCollector{P} <: _RingSink
     polys::Vector{P}
 end
 _RingCollector(::Type{T}) where {T} = _RingCollector(Vector{_get_poly_type(T)}(undef, 0))
@@ -942,7 +976,9 @@ _ring_start(::_RingCollector, pt) = [pt]
 _ring_step(::_RingCollector, pts, pt) = (push!(pts, pt); pts)
 _ring_close!(sink::_RingCollector, pts) = (push!(sink.polys, GI.Polygon([pts])); nothing)
 
-mutable struct _RingMeasurer{M <: Manifold, T}
+# The total area of those same rings, accumulated as they are walked. This is what lets
+# `intersection_area` trace without materializing a ring at all.
+mutable struct _RingMeasurer{M <: Manifold, T} <: _RingSink
     manifold::M
     area::T
     nrings::Int   # `isempty(polys)` for the collector: whether the trace found anything
@@ -955,7 +991,8 @@ _ring_start(sink::_RingMeasurer{M, T}, pt) where {M, T} = (pt, pt, zero(T))
 _ring_step(sink::_RingMeasurer, (first_pt, prev, acc), pt) =
     (first_pt, pt, acc + _ring_term(sink.manifold, first_pt, prev, pt))
 function _ring_close!(sink::_RingMeasurer, (first_pt, prev, acc))
-    sink.area += abs(_ring_total(sink.manifold, acc + _ring_term(sink.manifold, first_pt, prev, first_pt)))
+    #-- the tracer already closed the ring on `first_pt`, so `acc` is complete
+    sink.area += abs(_ring_total(sink.manifold, acc))
     sink.nrings += 1
     return nothing
 end
@@ -992,7 +1029,7 @@ A list of GeoInterface polygons is returned from this function.
 Note: `poly_a` and `poly_b` are temporary inputs used for debugging and can be removed
 eventually.
 =#
-function _trace_polynodes!(sink, alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b_list, a_idx_list, f_step, poly_a, poly_b) where {T, M, A}
+function _trace_polynodes!(sink::_RingSink, alg::FosterHormannClipping{M, A}, ::Type{T}, a_list, b_list, a_idx_list, f_step, poly_a, poly_b) where {T, M, A}
     n_a_pts, n_b_pts = length(a_list), length(b_list)
     total_pts = n_a_pts + n_b_pts
     n_cross_pts = length(a_idx_list)

--- a/src/methods/clipping/intersection_area.jl
+++ b/src/methods/clipping/intersection_area.jl
@@ -4,14 +4,11 @@ export intersection_area
 #=
 `intersection_area(alg, a, b)` is `area(manifold(alg), intersection(alg, a, b))` with the
 result geometry left unbuilt: each engine stops at the rings it would have wrapped and
-accumulates their area in place.
+sums their area in place, through the shared `_ring_area` kernels in `methods/area.jl`.
 
-Two engines implement it, on both `Planar()` and `Spherical()`:
-
-- [`ConvexConvexSutherlandHodgman`](@ref) clips into its cache buffers and sums straight
-  off them, so with a `cache` the whole call is allocation-free.
-- [`OverlayNG`](@ref) runs the arrangement as usual but replaces polygon assembly with a
-  ring-area sum, skipping the `Polygon`/`MultiPolygon` wrappers.
+The per-engine work lives with its engine — `_sh_clip_planar!` / `_sh_clip_spherical!` in
+`sutherland_hodgman.jl`, `_overlay_intersection_area` in `overlayng/overlay_ng.jl` — so
+this file is only the public surface.
 =#
 
 """
@@ -21,10 +18,15 @@ Area of the intersection of `geom_a` and `geom_b`, computed without constructing
 intersection geometry.
 
 Equivalent to `area(manifold(alg), intersection(alg, geom_a, geom_b))`, but the result
-polygon is never built. Supported for [`ConvexConvexSutherlandHodgman`](@ref) (which takes
-the same `cache` keyword as `intersection`) and [`OverlayNG`](@ref), on `Planar()` and
-`Spherical()` manifolds. On `Spherical()` the result is in square units of the manifold
+polygon is never built. On `Spherical()` the result is in square units of the manifold
 radius.
+
+The algorithm is required, and the supported list is closed:
+
+| algorithm | manifolds | notes |
+|:----------|:----------|:------|
+| [`ConvexConvexSutherlandHodgman`](@ref) | `Planar()`, `Spherical()` | takes the same `cache` keyword as `intersection`; with one, the call allocates nothing |
+| [`OverlayNG`](@ref) | `Planar()`, `Spherical()` | `T` sets the accumulator and return type only — the arrangement always runs at the algorithm's `point_type` |
 
 ## Example
 
@@ -43,44 +45,6 @@ GO.intersection_area(alg, a, b; cache)      # 1.0, allocation-free
 """
 function intersection_area end
 
-# ## Ring area
-#
-# Both engines hand their rings over as a plain vector of points, closed or not.
-
-_area_scale(::Planar) = 1
-_area_scale(m::Spherical) = m.radius^2
-
-# Shoelace over the ring, wrapping from the last point to the first. A repeated closing
-# point contributes a zero term, so closed and open rings both work.
-function _ring_area(::Planar, pts::AbstractVector, ::Type{T}) where {T}
-    n = length(pts)
-    n < 3 && return zero(T)
-    a = zero(T)
-    for i in 1:n
-        p1, p2 = pts[i], pts[mod1(i + 1, n)]
-        a += _area_component(p1, p2)
-    end
-    return T(a / 2)
-end
-
-@inline _unit_spherical(p::UnitSphericalPoint) = p
-@inline _unit_spherical(p) = UnitSphericalPoint(GI.PointTrait(), p)
-
-# Signed unit-sphere area by the same fan triangulation `area(::Spherical, geom)` uses.
-function _ring_area(::Spherical, pts::AbstractVector, ::Type{T}) where {T}
-    n = length(pts)
-    n < 3 && return zero(T)
-    p1 = _unit_spherical(pts[1])
-    # drop the closing point, if the ring carries one
-    _unit_spherical(pts[n]) ≈ p1 && (n -= 1)
-    n < 3 && return zero(T)
-    a = zero(T)
-    for i in 2:(n - 1)
-        a += _spherical_triangle_area(Eriksson(), p1, _unit_spherical(pts[i]), _unit_spherical(pts[i + 1]))
-    end
-    return T(a)
-end
-
 # ## Sutherland-Hodgman
 #
 # The clip buffers are the result; there is nothing left to do but measure them.
@@ -89,6 +53,7 @@ function intersection_area(
     alg::ConvexConvexSutherlandHodgman{Planar}, geom_a, geom_b, ::Type{T}=Float64;
     cache::Union{Nothing, SutherlandHodgmanCache}=nothing
 ) where {T<:AbstractFloat}
+    _sh_check_polygon_traits(GI.trait(geom_a), GI.trait(geom_b))
     cache = isnothing(cache) ? SutherlandHodgmanCache(Planar(), T) : _sh_check_cache(cache, Tuple{T,T})
     return abs(_ring_area(Planar(), _sh_clip_planar!(cache, geom_a, geom_b, T), T))
 end
@@ -97,38 +62,14 @@ function intersection_area(
     alg::ConvexConvexSutherlandHodgman{Spherical{F}}, geom_a, geom_b, ::Type{T}=Float64;
     cache::Union{Nothing, SutherlandHodgmanCache}=nothing
 ) where {F, T<:AbstractFloat}
+    _sh_check_polygon_traits(GI.trait(geom_a), GI.trait(geom_b))
     m = alg.manifold
     cache = isnothing(cache) ? SutherlandHodgmanCache(m, T) : _sh_check_cache(cache, UnitSphericalPoint{T})
     pts = _sh_clip_spherical!(cache, geom_a, geom_b, T)
-    return abs(_ring_area(m, pts, T)) * _area_scale(m)
+    return T(abs(_ring_area(m, pts, T)) * _area_scale(m))
 end
 
 # ## OverlayNG
-#
-# The arrangement runs unchanged; only the extraction is replaced. Anything but two areal
-# inputs has an intersection of dimension < 2, hence zero area, and needs no noding at all.
 
-function intersection_area(alg::OverlayNG, geom_a, geom_b, ::Type{T}=Float64) where {T<:AbstractFloat}
-    m = alg.manifold
-    (_overlay_dimension(geom_a) == 2 && _overlay_dimension(geom_b) == 2) || return zero(T)
-    (_ov_isempty(geom_a) || _ov_isempty(geom_b)) && return zero(T)
-
-    input = _OverlayInput(m, geom_a, geom_b, 2, 2, alg.exact, false, false, nothing, nothing)
-    ea, eb = _overlay_envelopes(m, OVERLAY_INTERSECTION, input)
-    _empty_result_short_circuit(m, OVERLAY_INTERSECTION, input, ea, eb) && return zero(T)
-
-    g = _overlay_marked_graph(m, alg.point_type, OVERLAY_INTERSECTION, geom_a, geom_b,
-                              input, alg.exact, nothing, nothing, ea, eb)
-    ctx = _build_polygon_ctx(m, g, graph_result_area_edges(g); exact = alg.exact)
-
-    total = zero(T)
-    for shell_handle in ctx.shell_list
-        shell = ctx.edge_rings[shell_handle]
-        a = abs(_ring_area(m, shell.ring_pts, T))
-        for hole in shell.holes
-            a -= abs(_ring_area(m, ctx.edge_rings[hole].ring_pts, T))
-        end
-        total += a
-    end
-    return total * _area_scale(m)
-end
+intersection_area(alg::OverlayNG, geom_a, geom_b, ::Type{T}=Float64) where {T<:AbstractFloat} =
+    T(_overlay_intersection_area(alg.manifold, T, alg.point_type, geom_a, geom_b, alg.exact))

--- a/src/methods/clipping/intersection_area.jl
+++ b/src/methods/clipping/intersection_area.jl
@@ -7,8 +7,8 @@ result geometry left unbuilt: each engine stops at the rings it would have wrapp
 sums their area in place, through the shared `_ring_area` kernels in `methods/area.jl`.
 
 The per-engine work lives with its engine — `_sh_clip_planar!` / `_sh_clip_spherical!` in
-`sutherland_hodgman.jl`, `_overlay_intersection_area` in `overlayng/overlay_ng.jl` — so
-this file is only the public surface.
+`sutherland_hodgman.jl`, `_overlay_intersection_area` in `overlayng/overlay_ng.jl`,
+`_RingMeasurer` in `clipping_processor.jl` — so this file is only the public surface.
 =#
 
 """
@@ -27,6 +27,7 @@ The algorithm is required, and the supported list is closed:
 |:----------|:----------|:------|
 | [`ConvexConvexSutherlandHodgman`](@ref) | `Planar()`, `Spherical()` | takes the same `cache` keyword as `intersection`; with one, the call allocates nothing |
 | [`OverlayNG`](@ref) | `Planar()`, `Spherical()` | `T` sets the accumulator and return type only — the arrangement always runs at the algorithm's `point_type` |
+| [`FosterHormannClipping`](@ref) | as `intersection` | accumulates during the trace for hole-free polygon pairs; other inputs delegate to the polygon path |
 
 ## Example
 
@@ -51,20 +52,20 @@ function intersection_area end
 
 function intersection_area(
     alg::ConvexConvexSutherlandHodgman{Planar}, geom_a, geom_b, ::Type{T}=Float64;
-    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
+    cache::SutherlandHodgmanCache = SutherlandHodgmanCache(Planar(), T)
 ) where {T<:AbstractFloat}
     _sh_check_polygon_traits(GI.trait(geom_a), GI.trait(geom_b))
-    cache = isnothing(cache) ? SutherlandHodgmanCache(Planar(), T) : _sh_check_cache(cache, Tuple{T,T})
+    _sh_check_cache(cache, Tuple{T,T})
     return abs(_ring_area(Planar(), _sh_clip_planar!(cache, geom_a, geom_b, T), T))
 end
 
 function intersection_area(
     alg::ConvexConvexSutherlandHodgman{Spherical{F}}, geom_a, geom_b, ::Type{T}=Float64;
-    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
+    cache::SutherlandHodgmanCache = SutherlandHodgmanCache(alg.manifold, T)
 ) where {F, T<:AbstractFloat}
     _sh_check_polygon_traits(GI.trait(geom_a), GI.trait(geom_b))
+    _sh_check_cache(cache, UnitSphericalPoint{T})
     m = alg.manifold
-    cache = isnothing(cache) ? SutherlandHodgmanCache(m, T) : _sh_check_cache(cache, UnitSphericalPoint{T})
     pts = _sh_clip_spherical!(cache, geom_a, geom_b, T)
     return T(abs(_ring_area(m, pts, T)) * _area_scale(m))
 end
@@ -73,3 +74,39 @@ end
 
 intersection_area(alg::OverlayNG, geom_a, geom_b, ::Type{T}=Float64) where {T<:AbstractFloat} =
     T(_overlay_intersection_area(alg.manifold, T, alg.point_type, geom_a, geom_b, alg.exact))
+
+# ## Foster-Hormann
+#
+# The tracer walks the result ring one vertex at a time, so the area can be accumulated as
+# it goes and no ring is ever built (`_RingMeasurer` in clipping_processor.jl).
+#
+# That covers hole-free polygon pairs. Holes and multipolygons are assembled from the
+# traced rings *afterwards* — `_add_holes_to_polys!` cuts holes into result polygons and
+# can split, merge and drop them — and there is no ring-level shortcut through that, so
+# those inputs delegate to the polygon path. The answer is the same either way; only the
+# saving is lost.
+
+function intersection_area(
+    alg::FosterHormannClipping, geom_a, geom_b, ::Type{T}=Float64; kwargs...
+) where {T<:AbstractFloat}
+    m = alg.manifold
+    if !(GI.trait(geom_a) isa GI.PolygonTrait && GI.trait(geom_b) isa GI.PolygonTrait) ||
+       GI.nhole(geom_a) != 0 || GI.nhole(geom_b) != 0
+        return _fh_polygon_path_area(alg, m, geom_a, geom_b, T; kwargs...)
+    end
+    ext_a, ext_b = GI.getexterior(geom_a), GI.getexterior(geom_b)
+    a_list, b_list, a_idx_list =
+        _build_ab_list(alg, T, ext_a, ext_b, _inter_delay_cross_f, _inter_delay_bounce_f; exact = True())
+    sink = _trace_polynodes!(_RingMeasurer(m, T), alg, T, a_list, b_list, a_idx_list,
+                             _inter_step, geom_a, geom_b)
+    #-- no crossings at all: either one polygon contains the other, or they are disjoint.
+    #-- Rare, and the polygon path already decides it in one step.
+    sink.nrings == 0 && return _fh_polygon_path_area(alg, m, geom_a, geom_b, T; kwargs...)
+    return T(sink.area * _area_scale(m))
+end
+
+#-- `target` is spelled out because the areal components are the only ones with an area,
+#-- and because `intersection`'s own `target = nothing` default is currently broken
+#-- (`TraitTarget(nothing)` has no method).
+_fh_polygon_path_area(alg, m, geom_a, geom_b, ::Type{T}; kwargs...) where {T} =
+    T(area(m, intersection(alg, geom_a, geom_b, T; target = GI.PolygonTrait(), kwargs...)))

--- a/src/methods/clipping/intersection_area.jl
+++ b/src/methods/clipping/intersection_area.jl
@@ -1,0 +1,134 @@
+# # Intersection area
+export intersection_area
+
+#=
+`intersection_area(alg, a, b)` is `area(manifold(alg), intersection(alg, a, b))` with the
+result geometry left unbuilt: each engine stops at the rings it would have wrapped and
+accumulates their area in place.
+
+Two engines implement it, on both `Planar()` and `Spherical()`:
+
+- [`ConvexConvexSutherlandHodgman`](@ref) clips into its cache buffers and sums straight
+  off them, so with a `cache` the whole call is allocation-free.
+- [`OverlayNG`](@ref) runs the arrangement as usual but replaces polygon assembly with a
+  ring-area sum, skipping the `Polygon`/`MultiPolygon` wrappers.
+=#
+
+"""
+    intersection_area(alg::Algorithm, geom_a, geom_b, [T = Float64]; kwargs...)
+
+Area of the intersection of `geom_a` and `geom_b`, computed without constructing the
+intersection geometry.
+
+Equivalent to `area(manifold(alg), intersection(alg, geom_a, geom_b))`, but the result
+polygon is never built. Supported for [`ConvexConvexSutherlandHodgman`](@ref) (which takes
+the same `cache` keyword as `intersection`) and [`OverlayNG`](@ref), on `Planar()` and
+`Spherical()` manifolds. On `Spherical()` the result is in square units of the manifold
+radius.
+
+## Example
+
+```julia
+import GeometryOps as GO, GeoInterface as GI
+
+a = GI.Polygon([[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)]])
+b = GI.Polygon([[(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0), (1.0, 1.0)]])
+
+GO.intersection_area(GO.OverlayNG(), a, b)  # 1.0
+
+alg = GO.ConvexConvexSutherlandHodgman()
+cache = GO.SutherlandHodgmanCache(alg)
+GO.intersection_area(alg, a, b; cache)      # 1.0, allocation-free
+```
+"""
+function intersection_area end
+
+# ## Ring area
+#
+# Both engines hand their rings over as a plain vector of points, closed or not.
+
+_area_scale(::Planar) = 1
+_area_scale(m::Spherical) = m.radius^2
+
+# Shoelace over the ring, wrapping from the last point to the first. A repeated closing
+# point contributes a zero term, so closed and open rings both work.
+function _ring_area(::Planar, pts::AbstractVector, ::Type{T}) where {T}
+    n = length(pts)
+    n < 3 && return zero(T)
+    a = zero(T)
+    for i in 1:n
+        p1, p2 = pts[i], pts[mod1(i + 1, n)]
+        a += _area_component(p1, p2)
+    end
+    return T(a / 2)
+end
+
+@inline _unit_spherical(p::UnitSphericalPoint) = p
+@inline _unit_spherical(p) = UnitSphericalPoint(GI.PointTrait(), p)
+
+# Signed unit-sphere area by the same fan triangulation `area(::Spherical, geom)` uses.
+function _ring_area(::Spherical, pts::AbstractVector, ::Type{T}) where {T}
+    n = length(pts)
+    n < 3 && return zero(T)
+    p1 = _unit_spherical(pts[1])
+    # drop the closing point, if the ring carries one
+    _unit_spherical(pts[n]) ≈ p1 && (n -= 1)
+    n < 3 && return zero(T)
+    a = zero(T)
+    for i in 2:(n - 1)
+        a += _spherical_triangle_area(Eriksson(), p1, _unit_spherical(pts[i]), _unit_spherical(pts[i + 1]))
+    end
+    return T(a)
+end
+
+# ## Sutherland-Hodgman
+#
+# The clip buffers are the result; there is nothing left to do but measure them.
+
+function intersection_area(
+    alg::ConvexConvexSutherlandHodgman{Planar}, geom_a, geom_b, ::Type{T}=Float64;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
+) where {T<:AbstractFloat}
+    cache = isnothing(cache) ? SutherlandHodgmanCache(Planar(), T) : _sh_check_cache(cache, Tuple{T,T})
+    return abs(_ring_area(Planar(), _sh_clip_planar!(cache, geom_a, geom_b, T), T))
+end
+
+function intersection_area(
+    alg::ConvexConvexSutherlandHodgman{Spherical{F}}, geom_a, geom_b, ::Type{T}=Float64;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
+) where {F, T<:AbstractFloat}
+    m = alg.manifold
+    cache = isnothing(cache) ? SutherlandHodgmanCache(m, T) : _sh_check_cache(cache, UnitSphericalPoint{T})
+    pts = _sh_clip_spherical!(cache, geom_a, geom_b, T)
+    return abs(_ring_area(m, pts, T)) * _area_scale(m)
+end
+
+# ## OverlayNG
+#
+# The arrangement runs unchanged; only the extraction is replaced. Anything but two areal
+# inputs has an intersection of dimension < 2, hence zero area, and needs no noding at all.
+
+function intersection_area(alg::OverlayNG, geom_a, geom_b, ::Type{T}=Float64) where {T<:AbstractFloat}
+    m = alg.manifold
+    (_overlay_dimension(geom_a) == 2 && _overlay_dimension(geom_b) == 2) || return zero(T)
+    (_ov_isempty(geom_a) || _ov_isempty(geom_b)) && return zero(T)
+
+    input = _OverlayInput(m, geom_a, geom_b, 2, 2, alg.exact, false, false, nothing, nothing)
+    ea, eb = _overlay_envelopes(m, OVERLAY_INTERSECTION, input)
+    _empty_result_short_circuit(m, OVERLAY_INTERSECTION, input, ea, eb) && return zero(T)
+
+    g = _overlay_marked_graph(m, alg.point_type, OVERLAY_INTERSECTION, geom_a, geom_b,
+                              input, alg.exact, nothing, nothing, ea, eb)
+    ctx = _build_polygon_ctx(m, g, graph_result_area_edges(g); exact = alg.exact)
+
+    total = zero(T)
+    for shell_handle in ctx.shell_list
+        shell = ctx.edge_rings[shell_handle]
+        a = abs(_ring_area(m, shell.ring_pts, T))
+        for hole in shell.holes
+            a -= abs(_ring_area(m, ctx.edge_rings[hole].ring_pts, T))
+        end
+        total += a
+    end
+    return total * _area_scale(m)
+end

--- a/src/methods/clipping/intersection_area.jl
+++ b/src/methods/clipping/intersection_area.jl
@@ -56,7 +56,8 @@ function intersection_area(
 ) where {T<:AbstractFloat}
     _sh_check_polygon_traits(GI.trait(geom_a), GI.trait(geom_b))
     _sh_check_cache(cache, Tuple{T,T})
-    return abs(_ring_area(Planar(), _sh_clip_planar!(cache, geom_a, geom_b, T), T))
+    #-- the clip buffers are open: they never repeat the first vertex
+    return abs(_ring_area(Planar(), _sh_clip_planar!(cache, geom_a, geom_b, T), T; closed = false))
 end
 
 function intersection_area(
@@ -67,7 +68,7 @@ function intersection_area(
     _sh_check_cache(cache, UnitSphericalPoint{T})
     m = alg.manifold
     pts = _sh_clip_spherical!(cache, geom_a, geom_b, T)
-    return T(abs(_ring_area(m, pts, T)) * _area_scale(m))
+    return T(abs(_ring_area(m, pts, T; closed = false)) * _area_scale(m))
 end
 
 # ## OverlayNG

--- a/src/methods/clipping/overlayng/overlay_ng.jl
+++ b/src/methods/clipping/overlayng/overlay_ng.jl
@@ -114,8 +114,7 @@ _overlay_ng(m::Manifold, op::_OverlayOpCode, a, b;
 function _overlay_ng(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
         target, exact, tree_a, tree_b) where {T}
     tgt = _ov_target(target)
-    input = _overlay_input(m, a, b, exact)
-    dim_a, dim_b = input.dim_a, input.dim_b
+    input, dim_a, dim_b = _overlay_input(m, a, b, exact)
 
     #-- a target above the result dimension can match nothing whatever the inputs
     #-- contain, so it is answered without noding at all
@@ -145,9 +144,19 @@ end
 # derives the dimensions and empty flags the same way — `_empty_result_short_circuit` and
 # `_overlay_envelopes` both read them, and a hand-built one that disagrees is a silent
 # wrong answer rather than an error.
-_overlay_input(m::Manifold, a, b, exact) =
-    _OverlayInput(m, a, b, _overlay_dimension(a), _overlay_dimension(b), exact,
-                  _ov_isempty(a), _ov_isempty(b), nothing, nothing)
+#
+#-- The dimensions come back alongside the input, and callers must branch on THOSE and not
+#-- on `input.dim_a`/`input.dim_b`. `_OverlayInput` is mutable and escapes into the
+#-- labeller, so a field load off it is opaque to inference, whereas `_overlay_dimension`
+#-- folds to a constant in the type domain — and that constant is what prunes the
+#-- untargeted result union down from `Any`. Returning them keeps the two in lockstep
+#-- without anyone having to remember to call `_overlay_dimension` twice.
+@inline function _overlay_input(m::Manifold, a, b, exact)
+    dim_a, dim_b = _overlay_dimension(a), _overlay_dimension(b)
+    input = _OverlayInput(m, a, b, dim_a, dim_b, exact,
+                          _ov_isempty(a), _ov_isempty(b), nothing, nothing)
+    return input, dim_a, dim_b
+end
 
 # Node the inputs, build the graph, label it, and mark its result-area edges: the
 # whole pipeline up to the point where a result is extracted from it. Shared with
@@ -174,8 +183,8 @@ end
 #-- in `_overlay_ng`: an unannotated type argument is not specialized on, and the whole
 #-- pipeline below is a function of it.
 function _overlay_intersection_area(m::Manifold, ::Type{T}, ::Type{P}, a, b, exact) where {T, P}
-    input = _overlay_input(m, a, b, exact)
-    (input.dim_a == 2 && input.dim_b == 2) || return zero(T)
+    input, dim_a, dim_b = _overlay_input(m, a, b, exact)
+    (dim_a == 2 && dim_b == 2) || return zero(T)
 
     ea, eb = _overlay_envelopes(m, OVERLAY_INTERSECTION, input)
     #-- empty inputs are part of what this rejects, so they need no separate test

--- a/src/methods/clipping/overlayng/overlay_ng.jl
+++ b/src/methods/clipping/overlayng/overlay_ng.jl
@@ -114,11 +114,8 @@ _overlay_ng(m::Manifold, op::_OverlayOpCode, a, b;
 function _overlay_ng(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
         target, exact, tree_a, tree_b) where {T}
     tgt = _ov_target(target)
-    dim_a = _overlay_dimension(a)
-    dim_b = _overlay_dimension(b)
-
-    input = _OverlayInput(m, a, b, dim_a, dim_b, exact, _ov_isempty(a), _ov_isempty(b),
-                          nothing, nothing)
+    input = _overlay_input(m, a, b, exact)
+    dim_a, dim_b = input.dim_a, input.dim_b
 
     #-- a target above the result dimension can match nothing whatever the inputs
     #-- contain, so it is answered without noding at all
@@ -139,16 +136,25 @@ function _overlay_ng(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
         return _overlay_mixed_points(m, T, op, a, b, dim_a, dim_b, tgt; exact)  # hasPoints
     end
 
-    g = _overlay_marked_graph(m, T, op, a, b, input, exact, tree_a, tree_b, ea, eb)
+    g = _overlay_marked_graph(m, T, op, a, b, input, tree_a, tree_b, ea, eb)
 
     return _extract_result(m, op, g, input, tgt; exact)
 end
 
+# The two operands as the engine's own input model. Shared so that every entry point
+# derives the dimensions and empty flags the same way — `_empty_result_short_circuit` and
+# `_overlay_envelopes` both read them, and a hand-built one that disagrees is a silent
+# wrong answer rather than an error.
+_overlay_input(m::Manifold, a, b, exact) =
+    _OverlayInput(m, a, b, _overlay_dimension(a), _overlay_dimension(b), exact,
+                  _ov_isempty(a), _ov_isempty(b), nothing, nothing)
+
 # Node the inputs, build the graph, label it, and mark its result-area edges: the
 # whole pipeline up to the point where a result is extracted from it. Shared with
-# `intersection_area`, which extracts an area instead of a geometry.
+# `_overlay_intersection_area`, which extracts an area instead of a geometry.
 function _overlay_marked_graph(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b, input,
-        exact, tree_a, tree_b, ea, eb) where {T}
+        tree_a, tree_b, ea, eb) where {T}
+    exact = input.exact
     clip_a, clip_b = _overlay_clip_envelopes(op, ea, eb)
     #-- the positional form: a `point_type` keyword would be re-boxed into the
     #-- kwargs `NamedTuple` as a bare `DataType` and `T` would stop propagating
@@ -159,6 +165,25 @@ function _overlay_marked_graph(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
     _mark_result_area_edges!(g, op)
     _unmark_duplicate_edges_from_result_area!(g)
     return g
+end
+
+# The area of the intersection, without building it: the driver's own preamble, then the
+# same marked graph, then a ring-area sum in place of the result assembly. Anything but two
+# areal inputs intersects in dimension < 2, so there is no area to find and no noding to do.
+#-- `P` (the output point type) is a POSITIONAL `::Type{P}` for the same reason it is one
+#-- in `_overlay_ng`: an unannotated type argument is not specialized on, and the whole
+#-- pipeline below is a function of it.
+function _overlay_intersection_area(m::Manifold, ::Type{T}, ::Type{P}, a, b, exact) where {T, P}
+    input = _overlay_input(m, a, b, exact)
+    (input.dim_a == 2 && input.dim_b == 2) || return zero(T)
+
+    ea, eb = _overlay_envelopes(m, OVERLAY_INTERSECTION, input)
+    #-- empty inputs are part of what this rejects, so they need no separate test
+    _empty_result_short_circuit(m, OVERLAY_INTERSECTION, input, ea, eb) && return zero(T)
+
+    g = _overlay_marked_graph(m, P, OVERLAY_INTERSECTION, a, b, input,
+                              nothing, nothing, ea, eb)
+    return _build_polygon_area(m, g, graph_result_area_edges(g), T; exact) * _area_scale(m)
 end
 
 # ## Result extraction (port of `extractResult`)

--- a/src/methods/clipping/overlayng/overlay_ng.jl
+++ b/src/methods/clipping/overlayng/overlay_ng.jl
@@ -24,20 +24,27 @@
 # ## Input model (port of `InputGeometry`)
 
 # The two overlay operands with their dimensions, lazily-built area locators, and
-# empty flags. `a`/`b` are boxed (`Any`) — only the cold locator-build path reads
-# them; the hot pipeline runs on the type-erased graph.
-mutable struct _OverlayInput{M <: Manifold, E}
+# empty flags.
+#-- Immutable so `dim_a`/`dim_b` const-fold: that fold prunes the untargeted
+#-- `intersection` return type to a concrete Union. Only the locator Refs mutate.
+const _OvLocRef{M, E} = Base.RefValue{Union{Nothing, IndexedPointInAreaLocator{M, E}}}
+struct _OverlayInput{M <: Manifold, A, B, E}
     m::M
-    a::Any
-    b::Any
+    a::A
+    b::B
     dim_a::Int
     dim_b::Int
     exact::E
     empty_a::Bool
     empty_b::Bool
-    loc_a::Any   # Union{Nothing, IndexedPointInAreaLocator}, lazy
-    loc_b::Any
+    loc_a::_OvLocRef{M, E}
+    loc_b::_OvLocRef{M, E}
 end
+
+#-- takes the locators unwrapped, so every call site reads `..., nothing, nothing)`
+_OverlayInput(m::M, a::A, b::B, dim_a, dim_b, exact::E, empty_a, empty_b, loc_a, loc_b) where {M, A, B, E} =
+    _OverlayInput{M, A, B, E}(m, a, b, dim_a, dim_b, exact, empty_a, empty_b,
+                              _OvLocRef{M, E}(loc_a), _OvLocRef{M, E}(loc_b))
 
 @inline _input_dim(input::_OverlayInput, gi::Integer) = gi == 0 ? input.dim_a : input.dim_b
 @inline _input_is_area(input::_OverlayInput, gi::Integer) = _input_dim(input, gi) == 2
@@ -54,14 +61,16 @@ end
 function _input_locate_in_area(input::_OverlayInput, gi::Integer, pt)
     if gi == 0
         input.empty_a && return LOC_EXTERIOR
-        input.loc_a === nothing &&
-            (input.loc_a = IndexedPointInAreaLocator(input.m, input.a; exact = input.exact))
-        return locate(input.loc_a, pt)
+        loc = input.loc_a[]
+        loc === nothing &&
+            (loc = input.loc_a[] = IndexedPointInAreaLocator(input.m, input.a; exact = input.exact))
+        return locate(loc, pt)
     else
         input.empty_b && return LOC_EXTERIOR
-        input.loc_b === nothing &&
-            (input.loc_b = IndexedPointInAreaLocator(input.m, input.b; exact = input.exact))
-        return locate(input.loc_b, pt)
+        loc = input.loc_b[]
+        loc === nothing &&
+            (loc = input.loc_b[] = IndexedPointInAreaLocator(input.m, input.b; exact = input.exact))
+        return locate(loc, pt)
     end
 end
 
@@ -114,7 +123,8 @@ _overlay_ng(m::Manifold, op::_OverlayOpCode, a, b;
 function _overlay_ng(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
         target, exact, tree_a, tree_b) where {T}
     tgt = _ov_target(target)
-    input, dim_a, dim_b = _overlay_input(m, a, b, exact)
+    input = _overlay_input(m, a, b, exact)
+    dim_a, dim_b = input.dim_a, input.dim_b
 
     #-- a target above the result dimension can match nothing whatever the inputs
     #-- contain, so it is answered without noding at all
@@ -144,19 +154,9 @@ end
 # derives the dimensions and empty flags the same way — `_empty_result_short_circuit` and
 # `_overlay_envelopes` both read them, and a hand-built one that disagrees is a silent
 # wrong answer rather than an error.
-#
-#-- The dimensions come back alongside the input, and callers must branch on THOSE and not
-#-- on `input.dim_a`/`input.dim_b`. `_OverlayInput` is mutable and escapes into the
-#-- labeller, so a field load off it is opaque to inference, whereas `_overlay_dimension`
-#-- folds to a constant in the type domain — and that constant is what prunes the
-#-- untargeted result union down from `Any`. Returning them keeps the two in lockstep
-#-- without anyone having to remember to call `_overlay_dimension` twice.
-@inline function _overlay_input(m::Manifold, a, b, exact)
-    dim_a, dim_b = _overlay_dimension(a), _overlay_dimension(b)
-    input = _OverlayInput(m, a, b, dim_a, dim_b, exact,
-                          _ov_isempty(a), _ov_isempty(b), nothing, nothing)
-    return input, dim_a, dim_b
-end
+@inline _overlay_input(m::Manifold, a, b, exact) =
+    _OverlayInput(m, a, b, _overlay_dimension(a), _overlay_dimension(b), exact,
+                  _ov_isempty(a), _ov_isempty(b), nothing, nothing)
 
 # Node the inputs, build the graph, label it, and mark its result-area edges: the
 # whole pipeline up to the point where a result is extracted from it. Shared with
@@ -183,8 +183,8 @@ end
 #-- in `_overlay_ng`: an unannotated type argument is not specialized on, and the whole
 #-- pipeline below is a function of it.
 function _overlay_intersection_area(m::Manifold, ::Type{T}, ::Type{P}, a, b, exact) where {T, P}
-    input, dim_a, dim_b = _overlay_input(m, a, b, exact)
-    (dim_a == 2 && dim_b == 2) || return zero(T)
+    input = _overlay_input(m, a, b, exact)
+    (input.dim_a == 2 && input.dim_b == 2) || return zero(T)
 
     ea, eb = _overlay_envelopes(m, OVERLAY_INTERSECTION, input)
     #-- empty inputs are part of what this rejects, so they need no separate test

--- a/src/methods/clipping/overlayng/overlay_ng.jl
+++ b/src/methods/clipping/overlayng/overlay_ng.jl
@@ -139,6 +139,16 @@ function _overlay_ng(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
         return _overlay_mixed_points(m, T, op, a, b, dim_a, dim_b, tgt; exact)  # hasPoints
     end
 
+    g = _overlay_marked_graph(m, T, op, a, b, input, exact, tree_a, tree_b, ea, eb)
+
+    return _extract_result(m, op, g, input, tgt; exact)
+end
+
+# Node the inputs, build the graph, label it, and mark its result-area edges: the
+# whole pipeline up to the point where a result is extracted from it. Shared with
+# `intersection_area`, which extracts an area instead of a geometry.
+function _overlay_marked_graph(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b, input,
+        exact, tree_a, tree_b, ea, eb) where {T}
     clip_a, clip_b = _overlay_clip_envelopes(op, ea, eb)
     #-- the positional form: a `point_type` keyword would be re-boxed into the
     #-- kwargs `NamedTuple` as a bare `DataType` and `T` would stop propagating
@@ -148,8 +158,7 @@ function _overlay_ng(m::Manifold, ::Type{T}, op::_OverlayOpCode, a, b,
     _compute_labelling!(g, input)
     _mark_result_area_edges!(g, op)
     _unmark_duplicate_edges_from_result_area!(g)
-
-    return _extract_result(m, op, g, input, tgt; exact)
+    return g
 end
 
 # ## Result extraction (port of `extractResult`)

--- a/src/methods/clipping/overlayng/polygon_builder.jl
+++ b/src/methods/clipping/overlayng/polygon_builder.jl
@@ -58,12 +58,12 @@ end
 
 # Ring the graph's result-area edges into shells and holes (port of the
 # `PolygonBuilder` constructor + `buildRings`), returning the builder context.
-function _build_polygon_ctx(m::Manifold, g::OverlayGraph{P, T}, result_area_edges; exact) where {P, T}
-    _assert_graph_extractable(g, "_build_polygons")
+function _build_polygon_ctx(m::Manifold, g::OverlayGraph{P, T}, result_area_edges, who; exact) where {P, T}
+    _assert_graph_extractable(g, who)
     #-- the op pipeline walks `onext`/`sym` directly and has no notion of a removed
     #-- edge, so a hygiene-filtered graph would silently ignore the removal
     _graph_has_removed_edges(g) && throw(_OverlayTopologyError(
-        "_build_polygons: this OverlayGraph has had half-edges removed by the " *
+        "$who: this OverlayGraph has had half-edges removed by the " *
         "face-walk hygiene pass (`remove_dangles` / `remove_cut_edges`). The op " *
         "pipeline does not honour removal, so its result would silently ignore it. " *
         "Hygiene is a face-enumeration facility — use `_build_faces` on that graph."))
@@ -76,8 +76,26 @@ end
 # Build the result polygons from the graph's result-area edges (port of the
 # `PolygonBuilder` constructor + `getPolygons`).
 function _build_polygons(m::Manifold, g::OverlayGraph, result_area_edges; exact)
-    ctx = _build_polygon_ctx(m, g, result_area_edges; exact)
+    ctx = _build_polygon_ctx(m, g, result_area_edges, "_build_polygons"; exact)
     return [_ring_to_polygon(ctx, sh) for sh in ctx.shell_list]
+end
+
+# The total area of those same polygons, summed off the rings instead of wrapping them
+# (`intersection_area`). The `_ring_to_polygon` companion: shell minus its holes, which is
+# what `GO.area` computes from the polygon this would have built.
+function _build_polygon_area(m::Manifold, g::OverlayGraph, result_area_edges, ::Type{T};
+        exact) where {T}
+    ctx = _build_polygon_ctx(m, g, result_area_edges, "_build_polygon_area"; exact)
+    total = zero(T)
+    for shell_handle in ctx.shell_list
+        shell = ctx.edge_rings[shell_handle]
+        area = abs(_ring_area(m, shell.ring_pts, T))
+        for hole in shell.holes
+            area -= abs(_ring_area(m, ctx.edge_rings[hole].ring_pts, T))
+        end
+        total += area
+    end
+    return total
 end
 
 # Port of `buildRings`.

--- a/src/methods/clipping/overlayng/polygon_builder.jl
+++ b/src/methods/clipping/overlayng/polygon_builder.jl
@@ -56,9 +56,9 @@ function _assert_graph_extractable(g::OverlayGraph, who::AbstractString)
     return nothing
 end
 
-# Build the result polygons from the graph's result-area edges (port of the
-# `PolygonBuilder` constructor + `getPolygons`).
-function _build_polygons(m::Manifold, g::OverlayGraph{P, T}, result_area_edges; exact) where {P, T}
+# Ring the graph's result-area edges into shells and holes (port of the
+# `PolygonBuilder` constructor + `buildRings`), returning the builder context.
+function _build_polygon_ctx(m::Manifold, g::OverlayGraph{P, T}, result_area_edges; exact) where {P, T}
     _assert_graph_extractable(g, "_build_polygons")
     #-- the op pipeline walks `onext`/`sym` directly and has no notion of a removed
     #-- edge, so a hygiene-filtered graph would silently ignore the removal
@@ -70,6 +70,13 @@ function _build_polygons(m::Manifold, g::OverlayGraph{P, T}, result_area_edges; 
     ctx = _PolyBuilderCtx(m, g.edges, g.arr, exact, _MaxEdgeRing[], _edge_ring_type(T)[],
                           Int32[], Int32[])
     _build_rings!(ctx, result_area_edges)
+    return ctx
+end
+
+# Build the result polygons from the graph's result-area edges (port of the
+# `PolygonBuilder` constructor + `getPolygons`).
+function _build_polygons(m::Manifold, g::OverlayGraph, result_area_edges; exact)
+    ctx = _build_polygon_ctx(m, g, result_area_edges; exact)
     return [_ring_to_polygon(ctx, sh) for sh in ctx.shell_list]
 end
 

--- a/src/methods/clipping/sutherland_hodgman.jl
+++ b/src/methods/clipping/sutherland_hodgman.jl
@@ -433,16 +433,24 @@ function _intersection_sutherland_hodgman(
     return GI.Polygon([result])
 end
 
-# Fallback for unsupported geometry combinations
-function _intersection_sutherland_hodgman(
-    alg::ConvexConvexSutherlandHodgman,
-    ::Type{T},
-    trait_a, geom_a,
-    trait_b, geom_b;
-    kwargs...
-) where {T}
-    throw(ArgumentError(
+# The one supported input combination, in one place: `intersection` reaches it through
+# trait dispatch, `intersection_area` calls it directly, and both fail with this message.
+function _sh_check_polygon_traits(trait_a, trait_b)
+    (trait_a isa GI.PolygonTrait && trait_b isa GI.PolygonTrait) || throw(ArgumentError(
         "ConvexConvexSutherlandHodgman only supports Polygon-Polygon intersection, " *
         "got $(typeof(trait_a)) and $(typeof(trait_b))"
+    ))
+    return nothing
+end
+
+# Fallback for unsupported geometry combinations
+function _intersection_sutherland_hodgman(
+    alg::ConvexConvexSutherlandHodgman, ::Type{T}, trait_a, geom_a, trait_b, geom_b; kwargs...
+) where {T}
+    _sh_check_polygon_traits(trait_a, trait_b)
+    #-- two polygons and still no method: it is the manifold that is unsupported
+    throw(ArgumentError(
+        "ConvexConvexSutherlandHodgman supports the `Planar()` and `Spherical()` " *
+        "manifolds; got $(typeof(manifold(alg)))"
     ))
 end

--- a/src/methods/clipping/sutherland_hodgman.jl
+++ b/src/methods/clipping/sutherland_hodgman.jl
@@ -115,16 +115,10 @@ function intersection(
     )
 end
 
-# Polygon-Polygon intersection using Sutherland-Hodgman
-function _intersection_sutherland_hodgman(
-    alg::ConvexConvexSutherlandHodgman{Planar},
-    ::Type{T},
-    ::GI.PolygonTrait, poly_a,
-    ::GI.PolygonTrait, poly_b;
-    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
-) where {T}
-    cache = isnothing(cache) ? SutherlandHodgmanCache(Planar(), T) : _sh_check_cache(cache, Tuple{T,T})
-
+# Clip `poly_a` against every edge of `poly_b`, returning the cache buffer holding the
+# surviving vertices (empty if the two polygons are disjoint). The ring is open - the
+# closing point is not repeated.
+function _sh_clip_planar!(cache::SutherlandHodgmanCache, poly_a, poly_b, ::Type{T}) where {T}
     # Get exterior rings (convex polygons have no holes)
     ring_a = GI.getexterior(poly_a)
     ring_b = GI.getexterior(poly_b)
@@ -148,6 +142,20 @@ function _intersection_sutherland_hodgman(
         _sh_clip_to_edge!(buf_out, buf_in, edge_start, edge_end, T)
         buf_in, buf_out = buf_out, buf_in
     end
+
+    return buf_in
+end
+
+# Polygon-Polygon intersection using Sutherland-Hodgman
+function _intersection_sutherland_hodgman(
+    alg::ConvexConvexSutherlandHodgman{Planar},
+    ::Type{T},
+    ::GI.PolygonTrait, poly_a,
+    ::GI.PolygonTrait, poly_b;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
+) where {T}
+    cache = isnothing(cache) ? SutherlandHodgmanCache(Planar(), T) : _sh_check_cache(cache, Tuple{T,T})
+    buf_in = _sh_clip_planar!(cache, poly_a, poly_b, T)
 
     # Handle empty result (no intersection) - return degenerate polygon with zero area
     if isempty(buf_in)
@@ -337,16 +345,10 @@ function _sh_clip_to_edge_spherical!(
     return output
 end
 
-# Spherical Polygon-Polygon intersection using Sutherland-Hodgman
-function _intersection_sutherland_hodgman(
-    alg::ConvexConvexSutherlandHodgman{Spherical{F}},
-    ::Type{T},
-    ::GI.PolygonTrait, poly_a,
-    ::GI.PolygonTrait, poly_b;
-    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
-) where {F, T}
-    cache = isnothing(cache) ? SutherlandHodgmanCache(alg.manifold, T) : _sh_check_cache(cache, UnitSpherical.UnitSphericalPoint{T})
-
+# Clip `poly_a` against every edge of `poly_b` on the sphere. Returns the cache buffer of
+# surviving vertices - which is the clip polygon itself when the subject contains it
+# entirely, and empty when the two are disjoint. Fewer than 3 points means no area.
+function _sh_clip_spherical!(cache::SutherlandHodgmanCache, poly_a, poly_b, ::Type{T}) where {T}
     ring_a = GI.getexterior(poly_a)
     ring_b = GI.getexterior(poly_b)
 
@@ -397,32 +399,37 @@ function _intersection_sutherland_hodgman(
         buf_in, buf_out = buf_out, buf_in
     end
 
-    # Handle empty result - check if clip polygon is fully inside the original subject.
+    # Empty result - the clip polygon may still be fully inside the original subject.
     # "Fully inside" needs EVERY clip vertex inside the subject, not just the first:
-    if isempty(buf_in)
-        if !isempty(clip_points) &&
-           all(p -> _point_in_convex_spherical_polygon(p, original_subject), clip_points)
-            # Subject contains clip - return clip polygon (copied, so it doesn't alias the cache)
-            result = copy(clip_points)
-            push!(result, result[1])
-            return GI.Polygon([result])
-        end
-        # Truly disjoint - return degenerate polygon with zero area
-        north_pole = UnitSpherical.UnitSphericalPoint{T}(0, 0, 1)
-        return GI.Polygon([[north_pole, north_pole, north_pole]])
+    if isempty(buf_in) && !isempty(clip_points) &&
+       all(p -> _point_in_convex_spherical_polygon(p, original_subject), clip_points)
+        return clip_points
     end
+    return buf_in
+end
 
-    # Handle degenerate result (1-2 points can't form a valid ring)
-    # This happens for adjacent polygons that share only an edge or corner
-    if length(buf_in) < 3
+# Spherical Polygon-Polygon intersection using Sutherland-Hodgman
+function _intersection_sutherland_hodgman(
+    alg::ConvexConvexSutherlandHodgman{Spherical{F}},
+    ::Type{T},
+    ::GI.PolygonTrait, poly_a,
+    ::GI.PolygonTrait, poly_b;
+    cache::Union{Nothing, SutherlandHodgmanCache}=nothing
+) where {F, T}
+    cache = isnothing(cache) ? SutherlandHodgmanCache(alg.manifold, T) : _sh_check_cache(cache, UnitSpherical.UnitSphericalPoint{T})
+    pts = _sh_clip_spherical!(cache, poly_a, poly_b, T)
+
+    # 1-2 points can't form a valid ring (disjoint polygons, or adjacent ones sharing only
+    # an edge or corner) - return a degenerate polygon with zero area
+    if length(pts) < 3
         north_pole = UnitSpherical.UnitSphericalPoint{T}(0, 0, 1)
         return GI.Polygon([[north_pole, north_pole, north_pole]])
     end
 
     # Copy into a fresh closed ring so the result doesn't alias the cache
-    result = Vector{UnitSpherical.UnitSphericalPoint{T}}(undef, length(buf_in) + 1)
-    copyto!(result, buf_in)
-    result[end] = buf_in[1]
+    result = Vector{UnitSpherical.UnitSphericalPoint{T}}(undef, length(pts) + 1)
+    copyto!(result, pts)
+    result[end] = pts[1]
     return GI.Polygon([result])
 end
 

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -60,6 +60,27 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         @test GO.intersection_area(alg, GI.Point(1.0, 1.0), square_a) == 0.0
     end
 
+    @testset "Sutherland-Hodgman rejects what `intersection` rejects" begin
+        line = GI.LineString([(0.0, 0.0), (2.0, 2.0)])
+        for alg in (GO.ConvexConvexSutherlandHodgman(), GO.ConvexConvexSutherlandHodgman(GO.Spherical()))
+            @test_throws ArgumentError GO.intersection_area(alg, line, square_a)
+            @test_throws ArgumentError GO.intersection_area(alg, square_a, GI.Point(1.0, 1.0))
+        end
+    end
+
+    @testset "Float type" begin
+        for alg in (GO.ConvexConvexSutherlandHodgman(), GO.OverlayNG())
+            @test GO.intersection_area(alg, square_a, square_b, Float32) isa Float32
+        end
+        # the spherical radius must not silently widen the result back to Float64
+        sph = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+        sa = _spherical_polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)])
+        sb = _spherical_polygon([(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0)])
+        f32_cache = GO.SutherlandHodgmanCache(sph, Float32)
+        @test GO.intersection_area(sph, sa, sb, Float32; cache = f32_cache) isa Float32
+        @test GO.intersection_area(GO.OverlayNG(GO.Spherical()), square_a, square_b, Float32) isa Float32
+    end
+
     @testset "Spherical" begin
         sh = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
         ov = GO.OverlayNG(GO.Spherical())
@@ -80,6 +101,19 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
             # both engines measure the same lune, whichever chart they work in
             @test GO.intersection_area(sh, sa, sb) ≈ GO.intersection_area(ov, la, lb) rtol=1e-8
         end
+
+        # the lon/lat output chart reaches the same area as the xyz one it rounds from
+        la = GI.Polygon([[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)]])
+        lb = GI.Polygon([[(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0), (1.0, 1.0)]])
+        lonlat = GO.OverlayNG(GO.Spherical(); point_type = Tuple{Float64,Float64})
+        @test GO.intersection_area(lonlat, la, lb) ≈ GO.intersection_area(ov, la, lb) rtol=1e-9
+
+        # a hole in the spherical result is subtracted, as it is on the plane
+        donut = GI.Polygon([[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)],
+                            [(3.0, 3.0), (3.0, 7.0), (7.0, 7.0), (7.0, 3.0), (3.0, 3.0)]])
+        box = GI.Polygon([[(2.0, 2.0), (8.0, 2.0), (8.0, 8.0), (2.0, 8.0), (2.0, 2.0)]])
+        @test GO.intersection_area(ov, donut, box) ≈
+            GO.area(GO.Spherical(), GO.intersection(ov, donut, box))
 
         # the radius of the manifold scales the result
         sa, sb = _spherical_polygon(coords_a), _spherical_polygon(coords_b)
@@ -106,6 +140,9 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         _area_bytes(spherical, sa, sb, spherical_cache)
         @test _area_bytes(planar, square_a, square_b, planar_cache) == 0
         @test _area_bytes(spherical, sa, sb, spherical_cache) == 0
+        # Guard against passing vacuously: without a cache the buffers cost something
+        _area_bytes(planar, square_a, square_b, nothing)
+        @test _area_bytes(planar, square_a, square_b, nothing) > 0
 
         @test_throws ArgumentError GO.intersection_area(planar, square_a, square_b; cache = spherical_cache)
     end

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -154,6 +154,33 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         @test GO.area(GO.difference(alg, square_a, square_b; target = GI.PolygonTrait())) ≈ 3.0
     end
 
+    @testset "Slivers - the clip buffers are open rings" begin
+        # A sliver's two end vertices are legitimately close together. The spherical ring
+        # area drops a closing point with `isapprox`'s default rtol (~1.5e-8), so on an
+        # OPEN buffer that tolerance eats a real vertex: the 4-vertex sliver becomes a
+        # triangle and loses half its area, or all of it once the fan degenerates.
+        sh = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+        big = _spherical_polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)])
+        for w in (1e-6, 1e-8, 1e-9, 1e-10, 1e-12)
+            # overlaps `big` in a corner sliver of side `w`, so buffer[end] ≈ buffer[1]
+            corner = _spherical_polygon([(2.0 - w, 2.0 - w), (4.0, 2.0 - w), (4.0, 4.0), (2.0 - w, 4.0)])
+            @test GO.intersection_area(sh, big, corner) ==
+                GO.area(GO.Spherical(), GO.intersection(sh, big, corner))
+            @test GO.intersection_area(sh, big, corner) > 0
+        end
+
+        # and the flag itself: an open ring whose ends are within that tolerance keeps
+        # every vertex, while a closed one still drops its closing point
+        t = UnitSphereFromGeographic()
+        open_ring = [t((0.0, 0.0)), t((1.0, 0.0)), t((1.0, 1.0)), t((1e-9, 1e-9))]
+        fan(pts) = sum(GO._spherical_triangle_area(GO.Eriksson(), pts[1], pts[i], pts[i + 1])
+                       for i in 2:(length(pts) - 1))
+        @test GO._ring_area(GO.Spherical(), open_ring, Float64; closed = false) == fan(open_ring)
+        @test GO._ring_area(GO.Spherical(), open_ring, Float64) != fan(open_ring)  # trimmed
+        closed_ring = push!(copy(open_ring), open_ring[1])
+        @test GO._ring_area(GO.Spherical(), closed_ring, Float64) == fan(open_ring)
+    end
+
     @testset "Cache" begin
         planar = GO.ConvexConvexSutherlandHodgman()
         spherical = GO.ConvexConvexSutherlandHodgman(GO.Spherical())

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -1,0 +1,112 @@
+using Test
+import GeometryOps as GO
+import GeoInterface as GI
+using GeometryOps.UnitSpherical: UnitSphereFromGeographic, UnitSphericalPoint
+
+# Probe for the cache allocation test.  This has to be a top-level function: measuring
+# `@allocated` directly on testset-local variables boxes them into the keyword `NamedTuple`
+# and charges the algorithm bytes that it never actually allocates.
+_area_bytes(alg, a, b, cache) = @allocated GO.intersection_area(alg, a, b; cache)
+
+function _spherical_polygon(coords)
+    transform = UnitSphereFromGeographic()
+    points = [transform((lon, lat)) for (lon, lat) in coords]
+    push!(points, points[1])
+    return GI.Polygon([points])
+end
+
+square_a = GI.Polygon([[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)]])
+square_b = GI.Polygon([[(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0), (1.0, 1.0)]])
+small = GI.Polygon([[(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5), (0.5, 0.5)]])
+far = GI.Polygon([[(9.0, 9.0), (10.0, 9.0), (10.0, 10.0), (9.0, 10.0), (9.0, 9.0)]])
+edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2.0, 0.0)]])
+
+@testset "intersection_area" begin
+    @testset "Planar - $(nameof(typeof(alg)))" for alg in
+            (GO.ConvexConvexSutherlandHodgman(), GO.OverlayNG())
+        @test GO.intersection_area(alg, square_a, square_b) ≈ 1.0
+        @test GO.intersection_area(alg, square_a, small) ≈ 1.0
+        @test GO.intersection_area(alg, small, square_a) ≈ 1.0
+        @test GO.intersection_area(alg, square_a, square_a) ≈ 4.0
+        @test GO.intersection_area(alg, square_a, far) == 0.0
+        # sharing only an edge is a zero-area intersection
+        @test GO.intersection_area(alg, square_a, edge_neighbour) == 0.0
+        # and it agrees with building the polygon and measuring it
+        for (a, b) in ((square_a, square_b), (square_a, small), (square_a, far))
+            @test GO.intersection_area(alg, a, b) ≈ GO.area(GO.intersection(alg, a, b))
+        end
+    end
+
+    @testset "Planar OverlayNG - non-convex inputs" begin
+        alg = GO.OverlayNG()
+        donut = GI.Polygon([[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)],
+                            [(3.0, 3.0), (3.0, 7.0), (7.0, 7.0), (7.0, 3.0), (3.0, 3.0)]])
+        box = GI.Polygon([[(2.0, 2.0), (8.0, 2.0), (8.0, 8.0), (2.0, 8.0), (2.0, 2.0)]])
+        # a hole survives into the result, and is subtracted
+        @test GO.intersection_area(alg, donut, box) ≈ 20.0
+        @test GO.intersection_area(alg, donut, box) ≈ GO.area(GO.intersection(alg, donut, box))
+
+        # two disconnected result polygons
+        bar = GI.Polygon([[(-1.0, 4.0), (11.0, 4.0), (11.0, 6.0), (-1.0, 6.0), (-1.0, 4.0)]])
+        @test GO.intersection_area(alg, donut, bar) ≈ GO.area(GO.intersection(alg, donut, bar))
+
+        # multipolygon input
+        mp = GI.MultiPolygon([square_a, far])
+        @test GO.intersection_area(alg, mp, square_b) ≈ GO.area(GO.intersection(alg, mp, square_b))
+
+        # anything below dimension 2 has no area
+        line = GI.LineString([(0.0, 0.0), (2.0, 2.0)])
+        @test GO.intersection_area(alg, line, square_a) == 0.0
+        @test GO.intersection_area(alg, GI.Point(1.0, 1.0), square_a) == 0.0
+    end
+
+    @testset "Spherical" begin
+        sh = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+        ov = GO.OverlayNG(GO.Spherical())
+        coords_a = [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]
+        coords_b = [(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0)]
+        coords_small = [(0.5, 0.5), (1.0, 0.5), (1.0, 1.0), (0.5, 1.0)]
+        coords_far = [(50.0, 50.0), (52.0, 50.0), (52.0, 52.0), (50.0, 52.0)]
+
+        for (ca, cb) in ((coords_a, coords_b), (coords_a, coords_small),
+                         (coords_small, coords_a), (coords_a, coords_far))
+            sa, sb = _spherical_polygon(ca), _spherical_polygon(cb)
+            @test GO.intersection_area(sh, sa, sb) ≈
+                GO.area(GO.Spherical(), GO.intersection(sh, sa, sb))
+
+            la, lb = GI.Polygon([push!(collect(ca), first(ca))]), GI.Polygon([push!(collect(cb), first(cb))])
+            @test GO.intersection_area(ov, la, lb) ≈
+                GO.area(GO.Spherical(), GO.intersection(ov, la, lb))
+            # both engines measure the same lune, whichever chart they work in
+            @test GO.intersection_area(sh, sa, sb) ≈ GO.intersection_area(ov, la, lb) rtol=1e-8
+        end
+
+        # the radius of the manifold scales the result
+        sa, sb = _spherical_polygon(coords_a), _spherical_polygon(coords_b)
+        unit = GO.ConvexConvexSutherlandHodgman(GO.Spherical(; radius = 1.0))
+        @test GO.intersection_area(sh, sa, sb) ≈
+            GO.intersection_area(unit, sa, sb) * GO.Spherical().radius^2
+    end
+
+    @testset "Cache" begin
+        planar = GO.ConvexConvexSutherlandHodgman()
+        spherical = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
+        planar_cache = GO.SutherlandHodgmanCache(planar)
+        spherical_cache = GO.SutherlandHodgmanCache(spherical)
+        sa = _spherical_polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)])
+        sb = _spherical_polygon([(1.0, 1.0), (3.0, 1.0), (3.0, 3.0), (1.0, 3.0)])
+
+        @test GO.intersection_area(planar, square_a, square_b; cache = planar_cache) ≈
+            GO.intersection_area(planar, square_a, square_b)
+        @test GO.intersection_area(spherical, sa, sb; cache = spherical_cache) ≈
+            GO.intersection_area(spherical, sa, sb)
+
+        # a reused cache is the whole point: with one, nothing is allocated at all
+        _area_bytes(planar, square_a, square_b, planar_cache)
+        _area_bytes(spherical, sa, sb, spherical_cache)
+        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0
+        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0
+
+        @test_throws ArgumentError GO.intersection_area(planar, square_a, square_b; cache = spherical_cache)
+    end
+end

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -7,6 +7,7 @@ using GeometryOps.UnitSpherical: UnitSphereFromGeographic, UnitSphericalPoint
 # `@allocated` directly on testset-local variables boxes them into the keyword `NamedTuple`
 # and charges the algorithm bytes that it never actually allocates.
 _area_bytes(alg, a, b, cache) = @allocated GO.intersection_area(alg, a, b; cache)
+_area_bytes(alg, a, b) = @allocated GO.intersection_area(alg, a, b)
 
 function _spherical_polygon(coords)
     transform = UnitSphereFromGeographic()
@@ -122,6 +123,37 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
             GO.intersection_area(unit, sa, sb) * GO.Spherical().radius^2
     end
 
+    @testset "Foster-Hormann" begin
+        alg = GO.FosterHormannClipping(GO.Planar())
+        #-- `intersection`'s own `target = nothing` default is broken (`TraitTarget(nothing)`
+        #-- has no method), so the reference call has to name the areal target
+        ref(x, y) = GO.area(GO.intersection(alg, x, y; target = GI.PolygonTrait()))
+
+        # traced without building a ring: hole-free polygon pairs
+        @test GO.intersection_area(alg, square_a, square_b) ≈ 1.0
+        @test GO.intersection_area(alg, square_a, square_b) ≈ ref(square_a, square_b)
+        @test GO.intersection_area(alg, square_a, edge_neighbour) == 0.0
+        # no crossings at all: containment either way round, and disjoint
+        @test GO.intersection_area(alg, square_a, small) ≈ ref(square_a, small)
+        @test GO.intersection_area(alg, small, square_a) ≈ ref(small, square_a)
+        @test GO.intersection_area(alg, square_a, far) == 0.0
+
+        # delegated to the polygon path, and still right
+        donut = GI.Polygon([[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)],
+                            [(3.0, 3.0), (3.0, 7.0), (7.0, 7.0), (7.0, 3.0), (3.0, 3.0)]])
+        box = GI.Polygon([[(2.0, 2.0), (8.0, 2.0), (8.0, 8.0), (2.0, 8.0), (2.0, 2.0)]])
+        @test GO.intersection_area(alg, donut, box) ≈ 20.0
+        @test GO.intersection_area(alg, donut, box) ≈ ref(donut, box)
+        mp = GI.MultiPolygon([square_a, far])
+        @test GO.intersection_area(alg, mp, square_b) ≈ ref(mp, square_b)
+
+        @test GO.intersection_area(alg, square_a, square_b, Float32) isa Float32
+
+        # the tracer is shared with `union`/`difference`: they must be untouched by it
+        @test GO.area(GO.union(alg, square_a, square_b; target = GI.PolygonTrait())) ≈ 7.0
+        @test GO.area(GO.difference(alg, square_a, square_b; target = GI.PolygonTrait())) ≈ 3.0
+    end
+
     @testset "Cache" begin
         planar = GO.ConvexConvexSutherlandHodgman()
         spherical = GO.ConvexConvexSutherlandHodgman(GO.Spherical())
@@ -141,8 +173,8 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         @test _area_bytes(planar, square_a, square_b, planar_cache) == 0
         @test _area_bytes(spherical, sa, sb, spherical_cache) == 0
         # Guard against passing vacuously: without a cache the buffers cost something
-        _area_bytes(planar, square_a, square_b, nothing)
-        @test _area_bytes(planar, square_a, square_b, nothing) > 0
+        _area_bytes(planar, square_a, square_b)
+        @test _area_bytes(planar, square_a, square_b) > 0
 
         @test_throws ArgumentError GO.intersection_area(planar, square_a, square_b; cache = spherical_cache)
     end

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -197,8 +197,8 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         # a reused cache is the whole point: with one, nothing is allocated at all
         _area_bytes(planar, square_a, square_b, planar_cache)
         _area_bytes(spherical, sa, sb, spherical_cache)
-        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0
-        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0
+        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0 skip = VERSION < v"1.12"
+        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0 skip = VERSION < v"1.12"
         # Guard against passing vacuously: without a cache the buffers cost something
         _area_bytes(planar, square_a, square_b)
         @test _area_bytes(planar, square_a, square_b) > 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
 @safetestset "OverlayNG real-data identities" begin include("methods/clipping/overlayng/realdata_identities.jl") end
 @safetestset "OverlayNG spherical vs s2geography" begin include("methods/clipping/overlayng/s2_differential.jl") end
 @safetestset "OverlayNG labeller robustness" begin include("methods/clipping/overlayng/labeller_robustness.jl") end
+@safetestset "Intersection area" begin include("methods/clipping/intersection_area.jl") end
 # Transformations
 @safetestset "Embed Extent" begin include("transformations/extent.jl") end
 @safetestset "Reproject" begin include("transformations/reproject.jl") end


### PR DESCRIPTION
`intersection_area(alg, a, b; cache)` computes `area(manifold(alg), intersection(alg, a, b))` without building the intersection geometry — each engine sums the rings it would otherwise have wrapped in a `Polygon`.

Implemented for all three clipping engines. The supported-algorithm list is closed — there is deliberately no algorithm-free fallback, since a prototype whose point is "without constructing the geometry" shouldn't quietly fall back to constructing it.

| engine | manifolds | how |
|:---|:---|:---|
| `ConvexConvexSutherlandHodgman` | `Planar()`, `Spherical()` | measures the clip buffers in place; with a `cache`, allocation-free |
| `OverlayNG` | `Planar()`, `Spherical()` | ring-area sum in place of polygon assembly |
| `FosterHormannClipping` | `Planar()` | accumulates during the trace, so no ring is materialized |

**Where the code lives.** The public file is only the export, docstring and dispatch; the work sits with each engine:

- `_ring_area` / `_area_scale` in `methods/area.jl`, next to the `_signed_area` and `_naive_triangulated_spherical_ring_area` formulas they have to stay term-for-term equal to — that equality is what makes the two paths agree bitwise, so they are commented as a pair;
- `_sh_clip_planar!` / `_sh_clip_spherical!` in `sutherland_hodgman.jl`;
- `_overlay_intersection_area` beside the driver in `overlay_ng.jl`, `_build_polygon_area` beside `_ring_to_polygon` in `polygon_builder.jl`;
- `_RingCollector` / `_RingMeasurer` in `clipping_processor.jl`.

Supporting refactors, all behaviour-preserving: `_build_polygons` splits into `_build_polygon_ctx` + the polygon wrap; the middle of `_overlay_ng` becomes `_overlay_marked_graph`; a shared `_overlay_input` builds the engine's input model so every entry point derives dimensions and empty flags the same way, and returns the dimensions alongside it (see below); `_trace_polynodes` takes a ring sink instead of always building a point vector.

**Foster-Hormann scope**: the streamed path covers hole-free polygon pairs. Holes and multipolygons are assembled from the traced rings *afterwards* — `_add_holes_to_polys!` cuts holes into result polygons and can split, merge and drop them — and there is no ring-level shortcut through that, so those inputs delegate to the polygon path. Same answer, no speedup.

**Measured**, mean over a loop that consumes the result (BenchmarkTools eliminates the allocation-free call), on the 2x2 square pair from the docstring:

| | time | bytes | allocs |
|---|---|---|---|
| `area ∘ intersection`, SH + cache | 141 ns | 288 | 7 |
| `intersection_area`, SH + cache | 86 ns | 0 | 0 |
| `area ∘ intersection`, FH | 1270 ns | 2848 | 27 |
| `intersection_area`, FH | 978 ns | 2096 | 14 |
| `area ∘ intersection`, OverlayNG | 4358 ns | 15856 | 254 |
| `intersection_area`, OverlayNG | 4103 ns | 15392 | 240 |

OverlayNG gains least — noding dominates, and polygon assembly was never the cost. FH's remaining allocations are the node lists from `_build_ab_list`.

**Behaviour change worth flagging**: the spherical Sutherland-Hodgman containment fallback previously returned a `Polygon` around the clip ring at any length, so a degenerate `< 3`-point clip polygon inside the subject produced an invalid ring. The `length(pts) < 3` guard now covers that path too.

**Tests**: `test/methods/clipping/intersection_area.jl` (78 tests) covers all three engines against `area(intersection(...))`, holes on both manifolds, disconnected results, multipolygons, sub-areal inputs, the lon/lat output chart, `Float32` return types, radius scaling, trait rejection, and the allocation-free cached path. The existing Sutherland-Hodgman suite (85 tests) still passes. Every entry point is `@inferred`-clean.

Fuzzing: 500 random polygon pairs per engine/manifold, plus a sliver-heavy sweep of 2000 pairs whose overlaps are corner slivers with widths from 1e-4 down to 1e-14. `intersection_area` is **bit-identical** to `area(intersection(...))` in every case, and the four-op OverlayNG area identities hold to 4e-16 (planar) / 3e-15 (spherical).

The sliver sweep exists because the first version of this PR was wrong on exactly those inputs, and the random-convex fuzz never generated them: `_ring_area(::Spherical, ...)` trimmed a trailing point that was `≈` the first, but the Sutherland-Hodgman buffers are open rings, so on a sliver whose two end vertices fell inside `isapprox`'s default rtol (~1.5e-8) it ate a real vertex — halving the area, or zeroing it once the remaining fan degenerated. `_ring_area` now takes `closed::Bool = true` to gate the trim, and the Sutherland-Hodgman paths pass `false`; OverlayNG's rings are closed (`ring[1] === ring[end]`) and keep the default. No tolerance can substitute for the flag: the two ends of a sliver are legitimately that close together.

**Three pre-existing bugs found along the way** (neither introduced here, neither fixed here — `intersection.jl` and the FH constructors are untouched):

1. `GO.intersection(a, b)` with no `target` throws `MethodError: no method matching TraitTarget(::Nothing)`. Every call form that omits `target` hits it, including the algorithm-free one. `intersection_area`'s FH fallback names `target = GI.PolygonTrait()` to route around it.
2. `GO.FosterHormannClipping(GO.Spherical())` is an ambiguous constructor call (`clipping_processor.jl:52` vs `:62`), so no spherical FH algorithm can be constructed. The spherical branch of the FH ring measurer is written but consequently unreachable and untested, and marked as such in a comment.
3. `area(::Spherical, geom)` trims its ring's closing point with the same `≈`, and `area` documents that an unclosed curve "is still assumed to be closed", so an unclosed sliver ring gets the same wrong answer through the public function. Not fixed here: it changes a core public function and belongs in its own PR.

**Full suite run.** Every suite this touches was run against `main` on the same machine, same manifest:

| | this branch | `main` |
|:---|:---|:---|
| totals | 13893 pass / 222 fail / 20 error / 8 broken | 13815 pass / 222 fail / 21 error / 8 broken |
| `methods/area.jl` | 135 pass | 135 pass |
| `polygon_clipping.jl` | 6347 pass | 6347 pass |
| `sutherland_hodgman.jl` | 85 pass | 85 pass |
| `intersection_area.jl` | 78 pass | — |
| OverlayNG engine | 765 pass / 4 error | 765 pass / 4 error |
| OverlayNG `xml_suite.jl` | 522 pass / 221 fail / 1 error / 2 broken | identical |
| OverlayNG `fuzz.jl` | 737 pass / 1 fail / 6 error | identical |
| noding, graph, faces, points, API, labeller, identities, s2_differential | unchanged | unchanged |

The delta is exactly +78 (the new tests) and −1 (`main` errors on the file not existing). The 222 failures and 20 errors are all pre-existing on `main` and untouched here — the errors are a `GI.npoint`-over-an-empty-collection `ArgumentError`, the XML-suite failures are the known JTS robust-overlay defects.

**That run caught a real regression in this PR**, since fixed. Reading `input.dim_a` back off `_overlay_input`'s result widened the *untargeted* `intersection` return type from its 7-member `Union` to `Any`: `_OverlayInput` was mutable and escapes into the labeller, so a field load off it is opaque to inference, where `_overlay_dimension(a)` folds to a constant that prunes the union. `@inline` does not rescue it — the escape defeats SROA either way. Fixed properly in 2825c4766 by typing the struct: `a`/`b` became type parameters, the lazy locators became concretely-typed `Ref`s (`IndexedPointInAreaLocator{M,E}` is parameterized only on manifold and exactness, so the `Ref` type is known without building the locator), and the struct became immutable — which both restores the const-fold on a plain field load and makes `locate` a static dispatch in `_input_locate_in_area` (~163ns → ~68ns per call). Those four `Any` fields predate this PR. Only the three inference assertions in "target makes the return type concrete and input-independent" ever failed; no result changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZi2npxCab69YAUv6qYk9a


