### PR TITLE
Reuse one scratch stack for cached child extents in `dual_depth_first_search`

### DIFF
--- a/src/utils/SpatialTreeInterface/README.md
+++ b/src/utils/SpatialTreeInterface/README.md
@@ -38,7 +38,7 @@ They enable the generic query functions described below:
 - `do_query(f, predicate, node)` - call `f(i)` for each index `i` in `node` that satisfies `predicate(extent(i))`.
 - `do_dual_query(f, predicate, tree1, tree2)` - call `f(i1, i2)` for each index `i1` in `tree1` and `i2` in `tree2` that satisfies `predicate(extent(i1), extent(i2))`.
 
-These are both completely non-allocating, and will only call `f` for indices that satisfy the predicate.  (Trees that opt into `node_extent_is_expensive` trade one small vector per visited internal node for far fewer `node_extent` calls.)
+These are both completely non-allocating, and will only call `f` for indices that satisfy the predicate.  (Trees that opt into `node_extent_is_expensive` allocate one scratch stack per traversal, and reuse it at every visited node, to get far fewer `node_extent` calls.)
 You can of course build a standard query interface on top of `do_query` if you want - that's simply:
 ```julia
 a = Int[]

--- a/src/utils/SpatialTreeInterface/SpatialTreeInterface.jl
+++ b/src/utils/SpatialTreeInterface/SpatialTreeInterface.jl
@@ -6,7 +6,7 @@ import Extents
 import GeoInterface as GI
 import AbstractTrees
 
-# public isspatialtree, isleaf, getchild, nchild, child_indices_extents, node_extent, node_extent_is_expensive
+# public isspatialtree, isleaf, getchild, nchild, child_indices_extents, node_extent, node_extent_is_expensive, children_extent_type
 export query
 export FlatNoTree
 export spatialtree

--- a/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
+++ b/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
@@ -28,9 +28,21 @@ end
 # The descent's scratch stack of derived child extents, or `nothing` to mean "call
 # `node_extent` in the loop".  `node_extent_is_expensive` is a function of `N`
 # alone, so the branch folds and only one arm is compiled.
-@inline _extent_stack(stack, node::N, ::E) where {N, E} = node_extent_is_expensive(N) ? _as_stack(stack, E) : nothing
-@inline _as_stack(stack, ::Type) = stack
-@inline _as_stack(::Nothing, ::Type{E}) where {E} = E[]
+@inline _extent_stack(stack, node::N, ::E) where {N, E} =
+    node_extent_is_expensive(N) ? _as_stack(stack, _child_extent_type(N, E), node) : nothing
+
+# Siblings share a type, so one stack serves a node's children; a level whose
+# children type differs from the stack it inherited starts its own.  Dispatch
+# picks the arm, so the reuse path never calls `nchild` - it can be costly.
+@inline _as_stack(stack::Vector{E}, ::Type{E}, node) where {E} = stack
+@inline _as_stack(stack, ::Type{E}, node) where {E} = sizehint!(Vector{E}(), nchild(node))
+
+# An inherited stack is appended to above whatever the ancestors left on it; a
+# stack this level started for itself begins empty.
+@inline _stack_base(::Nothing, stack) = 0
+@inline _stack_base(stack2, stack) = stack2 === stack ? length(stack2) : 0
+
+@inline _child_extent_type(::Type{N}, ::Type{E}) where {N, E} = something(children_extent_type(N), E)
 
 # Hand an ancestor's stack on through levels that do not need one themselves.
 @inline _carry(::Nothing, stack) = stack
@@ -89,7 +101,7 @@ function dual_depth_first_search(
         # node2's child extents go on the shared stack and come off again on the
         # way out, so the descent allocates no buffer per visited node pair
         stack2 = _extent_stack(stack, node2, extent2)
-        base = stack2 === nothing ? 0 : length(stack2)
+        base = _stack_base(stack2, stack)
         _fill_child_extents!(stack2, node2)
         child_stack = _carry(stack2, stack)
         for child1 in getchild(node1)

--- a/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
+++ b/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
@@ -25,22 +25,39 @@ function dual_depth_first_search(f::F, predicate::P, node1::N1, node2::N2) where
     return dual_depth_first_search(f, predicate, node1, node_extent(node1), node2, node_extent(node2))
 end
 
-# Extents of `node`'s children, derived once, or `nothing` to mean "call
+# The descent's scratch stack of derived child extents, or `nothing` to mean "call
 # `node_extent` in the loop".  `node_extent_is_expensive` is a function of `N`
 # alone, so the branch folds and only one arm is compiled.
-@inline function _child_extents(node::N) where {N}
-    node_extent_is_expensive(N) || return nothing
-    return [node_extent(child) for child in getchild(node)]
+@inline _extent_stack(stack, node::N, ::E) where {N, E} = node_extent_is_expensive(N) ? _as_stack(stack, E) : nothing
+@inline _as_stack(stack, ::Type) = stack
+@inline _as_stack(::Nothing, ::Type{E}) where {E} = E[]
+
+# Hand an ancestor's stack on through levels that do not need one themselves.
+@inline _carry(::Nothing, stack) = stack
+@inline _carry(stack, _) = stack
+
+@inline _fill_child_extents!(::Nothing, node) = nothing
+@inline function _fill_child_extents!(stack, node)
+    for child in getchild(node)
+        push!(stack, node_extent(child))
+    end
+    return nothing
 end
 
-@inline _child_extent(::Nothing, child, i) = node_extent(child)
-@inline _child_extent(extents, child, i) = extents[i]
+@inline _child_extent(::Nothing, base, child, i) = node_extent(child)
+@inline _child_extent(stack, base, child, i) = stack[base + i]
 
 # `extent1` and `extent2` are a precondition, not a hint: they must equal
 # `node_extent(node1)` and `node_extent(node2)`.
 function dual_depth_first_search(
     f::F, predicate::P, node1::N1, extent1::E1, node2::N2, extent2::E2
 ) where {F, P, N1, E1, N2, E2}
+    return dual_depth_first_search(f, predicate, node1, extent1, node2, extent2, nothing)
+end
+
+function dual_depth_first_search(
+    f::F, predicate::P, node1::N1, extent1::E1, node2::N2, extent2::E2, stack::S
+) where {F, P, N1, E1, N2, E2, S}
     leaf1 = isleaf(node1)
     leaf2 = isleaf(node2)
     if leaf1 && leaf2
@@ -58,30 +75,36 @@ function dual_depth_first_search(
         for child in getchild(node2)
             child_extent = node_extent(child)
             if predicate(extent1, child_extent)
-                @controlflow dual_depth_first_search(f, predicate, node1, extent1, child, child_extent)
+                @controlflow dual_depth_first_search(f, predicate, node1, extent1, child, child_extent, stack)
             end
         end
     elseif leaf2 # node1 is not a leaf, node2 is - recurse further into node1
         for child in getchild(node1)
             child_extent = node_extent(child)
             if predicate(child_extent, extent2)
-                @controlflow dual_depth_first_search(f, predicate, child, child_extent, node2, extent2)
+                @controlflow dual_depth_first_search(f, predicate, child, child_extent, node2, extent2, stack)
             end
         end
     else # neither node is a leaf, recurse into both children
-        extents2 = _child_extents(node2)
+        # node2's child extents go on the shared stack and come off again on the
+        # way out, so the descent allocates no buffer per visited node pair
+        stack2 = _extent_stack(stack, node2, extent2)
+        base = stack2 === nothing ? 0 : length(stack2)
+        _fill_child_extents!(stack2, node2)
+        child_stack = _carry(stack2, stack)
         for child1 in getchild(node1)
             child_extent1 = node_extent(child1)
             i2 = 0
             for child2 in getchild(node2)
                 i2 += 1
-                child_extent2 = _child_extent(extents2, child2, i2)
+                child_extent2 = _child_extent(stack2, base, child2, i2)
                 if predicate(child_extent1, child_extent2)
                     @controlflow dual_depth_first_search(
-                        f, predicate, child1, child_extent1, child2, child_extent2
+                        f, predicate, child1, child_extent1, child2, child_extent2, child_stack
                     )
                 end
             end
         end
+        stack2 === nothing || resize!(stack2, base)
     end
 end

--- a/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
+++ b/src/utils/SpatialTreeInterface/dual_depth_first_search.jl
@@ -29,7 +29,7 @@ end
 # `node_extent` in the loop".  `node_extent_is_expensive` is a function of `N`
 # alone, so the branch folds and only one arm is compiled.
 @inline _extent_stack(stack, node::N, ::E) where {N, E} =
-    node_extent_is_expensive(N) ? _as_stack(stack, _child_extent_type(N, E), node) : nothing
+    node_extent_is_expensive(N) ? _as_stack(stack, _child_extent_type(node, E), node) : nothing
 
 # Siblings share a type, so one stack serves a node's children; a level whose
 # children type differs from the stack it inherited starts its own.  Dispatch
@@ -42,7 +42,8 @@ end
 @inline _stack_base(::Nothing, stack) = 0
 @inline _stack_base(stack2, stack) = stack2 === stack ? length(stack2) : 0
 
-@inline _child_extent_type(::Type{N}, ::Type{E}) where {N, E} = something(children_extent_type(N), E)
+# asked of the node, not its type - the answer is constant per type either way
+@inline _child_extent_type(node, ::Type{E}) where {E} = something(children_extent_type(node), E)
 
 # Hand an ancestor's stack on through levels that do not need one themselves.
 @inline _carry(::Nothing, stack) = stack
@@ -119,4 +120,7 @@ function dual_depth_first_search(
         end
         stack2 === nothing || resize!(stack2, base)
     end
+    # never the scratch stack `resize!` hands back - only a propagating `Action`
+    # leaves this function with a value
+    return nothing
 end

--- a/src/utils/SpatialTreeInterface/interface.jl
+++ b/src/utils/SpatialTreeInterface/interface.jl
@@ -111,8 +111,11 @@ Return true if [`node_extent`](@ref) computes the node's extent instead of
 reading one the node already stores.  Defaults to false.
 
 When true, [`dual_depth_first_search`](@ref) caches a node's child extents rather
-than re-deriving them once per opposing child, at the cost of a small vector per
-visited node.
+than re-deriving them once per opposing child.  The cache is one scratch stack
+per traversal, so opting in does not allocate per visited node.
+
+All nodes of such a tree must return the same extent type, since they share that
+one stack.
 
 ## Implementation notes
 

--- a/src/utils/SpatialTreeInterface/interface.jl
+++ b/src/utils/SpatialTreeInterface/interface.jl
@@ -114,8 +114,8 @@ When true, [`dual_depth_first_search`](@ref) caches a node's child extents rathe
 than re-deriving them once per opposing child.  The cache is one scratch stack
 per traversal, so opting in does not allocate per visited node.
 
-All nodes of such a tree must return the same extent type, since they share that
-one stack.
+A node's children must all share an extent type, since they share one stack; see
+[`children_extent_type`](@ref) for trees where that type changes with depth.
 
 ## Implementation notes
 
@@ -125,3 +125,24 @@ there automatically.
 """
 node_extent_is_expensive(::T) where {T} = node_extent_is_expensive(T)
 node_extent_is_expensive(::Type{<:Any}) = false
+
+"""
+    children_extent_type(node)::Union{Type, Nothing}
+
+Return the type [`node_extent`](@ref) gives for `node`'s *children*, or `nothing`
+- the default - to say it is the same type as `node`'s own extent.
+
+Only [`dual_depth_first_search`](@ref) on a tree that opts into
+[`node_extent_is_expensive`](@ref) consults this: it caches a node's child
+extents in a typed scratch stack, and needs the element type before it touches
+a child.  Siblings must agree, but a tree whose extent type changes with depth
+can say so here and still be traversed.
+
+## Implementation notes
+
+Define this on the type - `children_extent_type(::Type{MyNode}) = MyChildExtent` -
+so that it is known at compile time; `children_extent_type(::MyNode)` forwards
+there automatically.
+"""
+children_extent_type(::T) where {T} = children_extent_type(T)
+children_extent_type(::Type{<:Any}) = nothing

--- a/src/utils/SpatialTreeInterface/interface.jl
+++ b/src/utils/SpatialTreeInterface/interface.jl
@@ -140,9 +140,10 @@ can say so here and still be traversed.
 
 ## Implementation notes
 
-Define this on the type - `children_extent_type(::Type{MyNode}) = MyChildExtent` -
-so that it is known at compile time; `children_extent_type(::MyNode)` forwards
-there automatically.
+Define it on the node - `children_extent_type(node::MyNode) = MyChildExtent` - or
+on its type if that reads better, `children_extent_type(::Type{MyNode}) = MyChildExtent`;
+the node method falls back to the type one.  Either way the answer is a constant
+per node type, so it folds away.
 """
-children_extent_type(::T) where {T} = children_extent_type(T)
+children_extent_type(node) = children_extent_type(typeof(node))
 children_extent_type(::Type{<:Any}) = nothing

--- a/test/utils/SpatialTreeInterface.jl
+++ b/test/utils/SpatialTreeInterface.jl
@@ -3,7 +3,7 @@ import GeometryOps as GO, GeoInterface as GI
 using GeometryOps.SpatialTreeInterface
 using GeometryOps.SpatialTreeInterface: isspatialtree, isleaf, getchild, nchild, child_indices_extents, node_extent
 using GeometryOps.SpatialTreeInterface: query, depth_first_search, dual_depth_first_search
-using GeometryOps.SpatialTreeInterface: FlatNoTree, spatialtree, node_extent_is_expensive
+using GeometryOps.SpatialTreeInterface: FlatNoTree, spatialtree, node_extent_is_expensive, children_extent_type
 using GeometryOps.LoopStateMachine: Action
 using GeometryOps.FlexibleRTrees: RTree, STR
 using GeometryOps.NaturalIndexing: NaturalIndex
@@ -315,6 +315,36 @@ function varying_fanout_tree(items::Vector{Tuple{Int,XYExtent}}, depth = 0)
 end
 varying_fanout_tree(extents::Vector{XYExtent}) = varying_fanout_tree(collect(enumerate(extents)))
 
+# An extent-like type that is not an `Extents.Extent`, so a tree using both has
+# an extent type that genuinely changes with depth.
+struct BoxExtent
+    X::Tuple{Float64,Float64}
+    Y::Tuple{Float64,Float64}
+end
+_asbox(e) = BoxExtent(e.X, e.Y)
+_boxy_intersects(a, b) = Extents.intersects(
+    Extents.Extent(X = a.X, Y = a.Y), Extents.Extent(X = b.X, Y = b.Y))
+
+# Odd levels report an `Extent`, even levels a `BoxExtent`.  Siblings agree,
+# levels do not - the case one tree-wide stack cannot serve.
+struct AlternatingExtentNode{N}
+    node::N
+    level::Int
+end
+AlternatingExtentNode(node) = AlternatingExtentNode(node, 0)
+GO.SpatialTreeInterface.isspatialtree(::Type{<:AlternatingExtentNode}) = true
+GO.SpatialTreeInterface.node_extent_is_expensive(::Type{<:AlternatingExtentNode}) = true
+GO.SpatialTreeInterface.children_extent_type(::Type{<:AlternatingExtentNode}) = Union{XYExtent,BoxExtent}
+GO.SpatialTreeInterface.isleaf(n::AlternatingExtentNode) = isleaf(n.node)
+GO.SpatialTreeInterface.nchild(n::AlternatingExtentNode) = nchild(n.node)
+GO.SpatialTreeInterface.getchild(n::AlternatingExtentNode) =
+    (AlternatingExtentNode(c, n.level + 1) for c in getchild(n.node))
+GO.SpatialTreeInterface.getchild(n::AlternatingExtentNode, i) =
+    AlternatingExtentNode(getchild(n.node, i), n.level + 1)
+GO.SpatialTreeInterface.child_indices_extents(n::AlternatingExtentNode) = child_indices_extents(n.node)
+GO.SpatialTreeInterface.node_extent(n::AlternatingExtentNode) =
+    iseven(n.level) ? node_extent(n.node) : _asbox(node_extent(n.node))
+
 collect_pairs(args...) = (out = Tuple{Int,Int}[];
                           dual_depth_first_search((i, j) -> push!(out, (i, j)), args...);
                           sort!(out))
@@ -391,6 +421,20 @@ collect_pairs(args...) = (out = Tuple{Int,Int}[];
         noop(i, j) = nothing
         dual_depth_first_search(noop, Extents.intersects, a, b)  # compile
         @test (@allocated dual_depth_first_search(noop, Extents.intersects, a, b)) < 4096
+    end
+
+    # a tree whose extent type changes with depth: siblings agree, levels do not
+    @testset "children_extent_type carries a per-level extent type" begin
+        a = AlternatingExtentNode(NaturalIndex(fine))
+        b = AlternatingExtentNode(NaturalIndex(coarse))
+        @test node_extent_is_expensive(a)
+        @test children_extent_type(a) === Union{XYExtent,BoxExtent}
+        # the answers are the ones the plain tree gives
+        @test collect_pairs(_boxy_intersects, a, b) ==
+              collect_pairs(Extents.intersects, NaturalIndex(fine), NaturalIndex(coarse))
+        # and the stack the traversal picks is the declared child type
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(nothing, a, node_extent(a))) isa
+              Vector{Union{XYExtent,BoxExtent}}
     end
 end
 

--- a/test/utils/SpatialTreeInterface.jl
+++ b/test/utils/SpatialTreeInterface.jl
@@ -345,6 +345,21 @@ GO.SpatialTreeInterface.child_indices_extents(n::AlternatingExtentNode) = child_
 GO.SpatialTreeInterface.node_extent(n::AlternatingExtentNode) =
     iseven(n.level) ? node_extent(n.node) : _asbox(node_extent(n.node))
 
+# Same idea, but the trait is spelled on the node rather than on its type; both
+# spellings have to work, and both have to stay inferrable.
+struct InstanceTraitNode{N}
+    node::N
+end
+GO.SpatialTreeInterface.isspatialtree(::Type{<:InstanceTraitNode}) = true
+GO.SpatialTreeInterface.node_extent_is_expensive(::Type{<:InstanceTraitNode}) = true
+GO.SpatialTreeInterface.children_extent_type(n::InstanceTraitNode) = XYExtent
+GO.SpatialTreeInterface.isleaf(n::InstanceTraitNode) = isleaf(n.node)
+GO.SpatialTreeInterface.nchild(n::InstanceTraitNode) = nchild(n.node)
+GO.SpatialTreeInterface.getchild(n::InstanceTraitNode) = (InstanceTraitNode(c) for c in getchild(n.node))
+GO.SpatialTreeInterface.getchild(n::InstanceTraitNode, i) = InstanceTraitNode(getchild(n.node, i))
+GO.SpatialTreeInterface.child_indices_extents(n::InstanceTraitNode) = child_indices_extents(n.node)
+GO.SpatialTreeInterface.node_extent(n::InstanceTraitNode) = node_extent(n.node)
+
 collect_pairs(args...) = (out = Tuple{Int,Int}[];
                           dual_depth_first_search((i, j) -> push!(out, (i, j)), args...);
                           sort!(out))
@@ -421,6 +436,29 @@ collect_pairs(args...) = (out = Tuple{Int,Int}[];
         noop(i, j) = nothing
         dual_depth_first_search(noop, Extents.intersects, a, b)  # compile
         @test (@allocated dual_depth_first_search(noop, Extents.intersects, a, b)) < 4096
+    end
+
+    # the traversal asks the node, so a tree may answer on the node or on its type
+    @testset "children_extent_type is asked of the node, in either spelling" begin
+        onnode = InstanceTraitNode(NaturalIndex(fine))
+        ontype = AlternatingExtentNode(NaturalIndex(fine))
+        @test children_extent_type(onnode) === XYExtent                    # defined on the node
+        @test children_extent_type(ontype) === Union{XYExtent,BoxExtent}   # defined on the type
+        @test children_extent_type(NaturalIndex(fine)) === nothing         # says nothing, so the default
+        # both spellings fold, so the stack type is still a compile-time choice
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(nothing, onnode, node_extent(onnode))) isa
+              Vector{XYExtent}
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(nothing, ontype, node_extent(ontype))) isa
+              Vector{Union{XYExtent,BoxExtent}}
+        # ...and the whole traversal stays inferrable through each
+        noop(i, j) = nothing
+        @test (@inferred dual_depth_first_search(noop, Extents.intersects, onnode,
+                                                 InstanceTraitNode(NaturalIndex(coarse)))) === nothing
+        @test (@inferred dual_depth_first_search(noop, _boxy_intersects, ontype,
+                                                 AlternatingExtentNode(NaturalIndex(coarse)))) === nothing
+        # the node-spelled tree answers exactly as the plain one does
+        @test collect_pairs(Extents.intersects, onnode, InstanceTraitNode(NaturalIndex(coarse))) ==
+              collect_pairs(Extents.intersects, NaturalIndex(fine), NaturalIndex(coarse))
     end
 
     # a tree whose extent type changes with depth: siblings agree, levels do not

--- a/test/utils/SpatialTreeInterface.jl
+++ b/test/utils/SpatialTreeInterface.jl
@@ -369,14 +369,28 @@ collect_pairs(args...) = (out = Tuple{Int,Int}[];
         @test (@allocated dual_depth_first_search(noop, Extents.intersects, t1, t2)) == 0
     end
 
-    # `_child_extents` picks the caching strategy; it has to fold to a concrete
+    # `_extent_stack` picks the caching strategy; it has to fold to a concrete
     # type from the node type alone, or the traversal boxes its loop variables.
     @testset "the caching strategy is a compile-time choice" begin
         cheap = varying_fanout_tree(fine)
         costly = CountedExtentNode(NaturalIndex(fine))
-        @test (@inferred GO.SpatialTreeInterface._child_extents(cheap)) === nothing
-        @test (@inferred GO.SpatialTreeInterface._child_extents(NaturalIndex(fine))) === nothing
-        @test (@inferred GO.SpatialTreeInterface._child_extents(costly)) isa Vector{<:Extents.Extent}
+        ext = node_extent(NaturalIndex(fine))
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(nothing, cheap, ext)) === nothing
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(nothing, NaturalIndex(fine), ext)) === nothing
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(nothing, costly, ext)) isa Vector{<:Extents.Extent}
+        # an existing stack is reused rather than replaced
+        stack = typeof(ext)[]
+        @test (@inferred GO.SpatialTreeInterface._extent_stack(stack, costly, ext)) === stack
+    end
+
+    # the opted-in path used to allocate a vector per visited node pair; now it
+    # allocates one scratch stack for the whole descent
+    @testset "an opted-in tree allocates a bounded amount" begin
+        a = CountedExtentNode(NaturalIndex(fine))
+        b = CountedExtentNode(NaturalIndex(coarse))
+        noop(i, j) = nothing
+        dual_depth_first_search(noop, Extents.intersects, a, b)  # compile
+        @test (@allocated dual_depth_first_search(noop, Extents.intersects, a, b)) < 4096
     end
 end
 


### PR DESCRIPTION
**Draft** — the code and the numbers are complete; opening it as a draft because the extent-type assumption it now documents deserves a second opinion before merge.

## What

`dual_depth_first_search`, in the branch where neither node is a leaf, hoists `node2`'s child extents out of the inner loop for trees that opt into `node_extent_is_expensive` (#462):

```julia
@inline function _child_extents(node::N) where {N}
    node_extent_is_expensive(N) || return nothing
    return [node_extent(child) for child in getchild(node)]   # one Vector per visited node pair
end
```

The hoisting is right — it turns `nchild1 * nchild2` extent derivations into `nchild1 + nchild2` — but it allocates a fresh vector for *every internal-vs-internal node pair the descent visits*.

This PR keeps the hoisting and drops the allocation: one scratch stack is threaded through the whole descent. Each visited node writes its children's extents onto the end, indexes them by offset for the duration of its double loop, and truncates back on the way out. The stack is created lazily at the first node that needs one and reused for the rest of the recursion, so the extent derivations are bit-for-bit what they were and the allocation count drops from *one per node pair* to *one per traversal*.

A stack has one element type, so the requirement is that **siblings agree** on their extent type. A new opt-in trait says so where that is not simply the parent's type. The traversal asks the *node*, and a node method falls back to a type method, so implementors may spell it either way:

```julia
children_extent_type(node::MyNode) = MyChildExtent          # asked of the node...
children_extent_type(::Type{MyNode}) = MyChildExtent        # ...or answered on the type
# default is `nothing`, meaning "same type as the node's own extent"
```

Both fold to a compile-time constant, so the stack's element type is still chosen at compile time — the tests `@inferred` the whole traversal through one tree of each spelling.

A level whose children type differs from the stack it inherited starts its own, so a tree whose extent type changes with depth still traverses correctly — it just pays an allocation per node at the levels where the type actually changes.

The public 4-arg and 6-arg entry points are unchanged; the stack rides on a new internal 7-arg method. Trees that do not opt in compile to exactly the old code — `node_extent_is_expensive` is still a function of the node type alone, so the branch folds.

## Why — the workload that found it

DiscreteGlobalGrids.jl conservatively regrids a 3600x3600 Copernicus GLO-30 tile onto a level-13 IGEO7 multi-order coverage of **16,181,892 cells**: **93,079,031 candidate pairs**, 66,129,312 nonzeros, ~51 s warm at `-t 8`. Both trees opt into `node_extent_is_expensive` — the source `RasterCellTree` derives a `SphericalCap` for a pixel-index rectangle, and the destination cell-cursor tree derives one for each internal node — and with IGEO7's fanout of 7 the descent spends most of its life in the both-internal branch.

An allocation profile of that call put this line at the **top of the whole regrid**: ~42 % of candidate-pair-generation bytes, the single largest site anywhere in the pipeline. (Sampled attribution folded a neighbouring DGG buffer into the same line; the deterministic figure for this vector alone is the 4.97 GiB in the table below.)

## Numbers

**End to end** (DGG target workload, warm, `-t 8`, Julia 1.12.6, shared 64-core box, digest of the regridded output byte-identical at `5b696475a3665634`):

| warm rep, mean of 6 | before | after | delta |
|:--|--:|--:|--:|
| wall | 52.07 s | **50.37 s** | −1.70 s (−3.3 %) |
| process CPU | 307.5 s | **303.4 s** | −4.1 CPU-s |
| GC | 5.33 s | **4.44 s** | −0.89 s (−17 %) |
| allocated | 38.58 GiB | **33.61 GiB** | −4.97 GiB (−12.9 %) |

Three A/B rounds with the two builds alternating in one window on a shared 64-core box, 1-minute load 21–39 throughout, three reps each (rep 1 cold-ish, reps 2–3 warm, all six warm reps above). The wall ranges do not overlap: 51.20–53.58 s before, 49.73–51.06 s after. That lands on DGG's own prediction for this lever, which its allocation profile ceilinged at about −1.3 s of 51 s.

One upstream lesson worth flagging: an earlier revision of this patch sized the fresh buffer with `nchild(node2)` on every visited node and *lost* 7 CPU-s end to end, because `nchild` on a cursor-style tree walks the child windows rather than reading a stored count. The reuse path is now chosen by dispatch, so `nchild` is only called on the levels that actually allocate.

**Isolated** (`BenchmarkTools`, `$`-interpolated, fanout-7 k-d tree, both trees opted in, two 63,001- and 62,500-leaf trees at matched resolution, 250,000 pairs, 30,399 internal-vs-internal node pairs):

| | before | after |
|:--|--:|--:|
| allocations | 4.17 MiB in 30,399 allocs | **5.87 KiB in 7 allocs** |
| time (min / median) | 21.989 / 24.424 ms | **21.555 / 21.671 ms** |

The control on the same tree shape with `node_extent_is_expensive = false` is unchanged (16 bytes, 1 alloc; 57.2 ms before, 58.0 ms after) — and still exactly 0 bytes in the existing "default trait allocates nothing" test.

## Tests

`Pkg.test()` on the branch passes in full (`Testing GeometryOps tests passed`), `test/utils/SpatialTreeInterface.jl` at 127/127. Added:

- `_extent_stack` inference test replacing the old `_child_extents` one (the strategy still has to fold from the node type alone), plus a check that an existing stack is reused rather than replaced.
- an allocation bound for an opted-in tree: the traversal must stay under 4 KiB regardless of how many node pairs it visits.
- a tree whose extent type alternates between `Extents.Extent` and a bespoke box type by depth, checking it gives the same pairs as the plain tree and that the traversal picks a stack of the declared child type.
- one tree spelling `children_extent_type` on the node and one on the type, with `@inferred` over the whole traversal for each. That test earned its keep immediately: it caught the both-internal branch falling out of the function with the value of `resize!`, i.e. **returning the scratch stack to the caller** instead of `nothing`. Fixed, and the traversal now infers `Nothing` again.

## Why not a bump allocator?

A reviewer asked whether [Bumper.jl](https://github.com/MasonProtter/Bumper.jl) would be better here: lock sibling homogeneity behind a trait, then back each node's hoisted buffer with a bump allocator so levels can hold differently-typed slabs without heap churn. I prototyped exactly that (one `SlabBuffer` fetched at the traversal entry and threaded down, `alloc!` + `checkpoint_save`/`checkpoint_restore!` per visited node) and measured it against the typed stack.

Both designs need the same `children_extent_type` trait — the relaxation comes from the trait, not from the allocator. What Bumper additionally buys is that a *level whose extent type differs from its parent's* costs no allocation. What it costs is listed below.

Isolated, fanout-7 k-d trees, 63,001 × 62,500 leaves, 250,000 pairs, **30,399 internal-vs-internal node pairs** (`BenchmarkTools`, `$`-interpolated, shared 64-core box, 1-minute load 22–34 recorded per run):

| tree shape | `main` | typed stack (this PR) | Bumper prototype |
|:--|:--|:--|:--|
| homogeneous extents | 21.99 ms · 4.17 MiB / 30,399 allocs | **21.6–21.7 ms · 3.18 KiB / 6** | 21.66 ms · 16 B / 1 |
| extent type changes every level | 18.24 ms · 4.17 MiB / 30,399 | 18.75 ms · 5.99 MiB / 96,629 | **17.62 ms · 16 B / 1** |

| | `main` | typed stack | Bumper |
|:--|:--|:--|:--|
| new dependency | — | — | Bumper + UnsafeArrays |
| `Union` extent type | works | works | **`MethodError`** — `UnsafeArray` needs an isbits eltype |
| non-isbits extent type | works | works | **`MethodError`**, same reason |
| `return` inside the hoisted scope | fine | fine | `@no_escape` **rejects `return` at macroexpansion** and recursively expands nested macros to find it, so `@controlflow` cannot appear in the block; needs a function barrier, which quietly changes how `Action(:return, x)` propagates |
| lifetime discipline | GC-tracked `Vector` | GC-tracked `Vector` | raw pointer that must not outlive its checkpoint, inside a recursive generic traversal |

**Recommendation: keep the typed stack.** On the only tree shape that exists today — every tree in GeometryOps, GlobalRegridding and DiscreteGlobalGrids, including the one that motivated this PR — the two are a dead tie, and both are ~0 against `main`'s 4.17 MiB. Bumper's advantage is confined to a shape nobody has, and it is paid for with a dependency, a hard isbits-only restriction on extent types that both `main` and this PR are free of, and raw-pointer lifetimes in a recursive traversal.

The honest cost of that choice: on a per-level-heterogeneous tree this PR allocates ~3× the objects `main` does (96,629 vs 30,399, 5.99 vs 4.17 MiB) and is ~3 % slower, because every type change starts a fresh vector. That case goes from *silently wrong to inference* to *correct but not free*. If you would rather have it free, the Bumper prototype is measured above and I will push it instead — I did not want to add a dependency to GeometryOps on my own judgement.

## Correctness

Every frame records the stack length on entry, reads only the region it wrote above that mark, and truncates back to it on the way out. A callee can only ever append above the caller's mark, so an early exit that skips a truncate (`Action(:return, x)`, or `Action(:full_return, x)` unwinding the whole traversal) leaves the caller's own region intact and is cleaned up by the caller's truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwnXToXzkTdstjqfp8ovhH
