### PR TITLE
Strip the discarded work out of two spherical predicates (`spherical_orient`, `SphericalCap` overlap)

### DIFF
--- a/src/utils/UnitSpherical/UnitSpherical.jl
+++ b/src/utils/UnitSpherical/UnitSpherical.jl
@@ -13,7 +13,7 @@ include("point.jl")
 
 include("robustcrossproduct/RobustCrossProduct.jl")
 # Re-export from RobustCrossProduct
-using .RobustCrossProduct: robust_cross_product
+using .RobustCrossProduct: robust_cross_product, min_stable_norm
 export robust_cross_product
 
 include("coordinate_transforms.jl")

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -103,35 +103,31 @@ const _CAP_CHORD_GUARD = 2.0^-40
 # This is all inexact and thus subject to floating point error
 #=
 Two caps intersect iff the angle `d` between their centers is at most the sum
-`r` of their radii.  Computing `d` costs a `spherical_distance` — a cross
-product, a `sqrt` and an `atan2` — but the *squared chord* between the centers,
-`c² = ‖p - q‖²`, is 3 subtractions and 3 multiplications, and it brackets `d`
+`r` of their radii.  We can shortcut by computing the *squared chord* between the centers,
+`c² = ‖p - q‖²`, which is 3 subtractions and 3 multiplications. It brackets `d`
 tightly enough to settle almost every pair without ever forming `d`:
 
     c  ≤  d = 2 asin(c/2)  ≤  c * (1 + c²/20)        for 0 ≤ c ≤ 1
 
 (the lower bound is `asin(x) ≥ x`; for the upper, `2 asin(c/2) - c` has the
 series `c³/24 + 3c⁵/640 + 15c⁷/21504 + …`, which stays under `c³/20` on `c ≤ 1`
-— verified in BigFloat, minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at
-`c = 1`).  Squaring both sides keeps it `sqrt`-free.  Only pairs that land
-inside the resulting band pay for `spherical_distance`, and there the original
-test runs unchanged.
+, minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at `c = 1`).
+Squaring both sides keeps it `sqrt`-free.
 
-`c ≤ 1` is `d ≤ 60°`; wider pairs skip the accept bound but still get the
-reject one, and `r ≥ π` accepts outright since no two points are further
-than `π` apart.
+This acts as an adaptive filter, similar to how the predicates work.
+Anything which is sufficiently far away gets caught by this, closer things
+go to the old comparison for accuracy.
 
-Every comparison is written so that a NaN radius (the whole-sphere cap that
-`minimum_bounding_circle` returns for empty input) fails it and falls through
-to the original test, which is what `NaN` did before.  Same for negative radii.
+The accept bound requires `c ≤ 1` (`d ≤ 60°`), but the reject bound does not.
+Since no two points are more than `π` apart, `r ≥ π` accepts immediately.
+NaN radii (used for empty-input whole-sphere caps) and negative radii fail the
+filter comparisons and reach the original test, preserving its semantics.
 
-Where this and the old test disagree, the old test is the one that is wrong:
-`spherical_distance`'s `cross(p, q)` cancels catastrophically for nearly equal
-`p, q`, giving `d` a relative error of order `eps/d`, while the chord is
-computed accurately there.  Adjudicated against 256-bit arithmetic over 600k
-pairs whose centers are 1e-12..1 rad apart with `r` within 2 ULP of the true
-distance: 111,514 disagreements, of which the old test got 111,514 wrong and
-this one got 0 wrong.
+For nearly equal centers, `spherical_distance` suffers catastrophic cancellation
+in `cross(p, q)` and relative error of order `eps/d`; the chord remains accurate.
+Against 256-bit arithmetic on 600k pairs 1e-12..1 rad apart, with `r` within
+2 ULP of the true distance, all 111,514 disagreements were old-test errors;
+the chord test had none.
 
 Assumes unit-length centers, as the rest of the cap API does.
 =#

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -94,10 +94,63 @@ end
 
 # TODO: this returns an approximately antipodal point...
 
+# The margin by which the cheap bounds in `_intersects` must clear the decision
+# before they are trusted: comfortably above the rounding of a squared chord
+# (~4 eps relative) and comfortably below any distance anyone cares about.
+const _CAP_CHORD_GUARD = 2.0^-40
+
 # TODO: exact-predicate intersection
 # This is all inexact and thus subject to floating point error
+#=
+Two caps intersect iff the angle `d` between their centers is at most the sum
+`r` of their radii.  Computing `d` costs a `spherical_distance` — a cross
+product, a `sqrt` and an `atan2` — but the *squared chord* between the centers,
+`c² = ‖p - q‖²`, is 3 subtractions and 3 multiplications, and it brackets `d`
+tightly enough to settle almost every pair without ever forming `d`:
+
+    c  ≤  d = 2 asin(c/2)  ≤  c * (1 + c²/20)        for 0 ≤ c ≤ 1
+
+(the lower bound is `asin(x) ≥ x`; for the upper, `2 asin(c/2) - c` has the
+series `c³/24 + 3c⁵/640 + 15c⁷/21504 + …`, which stays under `c³/20` on `c ≤ 1`
+— verified in BigFloat, minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at
+`c = 1`).  Squaring both sides keeps it `sqrt`-free.  Only pairs that land
+inside the resulting band pay for `spherical_distance`, and there the original
+test runs unchanged.
+
+`c ≤ 1` is `d ≤ 60°`; wider pairs skip the accept bound but still get the
+reject one, and `r ≥ π` accepts outright since no two points are further
+than `π` apart.
+
+Every comparison is written so that a NaN radius (the whole-sphere cap that
+`minimum_bounding_circle` returns for empty input) fails it and falls through
+to the original test, which is what `NaN` did before.  Same for negative radii.
+
+Where this and the old test disagree, the old test is the one that is wrong:
+`spherical_distance`'s `cross(p, q)` cancels catastrophically for nearly equal
+`p, q`, giving `d` a relative error of order `eps/d`, while the chord is
+computed accurately there.  Adjudicated against 256-bit arithmetic over 600k
+pairs whose centers are 1e-12..1 rad apart with `r` within 2 ULP of the true
+distance: 111,514 disagreements, of which the old test got 111,514 wrong and
+this one got 0 wrong.
+
+Assumes unit-length centers, as the rest of the cap API does.
+=#
 function _intersects(x::SphericalCap, y::SphericalCap)
-    spherical_distance(x.point, y.point) <= x.radius + y.radius
+    r = x.radius + y.radius
+    p, q = x.point, y.point
+    dx = p[1] - q[1]
+    dy = p[2] - q[2]
+    dz = p[3] - q[3]
+    c² = dx * dx + dy * dy + dz * dz
+    if r >= 0                       # false for NaN, and for negative radii
+        r >= oftype(r, π) && return true  # no two points on the sphere are further apart
+        r² = r * r
+        g = _CAP_CHORD_GUARD
+        c² > r² * (1 + g) && return false            # d ≥ c > r
+        b = 1 + 0.05 * c²   # 0.05 rounds up from 1/20, so `b` stays an upper bound
+        c² <= 1 && c² * b * b <= r² * (1 - g) && return true   # d ≤ c(1 + c²/20) ≤ r
+    end
+    return spherical_distance(p, q) <= r
 end
 
 _disjoint(x::SphericalCap, y::SphericalCap) = !_intersects(x, y)

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -103,31 +103,35 @@ const _CAP_CHORD_GUARD = 2.0^-40
 # This is all inexact and thus subject to floating point error
 #=
 Two caps intersect iff the angle `d` between their centers is at most the sum
-`r` of their radii.  We can shortcut by computing the *squared chord* between the centers,
-`c² = ‖p - q‖²`, which is 3 subtractions and 3 multiplications. It brackets `d`
+`r` of their radii.  Computing `d` costs a `spherical_distance` — a cross
+product, a `sqrt` and an `atan2` — but the *squared chord* between the centers,
+`c² = ‖p - q‖²`, is 3 subtractions and 3 multiplications, and it brackets `d`
 tightly enough to settle almost every pair without ever forming `d`:
 
     c  ≤  d = 2 asin(c/2)  ≤  c * (1 + c²/20)        for 0 ≤ c ≤ 1
 
 (the lower bound is `asin(x) ≥ x`; for the upper, `2 asin(c/2) - c` has the
 series `c³/24 + 3c⁵/640 + 15c⁷/21504 + …`, which stays under `c³/20` on `c ≤ 1`
-, minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at `c = 1`).
-Squaring both sides keeps it `sqrt`-free.
+— verified in BigFloat, minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at
+`c = 1`).  Squaring both sides keeps it `sqrt`-free.  Only pairs that land
+inside the resulting band pay for `spherical_distance`, and there the original
+test runs unchanged.
 
-This acts as an adaptive filter, similar to how the predicates work.
-Anything which is sufficiently far away gets caught by this, closer things
-go to the old comparison for accuracy.
+`c ≤ 1` is `d ≤ 60°`; wider pairs skip the accept bound but still get the
+reject one, and `r ≥ π` accepts outright since no two points are further
+than `π` apart.
 
-The accept bound requires `c ≤ 1` (`d ≤ 60°`), but the reject bound does not.
-Since no two points are more than `π` apart, `r ≥ π` accepts immediately.
-NaN radii (used for empty-input whole-sphere caps) and negative radii fail the
-filter comparisons and reach the original test, preserving its semantics.
+Every comparison is written so that a NaN radius (the whole-sphere cap that
+`minimum_bounding_circle` returns for empty input) fails it and falls through
+to the original test, which is what `NaN` did before.  Same for negative radii.
 
-For nearly equal centers, `spherical_distance` suffers catastrophic cancellation
-in `cross(p, q)` and relative error of order `eps/d`; the chord remains accurate.
-Against 256-bit arithmetic on 600k pairs 1e-12..1 rad apart, with `r` within
-2 ULP of the true distance, all 111,514 disagreements were old-test errors;
-the chord test had none.
+Where this and the old test disagree, the old test is the one that is wrong:
+`spherical_distance`'s `cross(p, q)` cancels catastrophically for nearly equal
+`p, q`, giving `d` a relative error of order `eps/d`, while the chord is
+computed accurately there.  Adjudicated against 256-bit arithmetic over 600k
+pairs whose centers are 1e-12..1 rad apart with `r` within 2 ULP of the true
+distance: 111,514 disagreements, of which the old test got 111,514 wrong and
+this one got 0 wrong.
 
 Assumes unit-length centers, as the rest of the cap API does.
 =#

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -103,37 +103,26 @@ const _CAP_CHORD_GUARD = 2.0^-40
 # This is all inexact and thus subject to floating point error
 #=
 Two caps intersect iff the angle `d` between their centers is at most the sum
-`r` of their radii.  Computing `d` costs a `spherical_distance` — a cross
-product, a `sqrt` and an `atan2` — but the *squared chord* between the centers,
-`c² = ‖p - q‖²`, is 3 subtractions and 3 multiplications, and it brackets `d`
-tightly enough to settle almost every pair without ever forming `d`:
+`r` of their radii. We can shortcut by computing the *squared chord* between
+the centers, `c² = ‖p - q‖²`, which is 3 subtractions and 3 multiplications. It
+brackets `d` tightly enough to settle almost every pair without ever forming
+`d`:
 
     c  ≤  d = 2 asin(c/2)  ≤  c * (1 + c²/20)        for 0 ≤ c ≤ 1
 
-(the lower bound is `asin(x) ≥ x`; for the upper, `2 asin(c/2) - c` has the
+(The lower bound is `asin(x) ≥ x`; for the upper, `2 asin(c/2) - c` has the
 series `c³/24 + 3c⁵/640 + 15c⁷/21504 + …`, which stays under `c³/20` on `c ≤ 1`
-— verified in BigFloat, minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at
-`c = 1`).  Squaring both sides keeps it `sqrt`-free.  Only pairs that land
-inside the resulting band pay for `spherical_distance`, and there the original
-test runs unchanged.
+with minimum slack `1.0e-18` at `c → 0` and `2.6e-3` at `c = 1`.) Squaring
+both sides keeps it `sqrt`-free.
 
-`c ≤ 1` is `d ≤ 60°`; wider pairs skip the accept bound but still get the
-reject one, and `r ≥ π` accepts outright since no two points are further
-than `π` apart.
+This acts as an adaptive filter, similar to the predicates. Pairs far from the
+boundary use the cheap bounds; closer pairs use `spherical_distance`.
 
-Every comparison is written so that a NaN radius (the whole-sphere cap that
-`minimum_bounding_circle` returns for empty input) fails it and falls through
-to the original test, which is what `NaN` did before.  Same for negative radii.
+For `c > 1` only the reject bound applies. A radius sum of at least `π` accepts
+outright. NaN and negative radii fall through to the original comparison.
 
-Where this and the old test disagree, the old test is the one that is wrong:
-`spherical_distance`'s `cross(p, q)` cancels catastrophically for nearly equal
-`p, q`, giving `d` a relative error of order `eps/d`, while the chord is
-computed accurately there.  Adjudicated against 256-bit arithmetic over 600k
-pairs whose centers are 1e-12..1 rad apart with `r` within 2 ULP of the true
-distance: 111,514 disagreements, of which the old test got 111,514 wrong and
-this one got 0 wrong.
-
-Assumes unit-length centers, as the rest of the cap API does.
+The chord is also more accurate for nearly equal centers, where
+`spherical_distance` loses precision. Centers are assumed to have unit length.
 =#
 function _intersects(x::SphericalCap, y::SphericalCap)
     r = x.radius + y.radius

--- a/src/utils/UnitSpherical/predicates.jl
+++ b/src/utils/UnitSpherical/predicates.jl
@@ -31,28 +31,12 @@ spherical_orient(a, b, c)
 
 ## Why this does not simply call `robust_cross_product`
 
-`robust_cross_product` returns a *normalized* normal, but a sign test does not
-need one: only the sign of `n ⋅ c` matters, and normalizing scales `n` by a
-positive number.  So the common case is inlined here as the bare stable cross
-product `cross(a - b, a + b)`, skipping both the `normalize` and the unit-length
-`@assert`s (whose job is done by the stability test below, which is the thing
-that actually decides whether the cheap value may be used).
+The common path uses the unnormalized `cross(a - b, a + b)`: orientation needs
+only the sign of its dot product with `c`. The squared degeneracy test avoids
+normalizing the cross product or taking a square root.
 
-The degeneracy band is preserved exactly in form: `robust_cross_product`'s
-result is unit length, so `abs(n̂ ⋅ c) < tol` — and for the unnormalized `n`,
-`abs(n ⋅ c) / ‖n‖ < tol`, which is tested as `(n ⋅ c)^2 < tol^2 * ‖n‖^2` to
-avoid the `sqrt`.  This is algebraically the same test; at the threshold itself
-the two differ by the rounding of the dot product (a few ULPs of `n ⋅ c`, i.e.
-a few percent of `tol`, since `tol` is only `16 * eps`).  Points that close to
-the boundary are exactly the ones the tolerance declares indeterminate; no
-input can flip between `+1` and `-1`, only between `0` and a sign.
-
-When the cheap cross product is *not* trustworthy — `a` and `b` nearly equal or
-nearly antipodal, i.e. `‖n‖ < min_stable_norm(T)` — this falls back to the full
-`robust_cross_product`, including its extended/exact-precision and symbolic
-perturbation paths.  That fallback is unreachable from the Sutherland-Hodgman
-clipping path (which skips `edge_start == edge_end` edges), but this is a
-general-purpose predicate with other callers, so it stays.
+For nearly equal or antipodal `a` and `b`, the cross-product direction becomes
+unstable. Those cases fall back to [`robust_cross_product`](@ref).
 """
 function spherical_orient(a::UnitSphericalPoint, b::UnitSphericalPoint, c::UnitSphericalPoint)
     # The orientation is determined by sign((a × b) · c).

--- a/src/utils/UnitSpherical/predicates.jl
+++ b/src/utils/UnitSpherical/predicates.jl
@@ -31,16 +31,28 @@ spherical_orient(a, b, c)
 
 ## Why this does not simply call `robust_cross_product`
 
-Only the sign of `n ⋅ c` matters, so the fast path uses the unnormalized
-`cross(a - b, a + b)` and skips normalization and its unit-length assertions.
-It preserves the degeneracy test without a square root by comparing
-`(n ⋅ c)^2 < tol^2 * ‖n‖^2`. Rounding at the boundary may change `0` to a sign,
-but cannot flip `+1` to `-1`.
+`robust_cross_product` returns a *normalized* normal, but a sign test does not
+need one: only the sign of `n ⋅ c` matters, and normalizing scales `n` by a
+positive number.  So the common case is inlined here as the bare stable cross
+product `cross(a - b, a + b)`, skipping both the `normalize` and the unit-length
+`@assert`s (whose job is done by the stability test below, which is the thing
+that actually decides whether the cheap value may be used).
 
-If `‖n‖ < min_stable_norm(T)` (nearly equal or antipodal inputs), the full
-extended/exact-precision and symbolic-perturbation path recovers the normal.
-Sutherland-Hodgman skips equal-endpoint edges and cannot reach this fallback,
-but other callers can.
+The degeneracy band is preserved exactly in form: `robust_cross_product`'s
+result is unit length, so `abs(n̂ ⋅ c) < tol` — and for the unnormalized `n`,
+`abs(n ⋅ c) / ‖n‖ < tol`, which is tested as `(n ⋅ c)^2 < tol^2 * ‖n‖^2` to
+avoid the `sqrt`.  This is algebraically the same test; at the threshold itself
+the two differ by the rounding of the dot product (a few ULPs of `n ⋅ c`, i.e.
+a few percent of `tol`, since `tol` is only `16 * eps`).  Points that close to
+the boundary are exactly the ones the tolerance declares indeterminate; no
+input can flip between `+1` and `-1`, only between `0` and a sign.
+
+When the cheap cross product is *not* trustworthy — `a` and `b` nearly equal or
+nearly antipodal, i.e. `‖n‖ < min_stable_norm(T)` — this falls back to the full
+`robust_cross_product`, including its extended/exact-precision and symbolic
+perturbation paths.  That fallback is unreachable from the Sutherland-Hodgman
+clipping path (which skips `edge_start == edge_end` edges), but this is a
+general-purpose predicate with other callers, so it stays.
 """
 function spherical_orient(a::UnitSphericalPoint, b::UnitSphericalPoint, c::UnitSphericalPoint)
     # The orientation is determined by sign((a × b) · c).

--- a/src/utils/UnitSpherical/predicates.jl
+++ b/src/utils/UnitSpherical/predicates.jl
@@ -31,28 +31,16 @@ spherical_orient(a, b, c)
 
 ## Why this does not simply call `robust_cross_product`
 
-`robust_cross_product` returns a *normalized* normal, but a sign test does not
-need one: only the sign of `n ⋅ c` matters, and normalizing scales `n` by a
-positive number.  So the common case is inlined here as the bare stable cross
-product `cross(a - b, a + b)`, skipping both the `normalize` and the unit-length
-`@assert`s (whose job is done by the stability test below, which is the thing
-that actually decides whether the cheap value may be used).
+Only the sign of `n ⋅ c` matters, so the fast path uses the unnormalized
+`cross(a - b, a + b)` and skips normalization and its unit-length assertions.
+It preserves the degeneracy test without a square root by comparing
+`(n ⋅ c)^2 < tol^2 * ‖n‖^2`. Rounding at the boundary may change `0` to a sign,
+but cannot flip `+1` to `-1`.
 
-The degeneracy band is preserved exactly in form: `robust_cross_product`'s
-result is unit length, so `abs(n̂ ⋅ c) < tol` — and for the unnormalized `n`,
-`abs(n ⋅ c) / ‖n‖ < tol`, which is tested as `(n ⋅ c)^2 < tol^2 * ‖n‖^2` to
-avoid the `sqrt`.  This is algebraically the same test; at the threshold itself
-the two differ by the rounding of the dot product (a few ULPs of `n ⋅ c`, i.e.
-a few percent of `tol`, since `tol` is only `16 * eps`).  Points that close to
-the boundary are exactly the ones the tolerance declares indeterminate; no
-input can flip between `+1` and `-1`, only between `0` and a sign.
-
-When the cheap cross product is *not* trustworthy — `a` and `b` nearly equal or
-nearly antipodal, i.e. `‖n‖ < min_stable_norm(T)` — this falls back to the full
-`robust_cross_product`, including its extended/exact-precision and symbolic
-perturbation paths.  That fallback is unreachable from the Sutherland-Hodgman
-clipping path (which skips `edge_start == edge_end` edges), but this is a
-general-purpose predicate with other callers, so it stays.
+If `‖n‖ < min_stable_norm(T)` (nearly equal or antipodal inputs), the full
+extended/exact-precision and symbolic-perturbation path recovers the normal.
+Sutherland-Hodgman skips equal-endpoint edges and cannot reach this fallback,
+but other callers can.
 """
 function spherical_orient(a::UnitSphericalPoint, b::UnitSphericalPoint, c::UnitSphericalPoint)
     # The orientation is determined by sign((a × b) · c).

--- a/src/utils/UnitSpherical/predicates.jl
+++ b/src/utils/UnitSpherical/predicates.jl
@@ -26,10 +26,60 @@ spherical_orient(a, b, c)
 # output
 1
 ```
+
+# Extended help
+
+## Why this does not simply call `robust_cross_product`
+
+`robust_cross_product` returns a *normalized* normal, but a sign test does not
+need one: only the sign of `n ⋅ c` matters, and normalizing scales `n` by a
+positive number.  So the common case is inlined here as the bare stable cross
+product `cross(a - b, a + b)`, skipping both the `normalize` and the unit-length
+`@assert`s (whose job is done by the stability test below, which is the thing
+that actually decides whether the cheap value may be used).
+
+The degeneracy band is preserved exactly in form: `robust_cross_product`'s
+result is unit length, so `abs(n̂ ⋅ c) < tol` — and for the unnormalized `n`,
+`abs(n ⋅ c) / ‖n‖ < tol`, which is tested as `(n ⋅ c)^2 < tol^2 * ‖n‖^2` to
+avoid the `sqrt`.  This is algebraically the same test; at the threshold itself
+the two differ by the rounding of the dot product (a few ULPs of `n ⋅ c`, i.e.
+a few percent of `tol`, since `tol` is only `16 * eps`).  Points that close to
+the boundary are exactly the ones the tolerance declares indeterminate; no
+input can flip between `+1` and `-1`, only between `0` and a sign.
+
+When the cheap cross product is *not* trustworthy — `a` and `b` nearly equal or
+nearly antipodal, i.e. `‖n‖ < min_stable_norm(T)` — this falls back to the full
+`robust_cross_product`, including its extended/exact-precision and symbolic
+perturbation paths.  That fallback is unreachable from the Sutherland-Hodgman
+clipping path (which skips `edge_start == edge_end` edges), but this is a
+general-purpose predicate with other callers, so it stays.
 """
 function spherical_orient(a::UnitSphericalPoint, b::UnitSphericalPoint, c::UnitSphericalPoint)
-    # The orientation is determined by sign((a × b) · c)
-    # Use robust_cross_product for numerical stability
+    # The orientation is determined by sign((a × b) · c).
+    #
+    # Fast path: the stable cross product `cross(a - b, a + b)` (== 2(a × b),
+    # but far better conditioned for nearly-identical inputs), left
+    # unnormalized.  Written out componentwise so nothing allocates or is
+    # recomputed.
+    d1 = a[1] - b[1]; d2 = a[2] - b[2]; d3 = a[3] - b[3]
+    s1 = a[1] + b[1]; s2 = a[2] + b[2]; s3 = a[3] + b[3]
+    n1 = d2 * s3 - d3 * s2
+    n2 = d3 * s1 - d1 * s3
+    n3 = d1 * s2 - d2 * s1
+    nsqr = n1 * n1 + n2 * n2 + n3 * n3
+    # Same stability criterion `robust_cross_product` applies internally.
+    kmin = min_stable_norm(promote_type(eltype(a), eltype(b)))
+    if nsqr >= kmin * kmin
+        dot_product = n1 * c[1] + n2 * c[2] + n3 * c[3]
+        tol = eps(Float64) * 16  # Same tolerance as S2 geometry
+        # `abs(dot_product) / sqrt(nsqr) < tol`, without the sqrt
+        dot_product * dot_product < (tol * tol) * nsqr && return 0
+        return dot_product > 0 ? 1 : -1
+    end
+
+    # Slow path: `a` and `b` are nearly equal or nearly antipodal, so the
+    # Float64 cross product has lost the direction of the normal.  Recover it
+    # with the exact-arithmetic / symbolic-perturbation machinery.
     n = robust_cross_product(a, b)
     dot_product = n ⋅ c
 

--- a/src/utils/UnitSpherical/predicates.jl
+++ b/src/utils/UnitSpherical/predicates.jl
@@ -33,7 +33,8 @@ spherical_orient(a, b, c)
 
 The common path uses the unnormalized `cross(a - b, a + b)`: orientation needs
 only the sign of its dot product with `c`. The squared degeneracy test avoids
-normalizing the cross product or taking a square root.
+normalizing the cross product or taking a square root. Rounding at the boundary
+may change `0` to a sign, but cannot flip `+1` to `-1`.
 
 For nearly equal or antipodal `a` and `b`, the cross-product direction becomes
 unstable. Those cases fall back to [`robust_cross_product`](@ref).

--- a/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
+++ b/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
@@ -68,6 +68,25 @@ const HAS_LONG_DOUBLE = precision(Float64) < precision(BigFloat)
 # Error for exact cross product calculations
 const EXACT_CROSS_PROD_ERROR = DBL_ERR
 
+"""
+    min_stable_norm(::Type{T})
+
+The smallest `norm(cross(a - b, a + b))` for which [`stable_cross_product`](@ref)
+evaluated in precision `T` still meets `ROBUST_CROSS_PROD_ERROR`.  Below it,
+[`robust_cross_product`](@ref) must escalate to higher precision, exact
+arithmetic, or symbolic perturbation.
+
+Callers that want the cheap unnormalized `cross(a - b, a + b)` directly (the
+orientation predicate, say, which only needs the *sign* of a dot product
+against it, and so needs neither the normalization nor a scale-correct norm)
+can use this to decide when the cheap value is trustworthy and when they must
+fall back to `robust_cross_product`.
+
+See the derivation in [`stable_cross_product`](@ref).
+"""
+min_stable_norm(::Type{T}) where {T} =
+    (32 * SQRT3 * DBL_ERR) / (ROBUST_CROSS_PROD_ERROR / (eps(float(T)) / 2) - (1 + 2 * SQRT3))
+
 isDoubleFloatsAvailable(args...) = false
 
 """
@@ -179,8 +198,7 @@ function stable_cross_product(a::AbstractVector{T}, b::AbstractVector{T}) where 
     # precision is needed; in particular, higher precision is only necessary when
     # "a" and "b" are closer than about `18 * DBL_ERR == 9 * DBL_EPSILON`.
     # (80-bit precision can handle inputs as close as `2.5 * LDBL_EPSILON`.)
-    T_ERR = eps(float(T)) / 2 
-    kMinNorm = (32 * sqrt(3) * DBL_ERR) / (ROBUST_CROSS_PROD_ERROR / T_ERR - (1 + 2sqrt(3)))
+    kMinNorm = min_stable_norm(T)
 
     # Finally...we compute the result by regular cross product.
     result = cross(a - b, a + b)

--- a/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
+++ b/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
@@ -71,18 +71,8 @@ const EXACT_CROSS_PROD_ERROR = DBL_ERR
 """
     min_stable_norm(::Type{T})
 
-The smallest `norm(cross(a - b, a + b))` for which [`stable_cross_product`](@ref)
-evaluated in precision `T` still meets `ROBUST_CROSS_PROD_ERROR`.  Below it,
-[`robust_cross_product`](@ref) must escalate to higher precision, exact
-arithmetic, or symbolic perturbation.
-
-Callers that want the cheap unnormalized `cross(a - b, a + b)` directly (the
-orientation predicate, say, which only needs the *sign* of a dot product
-against it, and so needs neither the normalization nor a scale-correct norm)
-can use this to decide when the cheap value is trustworthy and when they must
-fall back to `robust_cross_product`.
-
-See the derivation in [`stable_cross_product`](@ref).
+Return the smallest stable-cross-product norm that meets
+`ROBUST_CROSS_PROD_ERROR` in precision `T`.
 """
 min_stable_norm(::Type{T}) where {T} =
     (32 * SQRT3 * DBL_ERR) / (ROBUST_CROSS_PROD_ERROR / (eps(float(T)) / 2) - (1 + 2 * SQRT3))

--- a/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
+++ b/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
@@ -71,18 +71,11 @@ const EXACT_CROSS_PROD_ERROR = DBL_ERR
 """
     min_stable_norm(::Type{T})
 
-The smallest `norm(cross(a - b, a + b))` for which [`stable_cross_product`](@ref)
-evaluated in precision `T` still meets `ROBUST_CROSS_PROD_ERROR`.  Below it,
-[`robust_cross_product`](@ref) must escalate to higher precision, exact
-arithmetic, or symbolic perturbation.
-
-Callers that want the cheap unnormalized `cross(a - b, a + b)` directly (the
-orientation predicate, say, which only needs the *sign* of a dot product
-against it, and so needs neither the normalization nor a scale-correct norm)
-can use this to decide when the cheap value is trustworthy and when they must
-fall back to `robust_cross_product`.
-
-See the derivation in [`stable_cross_product`](@ref).
+Smallest `norm(cross(a - b, a + b))` that meets
+`ROBUST_CROSS_PROD_ERROR` in precision `T`. Below it,
+[`robust_cross_product`](@ref) must use a higher-precision fallback. Callers
+that only need the sign may use this threshold on the unnormalized cross
+product. See [`stable_cross_product`](@ref) for the derivation.
 """
 min_stable_norm(::Type{T}) where {T} =
     (32 * SQRT3 * DBL_ERR) / (ROBUST_CROSS_PROD_ERROR / (eps(float(T)) / 2) - (1 + 2 * SQRT3))

--- a/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
+++ b/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
@@ -73,6 +73,8 @@ const EXACT_CROSS_PROD_ERROR = DBL_ERR
 
 Return the smallest stable-cross-product norm that meets
 `ROBUST_CROSS_PROD_ERROR` in precision `T`.
+
+This is S2's `kMinNorm`: [s2edge_crossings.cc#L129-L131](https://github.com/google/s2geometry/blob/dabeea21c0261cb2e449d28f3034df1e12eaf223/src/s2/s2edge_crossings.cc#L129-L131).
 """
 min_stable_norm(::Type{T}) where {T} =
     (32 * SQRT3 * DBL_ERR) / (ROBUST_CROSS_PROD_ERROR / (eps(float(T)) / 2) - (1 + 2 * SQRT3))

--- a/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
+++ b/src/utils/UnitSpherical/robustcrossproduct/RobustCrossProduct.jl
@@ -71,11 +71,18 @@ const EXACT_CROSS_PROD_ERROR = DBL_ERR
 """
     min_stable_norm(::Type{T})
 
-Smallest `norm(cross(a - b, a + b))` that meets
-`ROBUST_CROSS_PROD_ERROR` in precision `T`. Below it,
-[`robust_cross_product`](@ref) must use a higher-precision fallback. Callers
-that only need the sign may use this threshold on the unnormalized cross
-product. See [`stable_cross_product`](@ref) for the derivation.
+The smallest `norm(cross(a - b, a + b))` for which [`stable_cross_product`](@ref)
+evaluated in precision `T` still meets `ROBUST_CROSS_PROD_ERROR`.  Below it,
+[`robust_cross_product`](@ref) must escalate to higher precision, exact
+arithmetic, or symbolic perturbation.
+
+Callers that want the cheap unnormalized `cross(a - b, a + b)` directly (the
+orientation predicate, say, which only needs the *sign* of a dot product
+against it, and so needs neither the normalization nor a scale-correct norm)
+can use this to decide when the cheap value is trustworthy and when they must
+fall back to `robust_cross_product`.
+
+See the derivation in [`stable_cross_product`](@ref).
 """
 min_stable_norm(::Type{T}) where {T} =
     (32 * SQRT3 * DBL_ERR) / (ROBUST_CROSS_PROD_ERROR / (eps(float(T)) / 2) - (1 + 2 * SQRT3))

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -197,8 +197,8 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         # a reused cache is the whole point: with one, nothing is allocated at all
         _area_bytes(planar, square_a, square_b, planar_cache)
         _area_bytes(spherical, sa, sb, spherical_cache)
-        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0 skip = VERSION < v"1.12"
-        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0 skip = VERSION < v"1.12"
+        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0
+        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0
         # Guard against passing vacuously: without a cache the buffers cost something
         _area_bytes(planar, square_a, square_b)
         @test _area_bytes(planar, square_a, square_b) > 0

--- a/test/methods/clipping/intersection_area.jl
+++ b/test/methods/clipping/intersection_area.jl
@@ -197,8 +197,8 @@ edge_neighbour = GI.Polygon([[(2.0, 0.0), (4.0, 0.0), (4.0, 2.0), (2.0, 2.0), (2
         # a reused cache is the whole point: with one, nothing is allocated at all
         _area_bytes(planar, square_a, square_b, planar_cache)
         _area_bytes(spherical, sa, sb, spherical_cache)
-        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0
-        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0
+        @test _area_bytes(planar, square_a, square_b, planar_cache) == 0 skip = VERSION < v"1.12"
+        @test _area_bytes(spherical, sa, sb, spherical_cache) == 0 skip = VERSION < v"1.12"
         # Guard against passing vacuously: without a cache the buffers cost something
         _area_bytes(planar, square_a, square_b)
         @test _area_bytes(planar, square_a, square_b) > 0


### PR DESCRIPTION
Two spherical predicates were paying for arithmetic they then threw away. This
strips that work out without changing what either predicate answers.

**Stacked on #473** (`as/intersection_area`) — this PR's base is that branch, so
the diff below is only the two commits on top of it. Please merge #473 first.

## What changed

### 1. `spherical_orient`: drop the discarded `normalize` (and the asserts that came with it)

`spherical_orient` needs only the *sign* of `n ⋅ c`. It obtained `n` from
`robust_cross_product`, which **normalizes** its result — a `sqrt` and three
divides — and, on the way in, runs two `@boundscheck @assert isUnitLength(...)`
checks on its arguments.

Normalizing `n` scales it by a positive number, so it cannot change the sign of
`n ⋅ c`: the `sqrt`, the divides, and the input asserts are all work the
predicate discards. The common case is now the bare stable cross product
`cross(a - b, a + b)`, written out componentwise and left unnormalized. The
degeneracy band is preserved in form and in tolerance, just rescaled to the
unnormalized normal so it too avoids the `sqrt`:

```
abs(n̂ ⋅ c) < tol   ⟺   abs(n ⋅ c) / ‖n‖ < tol   ⟺   (n ⋅ c)² < tol² ‖n‖²
```

**The exact-arithmetic and symbolic-perturbation fallback is kept.** When `a`
and `b` are nearly equal or nearly antipodal the Float64 cross product has lost
the normal's direction; that case still calls the full `robust_cross_product`,
guarded by exactly the criterion `robust_cross_product` applies internally. To
keep one source of truth for that criterion, the `kMinNorm` expression is lifted
out of `stable_cross_product` into `RobustCrossProduct.min_stable_norm(T)` —
same expression, same association order, same `Float64` value. It constant-folds;
the emitted fast path has no `fdiv` and no `sqrt`.

Measured **36.8 ns → 4.6 ns per call (8.0x)** over 4096 random triples, and the
same over short-edge "clipping-like" triples. Still zero allocations.

Equivalence, old vs new run side by side over **22.2M triples**:

| suite | disagreements |
|---|---|
| 8.0M uniform random unit triples | 0 |
| 2.0M exactly collinear (`c ∈ span(a,b)`) | 0 |
| 200k near-degenerate `a,b` (identical, 1–4 ulp apart, antipodal, near-antipodal; 177,576 slow path) | 0 |
| 8000 exhaustive over axes/poles/diagonals (760 slow path) | 0 |
| 6.0M with `c` placed deliberately *inside* the band, `abs(n̂ ⋅ c) = ρ·tol`, ρ ∈ [0.95, 1.05] | 371,908 |
| 2.0M near-antipodal `a,b` with `c` in the band (325,066 slow path) | 7,470 |

Every disagreement, in every suite, has `abs(n̂ ⋅ c) / tol` between 0.950 and
1.048 — the ULP noise of the dot product itself, which at a tolerance of only
`16 eps` is a few percent of the tolerance. **Zero disagreements were of the form
+1 vs -1**: the two implementations never disagree about which side a point is
on, only about whether a point within ~5% of the tolerance boundary is inside the
"collinear" band. Those are precisely the points the tolerance declares
indeterminate.

### 2. `SphericalCap` `_intersects`: settle on the squared chord, not `atan2`

`_intersects` formed the full central angle with `spherical_distance` — a cross
product, a `sqrt` and an `atan2` — only to compare it against the sum of the two
radii. The squared chord between the centers is 3 subtractions and 3
multiplications, and it brackets that angle tightly enough to settle almost every
pair outright:

```
c ≤ d = 2 asin(c/2) ≤ c (1 + c²/20)      for 0 ≤ c ≤ 1
```

so `c² > r²` rejects and `c²(1 + c²/20)² ≤ r²` accepts, both `sqrt`-free;
`r ≥ π` accepts outright. Only pairs left inside the band pay for
`spherical_distance`, and there the original expression runs unchanged.

The upper bound was verified in BigFloat over 200k values of `c ∈ (0, 1]`:
minimum slack 1.04e-18, i.e. it never crosses. Both cheap branches must clear
the decision by `2^-40` relative — ~1000x the rounding of a squared chord — so
neither can fire on the strength of its own round-off. Whole-sphere (NaN-radius)
caps, which `minimum_bounding_circle` returns for empty input, are unchanged:
every comparison here is false against `NaN`, so such a pair falls through to the
original test and still answers `false`. Same for a NaN center, and for negative
radii.

Measured, 4096 cap pairs each:

| case | before | after |
|---|---:|---:|
| random centers, radii `[0, π)` | 16.5 ns | 7.35 ns (2.25x) |
| random centers, radii ~1e-3 | 16.6 ns | 3.43 ns (4.83x) |
| near centers (sep 1e-2), r ~1e-3 | 12.9 ns | 3.49 ns (3.70x) |
| near centers (sep 1e-3), r ~1e-3 | 12.8 ns | 3.80 ns (3.36x) |
| near centers (sep 1e-3), r ~1e-2 | 12.9 ns | 4.28 ns (3.02x) |

Equivalence over 8.5M pairs: **0 disagreements** for uniform radii in `[0, π)`,
for radii < 0.01, for radii < 1e-6, for identical and exactly-antipodal centers,
and for 2M pairs with `rx + ry` tuned to within 1e-13 relative of the true center
distance.

The two *do* differ once the centers are closer than ~1e-6 rad and `rx + ry` is
within a couple of ULPs of that distance — **and there the old test is the one
that is wrong.** `spherical_distance`'s `cross(p, q)` cancels catastrophically
for nearly equal `p, q`, giving the angle a relative error of order `eps/d`,
while the chord is computed accurately in that regime. Adjudicated against
256-bit arithmetic over 600k such pairs: 111,514 disagreements, old wrong on
111,514 of them, new wrong on 0. So this is a small accuracy improvement as well
as a speedup.

## Why it's worth doing

These came out of a downstream profiling campaign on a CopDEM → IGeo7 conservative
regrid, where `spherical_orient` is called **114,212,848 times per output column**
(it backs `point_on_spherical_arc`, the ring-containment crossing parities, and
the spherical Sutherland–Hodgman clip) and the cap-overlap test was 24.7% of CPU
in the tree walk. Repinning GeometryOps to these two commits measured
**−15% end-to-end, bit-identical output, reproduced twice**, with allocation
unchanged — as expected of two changes that only remove arithmetic.

Measurement records, with the benchmark harnesses and the equivalence suites:

- `DiscreteGlobalGrids.jl/regrid-notes/2026-08-20-perf-ladder.md` (§2.7)
- `DiscreteGlobalGrids.jl/regrid-notes/2026-08-20-more-improvements.md` (§2.2, §2.4)

## Tests

GeometryOps' own suite is unchanged across the pair: **231,527 pass / 0 fail,
per-testset identical** on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC7rbi9eqZypWseMjBGSJ2
