### PR TITLE
Publish spherical cap extent primitives

### DIFF
--- a/src/utils/UnitSpherical/UnitSpherical.jl
+++ b/src/utils/UnitSpherical/UnitSpherical.jl
@@ -24,7 +24,8 @@ include("arc_intersection.jl")
 include("arc_extent.jl")
 
 export UnitSphericalPoint, UnitSphereFromGeographic, GeographicFromUnitSphere,
-       slerp, SphericalCap, spherical_distance, spherical_orient, point_on_spherical_arc,
+       slerp, SphericalCap, cap_contains, merge_caps, dilate_cap, cap_xyz_extent,
+       spherical_distance, spherical_orient, point_on_spherical_arc,
        spherical_ring_contains, spherical_ring_encloses, spherical_exterior_anchor,
        spherical_arc_intersection, ArcIntersectionResult,
        arc_cross, arc_hinge, arc_overlap, arc_disjoint,

--- a/src/utils/UnitSpherical/UnitSpherical.jl
+++ b/src/utils/UnitSpherical/UnitSpherical.jl
@@ -24,8 +24,7 @@ include("arc_intersection.jl")
 include("arc_extent.jl")
 
 export UnitSphericalPoint, UnitSphereFromGeographic, GeographicFromUnitSphere,
-       slerp, SphericalCap, cap_contains, merge_caps, dilate_cap, cap_xyz_extent,
-       spherical_distance, spherical_orient, point_on_spherical_arc,
+       slerp, SphericalCap, spherical_distance, spherical_orient, point_on_spherical_arc,
        spherical_ring_contains, spherical_ring_encloses, spherical_exterior_anchor,
        spherical_arc_intersection, ArcIntersectionResult,
        arc_cross, arc_hinge, arc_overlap, arc_disjoint,

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -7,6 +7,10 @@ CollapsedDocStrings = true
 
 ```@docs; canonical=false
 SphericalCap
+cap_contains
+merge_caps
+dilate_cap
+cap_xyz_extent
 circumcenter_on_unit_sphere
 ```
 
@@ -144,16 +148,43 @@ end
 
 _disjoint(x::SphericalCap, y::SphericalCap) = !_intersects(x, y)
 
-function _contains(big::SphericalCap, small::SphericalCap)
+"""
+    cap_contains(big::SphericalCap, small::SphericalCap) -> Bool
+    cap_contains(cap::SphericalCap, point::UnitSphericalPoint) -> Bool
+
+Whether the closed cap `big` contains all of `small`, or whether the closed
+`cap` contains `point`. A cap whose radius is at least `π` contains the whole
+unit sphere.
+"""
+function cap_contains(big::SphericalCap, small::SphericalCap)
+    big.radius >= oftype(big.radius, π) && return true
+    small.radius >= oftype(small.radius, π) && return false
     dist = spherical_distance(big.point, small.point)
     # small circle fits in big circle; `<=` so internally-tangent small
     # caps count as contained, matching the point overload below and
     # S2's `S2Cap::Contains(const S2Cap&)` convention.
     return dist + small.radius <= big.radius
 end
-function _contains(cap::SphericalCap, point::UnitSphericalPoint)
+function cap_contains(cap::SphericalCap, point::UnitSphericalPoint)
+    cap.radius >= oftype(cap.radius, π) && return true
     spherical_distance(cap.point, point) <= cap.radius
 end
+
+# Private spellings retained for compatibility with existing callers.
+_contains(big::SphericalCap, small::SphericalCap) = cap_contains(big, small)
+_contains(cap::SphericalCap, point::UnitSphericalPoint) = cap_contains(cap, point)
+
+# ## Cap intersection
+
+"""
+    Extents.intersects(x::SphericalCap, y::SphericalCap)
+
+Whether the two closed caps intersect. Tangency counts as intersection. The
+comparison delegates to the cap predicate's guarded squared-chord test, which
+retains precision for nearly coincident centres and falls back to angular
+distance only inside its uncertainty band.
+"""
+Extents.intersects(x::SphericalCap, y::SphericalCap) = _intersects(x, y)
 
 # ## Cap–extent intersection
 
@@ -183,23 +214,84 @@ end
 Extents.intersects(ext::Extents.Extent{(:X, :Y, :Z)}, cap::SphericalCap) =
     Extents.intersects(cap, ext)
 
-#Comment by asinghvi: this could be transformed to GO.union
-function _merge(x::SphericalCap, y::SphericalCap)
+"""
+    cap_xyz_extent(cap::SphericalCap) -> Extents.Extent{(:X, :Y, :Z)}
+
+Return an outward-rounded Cartesian bounding box for every unit-sphere point
+in `cap`. The result is intended for Cartesian spatial indexes over
+unit-spherical data; it is deliberately an explicitly named conversion rather
+than `Extents.extent(cap)`, because a `SphericalCap` remains a spherical query
+object rather than ordinary Cartesian geometry.
+
+Valid caps have radii in `[0, π]`. A radius at least `π`, or a non-finite or
+negative radius, conservatively returns the whole unit-sphere box.
+"""
+function cap_xyz_extent(cap::SphericalCap{T}) where {T <: AbstractFloat}
+    oneT = one(T)
+    whole = (-oneT, oneT)
+    r = cap.radius
+    if !(zero(T) <= r < T(π))
+        return Extents.Extent(X = whole, Y = whole, Z = whole)
+    end
+
+    cr, sr = cos(r), sin(r)
+    # Covers the accumulated error in sin/cos, the transverse square root,
+    # and the multiply-adds. The final adjacent-float step makes the direction
+    # of rounding explicit even when subtracting the guard is exact.
+    guard = 8 * eps(T)
+    bounds = ntuple(Val(3)) do i
+        x = clamp(cap.point[i], -oneT, oneT)
+        transverse = sqrt(max(zero(T), (oneT - x) * (oneT + x)))
+        lo = x <= -cr ? -oneT : x * cr - transverse * sr
+        hi = x >= cr ? oneT : x * cr + transverse * sr
+        (max(-oneT, prevfloat(lo - guard)),
+         min(oneT, nextfloat(hi + guard)))
+    end
+    return Extents.Extent(X = bounds[1], Y = bounds[2], Z = bounds[3])
+end
+
+"""
+    dilate_cap(cap::SphericalCap, radius::Real) -> SphericalCap
+
+Return `cap` enlarged by the nonnegative angular `radius` in radians. Positive
+dilations are rounded outward and capped at `π`; dilating by zero returns
+`cap` unchanged.
+"""
+function dilate_cap(cap::SphericalCap{T}, radius::Real) where {T <: AbstractFloat}
+    δ = convert(T, radius)
+    δ >= zero(T) || throw(DomainError(radius, "cap dilation must be nonnegative"))
+    δ == zero(T) && return cap
+    cap.radius >= T(π) && return cap
+    widened = min(T(π), nextfloat(cap.radius + δ))
+    return SphericalCap(cap.point, widened)
+end
+
+"""
+    merge_caps(x::SphericalCap, y::SphericalCap) -> SphericalCap
+
+Return a cap containing both `x` and `y`. If either input already contains the
+other it is returned unchanged. Otherwise the centre lies between the input
+centres and the radius is rounded outward to preserve coverage.
+"""
+function merge_caps(x::SphericalCap, y::SphericalCap)
+    cap_contains(x, y) && return x
+    cap_contains(y, x) && return y
 
     d = spherical_distance(x.point, y.point)
     newradius = (x.radius + y.radius + d) / 2
-    if newradius < x.radius
-        #x contains y
-        x
-    elseif newradius < y.radius
-        #y contains x
-        y
-    else
-        excenter = 0.5 * (1 - (x.radius - y.radius) / d)
-        newcenter = slerp(x.point, y.point, excenter)
-        SphericalCap(newcenter, newradius)
-    end
+    excenter = 0.5 * (1 - (x.radius - y.radius) / d)
+    newcenter = slerp(x.point, y.point, excenter)
+    # Re-evaluate coverage at the computed centre: this absorbs interpolation
+    # and distance rounding, not only the closed-form radius's rounding.
+    covering_radius = max(newradius,
+        spherical_distance(newcenter, x.point) + x.radius,
+        spherical_distance(newcenter, y.point) + y.radius)
+    radius = min(oftype(covering_radius, π), nextfloat(covering_radius))
+    return SphericalCap(newcenter, radius)
 end
+
+# Private spelling retained for compatibility with existing callers.
+_merge(x::SphericalCap, y::SphericalCap) = merge_caps(x, y)
 
 """
     circumcenter_on_unit_sphere(a, b, c)

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -7,10 +7,11 @@ CollapsedDocStrings = true
 
 ```@docs; canonical=false
 SphericalCap
-cap_contains
-merge_caps
-dilate_cap
-cap_xyz_extent
+Extents.contains
+Extents.within
+Extents.extent
+Extents.union
+Extents.grow
 circumcenter_on_unit_sphere
 ```
 
@@ -149,14 +150,14 @@ end
 _disjoint(x::SphericalCap, y::SphericalCap) = !_intersects(x, y)
 
 """
-    cap_contains(big::SphericalCap, small::SphericalCap) -> Bool
-    cap_contains(cap::SphericalCap, point::UnitSphericalPoint) -> Bool
+    Extents.contains(big::SphericalCap, small::SphericalCap; strict=false)
+    Extents.within(small::SphericalCap, big::SphericalCap; strict=false)
 
-Whether the closed cap `big` contains all of `small`, or whether the closed
-`cap` contains `point`. A cap whose radius is at least `π` contains the whole
-unit sphere.
+Whether the closed cap `big` contains all of `small`. A cap whose radius is at
+least `π` contains the whole unit sphere. `strict` is accepted for consistency
+with the Extents API and has no effect because both inputs use the same domain.
 """
-function cap_contains(big::SphericalCap, small::SphericalCap)
+function Extents.contains(big::SphericalCap, small::SphericalCap; strict=false)
     big.radius >= oftype(big.radius, π) && return true
     small.radius >= oftype(small.radius, π) && return false
     dist = spherical_distance(big.point, small.point)
@@ -165,14 +166,15 @@ function cap_contains(big::SphericalCap, small::SphericalCap)
     # S2's `S2Cap::Contains(const S2Cap&)` convention.
     return dist + small.radius <= big.radius
 end
-function cap_contains(cap::SphericalCap, point::UnitSphericalPoint)
+Extents.within(small::SphericalCap, big::SphericalCap; strict=false) =
+    Extents.contains(big, small; strict)
+
+# Point membership stays internal: a point is not an `Extents.Extent`, so the
+# Extents DE-9IM containment generic does not describe this mixed relation.
+function _contains(cap::SphericalCap, point::UnitSphericalPoint)
     cap.radius >= oftype(cap.radius, π) && return true
     spherical_distance(cap.point, point) <= cap.radius
 end
-
-# Private spellings retained for compatibility with existing callers.
-_contains(big::SphericalCap, small::SphericalCap) = cap_contains(big, small)
-_contains(cap::SphericalCap, point::UnitSphericalPoint) = cap_contains(cap, point)
 
 # ## Cap intersection
 
@@ -215,18 +217,16 @@ Extents.intersects(ext::Extents.Extent{(:X, :Y, :Z)}, cap::SphericalCap) =
     Extents.intersects(cap, ext)
 
 """
-    cap_xyz_extent(cap::SphericalCap) -> Extents.Extent{(:X, :Y, :Z)}
+    Extents.extent(cap::SphericalCap) -> Extents.Extent{(:X, :Y, :Z)}
 
 Return an outward-rounded Cartesian bounding box for every unit-sphere point
 in `cap`. The result is intended for Cartesian spatial indexes over
-unit-spherical data; it is deliberately an explicitly named conversion rather
-than `Extents.extent(cap)`, because a `SphericalCap` remains a spherical query
-object rather than ordinary Cartesian geometry.
+unit-spherical data.
 
 Valid caps have radii in `[0, π]`. A radius at least `π`, or a non-finite or
 negative radius, conservatively returns the whole unit-sphere box.
 """
-function cap_xyz_extent(cap::SphericalCap{T}) where {T <: AbstractFloat}
+function Extents.extent(cap::SphericalCap{T}) where {T <: AbstractFloat}
     oneT = one(T)
     whole = (-oneT, oneT)
     r = cap.radius
@@ -251,31 +251,35 @@ function cap_xyz_extent(cap::SphericalCap{T}) where {T <: AbstractFloat}
 end
 
 """
-    dilate_cap(cap::SphericalCap, radius::Real) -> SphericalCap
+    Extents.grow(cap::SphericalCap, factor::Real) -> SphericalCap
 
-Return `cap` enlarged by the nonnegative angular `radius` in radians. Positive
-dilations are rounded outward and capped at `π`; dilating by zero returns
-`cap` unchanged.
+Grow the cap's angular diameter by `factor` on each side, matching the scalar
+`Extents.grow` convention. Positive growth is rounded outward and capped at
+`π`; zero returns `cap` unchanged. A factor of `0.5` therefore doubles the
+radius. Negative factors shrink it, provided the resulting radius is valid.
 """
-function dilate_cap(cap::SphericalCap{T}, radius::Real) where {T <: AbstractFloat}
-    δ = convert(T, radius)
-    δ >= zero(T) || throw(DomainError(radius, "cap dilation must be nonnegative"))
+function Extents.grow(cap::SphericalCap{T}, factor::Real) where {T <: AbstractFloat}
+    δ = convert(T, factor)
     δ == zero(T) && return cap
-    cap.radius >= T(π) && return cap
-    widened = min(T(π), nextfloat(cap.radius + δ))
-    return SphericalCap(cap.point, widened)
+    δ > zero(T) && cap.radius >= T(π) && return cap
+    grown = cap.radius + 2 * cap.radius * δ
+    grown >= zero(T) || throw(DomainError(factor, "cap growth factor produces a negative radius"))
+    radius = grown > cap.radius ? min(T(π), nextfloat(grown)) : grown
+    return SphericalCap(cap.point, radius)
 end
 
 """
-    merge_caps(x::SphericalCap, y::SphericalCap) -> SphericalCap
+    Extents.union(x::SphericalCap, y::SphericalCap; strict=false) -> SphericalCap
 
 Return a cap containing both `x` and `y`. If either input already contains the
 other it is returned unchanged. Otherwise the centre lies between the input
-centres and the radius is rounded outward to preserve coverage.
+centres and the radius is rounded outward to preserve coverage. `strict` is
+accepted for consistency with the Extents API and has no effect because both
+inputs use the same domain.
 """
-function merge_caps(x::SphericalCap, y::SphericalCap)
-    cap_contains(x, y) && return x
-    cap_contains(y, x) && return y
+function Extents.union(x::SphericalCap, y::SphericalCap; strict=false)
+    Extents.contains(x, y; strict) && return x
+    Extents.contains(y, x; strict) && return y
 
     d = spherical_distance(x.point, y.point)
     newradius = (x.radius + y.radius + d) / 2
@@ -289,9 +293,6 @@ function merge_caps(x::SphericalCap, y::SphericalCap)
     radius = min(oftype(covering_radius, π), nextfloat(covering_radius))
     return SphericalCap(newcenter, radius)
 end
-
-# Private spelling retained for compatibility with existing callers.
-_merge(x::SphericalCap, y::SphericalCap) = merge_caps(x, y)
 
 """
     circumcenter_on_unit_sphere(a, b, c)

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -30,6 +30,12 @@ The `SphericalCap` type offers multiple constructors to create caps from:
 - Geographic coordinates and radius
 - Three points on the unit sphere (circumcircle)
 
+!!! note Interop with Extents
+    You can convert a spherical cap to a 3D extent in the Cartesian space that holds the unit sphere
+    by `convert(Extent, cap)`.  All of the Extents.jl predicates like covers, within, etc are also 
+    extended to work and compare `Extent{(:X, :Y, :Z)}` with spherical caps - assuming everything on
+    the unit sphere.
+
 ## Examples
 
 ```@example sphericalcap

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -9,7 +9,6 @@ CollapsedDocStrings = true
 SphericalCap
 Extents.contains
 Extents.within
-Extents.extent
 Extents.union
 Extents.grow
 circumcenter_on_unit_sphere
@@ -216,21 +215,32 @@ Extents.intersects(ext::Extents.Extent{(:X, :Y, :Z)}, cap::SphericalCap) =
     Extents.intersects(cap, ext)
 
 """
-    Extents.extent(cap::SphericalCap) -> Extents.Extent{(:X, :Y, :Z)}
+    convert(::Type{<:Extents.Extent}, cap::SphericalCap) -> Extents.Extent{(:X, :Y, :Z)}
 
-Return an outward-rounded Cartesian bounding box for every unit-sphere point
-in `cap`. The result is intended for Cartesian spatial indexes over
-unit-spherical data.
+Convert `cap` to an outward-rounded Cartesian bounding box containing every
+unit-sphere point in the cap. The result is intended for Cartesian spatial
+indexes over unit-spherical data.
+
+Extent extraction conventionally means that an object *has* a Cartesian
+extent. A `SphericalCap` is instead a spherical query object, so conversion
+makes this boundary crossing explicit.
 
 Valid caps have radii in `[0, π]`. A radius at least `π`, or a non-finite or
 negative radius, conservatively returns the whole unit-sphere box.
+
+The abstract target `Extents.Extent` and compatible concrete targets are
+accepted. Incompatible concrete targets throw an `ArgumentError`.
 """
-function Extents.extent(cap::SphericalCap{T}) where {T <: AbstractFloat}
+function Base.convert(target::Type{<:Extents.Extent}, cap::SphericalCap{T}) where {
+        T <: AbstractFloat}
     oneT = one(T)
     whole = (-oneT, oneT)
     r = cap.radius
     if !(zero(T) <= r < T(π))
-        return Extents.Extent(X = whole, Y = whole, Z = whole)
+        result = Extents.Extent(X = whole, Y = whole, Z = whole)
+        result isa target || throw(ArgumentError(
+            "cannot convert SphericalCap{$T} to incompatible extent type $target"))
+        return result
     end
 
     cr, sr = cos(r), sin(r)
@@ -246,7 +256,10 @@ function Extents.extent(cap::SphericalCap{T}) where {T <: AbstractFloat}
         (max(-oneT, prevfloat(lo - guard)),
          min(oneT, nextfloat(hi + guard)))
     end
-    return Extents.Extent(X = bounds[1], Y = bounds[2], Z = bounds[3])
+    result = Extents.Extent(X = bounds[1], Y = bounds[2], Z = bounds[3])
+    result isa target || throw(ArgumentError(
+        "cannot convert SphericalCap{$T} to incompatible extent type $target"))
+    return result
 end
 
 """

--- a/src/utils/UnitSpherical/cap.jl
+++ b/src/utils/UnitSpherical/cap.jl
@@ -151,11 +151,8 @@ _disjoint(x::SphericalCap, y::SphericalCap) = !_intersects(x, y)
 
 """
     Extents.contains(big::SphericalCap, small::SphericalCap; strict=false)
-    Extents.within(small::SphericalCap, big::SphericalCap; strict=false)
 
-Whether the closed cap `big` contains all of `small`. A cap whose radius is at
-least `π` contains the whole unit sphere. `strict` is accepted for consistency
-with the Extents API and has no effect because both inputs use the same domain.
+Whether the closed cap `big` contains all of `small`.
 """
 function Extents.contains(big::SphericalCap, small::SphericalCap; strict=false)
     big.radius >= oftype(big.radius, π) && return true
@@ -166,6 +163,11 @@ function Extents.contains(big::SphericalCap, small::SphericalCap; strict=false)
     # S2's `S2Cap::Contains(const S2Cap&)` convention.
     return dist + small.radius <= big.radius
 end
+"""
+    Extents.within(small::SphericalCap, big::SphericalCap; strict=false)
+
+Whether the closed cap `small` is within `big`.
+"""
 Extents.within(small::SphericalCap, big::SphericalCap; strict=false) =
     Extents.contains(big, small; strict)
 
@@ -181,10 +183,7 @@ end
 """
     Extents.intersects(x::SphericalCap, y::SphericalCap)
 
-Whether the two closed caps intersect. Tangency counts as intersection. The
-comparison delegates to the cap predicate's guarded squared-chord test, which
-retains precision for nearly coincident centres and falls back to angular
-distance only inside its uncertainty band.
+Whether the two closed caps intersect, including at tangency.
 """
 Extents.intersects(x::SphericalCap, y::SphericalCap) = _intersects(x, y)
 
@@ -253,10 +252,7 @@ end
 """
     Extents.grow(cap::SphericalCap, factor::Real) -> SphericalCap
 
-Grow the cap's angular diameter by `factor` on each side, matching the scalar
-`Extents.grow` convention. Positive growth is rounded outward and capped at
-`π`; zero returns `cap` unchanged. A factor of `0.5` therefore doubles the
-radius. Negative factors shrink it, provided the resulting radius is valid.
+Grow the cap's angular diameter by `factor` on each side.
 """
 function Extents.grow(cap::SphericalCap{T}, factor::Real) where {T <: AbstractFloat}
     δ = convert(T, factor)
@@ -271,11 +267,14 @@ end
 """
     Extents.union(x::SphericalCap, y::SphericalCap; strict=false) -> SphericalCap
 
-Return a cap containing both `x` and `y`. If either input already contains the
-other it is returned unchanged. Otherwise the centre lies between the input
-centres and the radius is rounded outward to preserve coverage. `strict` is
-accepted for consistency with the Extents API and has no effect because both
-inputs use the same domain.
+Return a cap containing both `x` and `y`.
+
+If either input already contains the other it is returned unchanged.
+Otherwise, the centre lies between the input caps' centres, and the radius is
+rounded outward to preserve coverage.
+
+`strict` is accepted for consistency with the Extents API and has no effect
+because both inputs use the same domain.
 """
 function Extents.union(x::SphericalCap, y::SphericalCap; strict=false)
     Extents.contains(x, y; strict) && return x

--- a/test/utils/unitspherical.jl
+++ b/test/utils/unitspherical.jl
@@ -259,21 +259,49 @@ end
         # Create two caps that intersect
         cap1 = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π/4)
         cap2 = SphericalCap(UnitSphericalPoint(1/√2, 1/√2, 0.0), π/4)
-        @test UnitSpherical._intersects(cap1, cap2)
-        @test UnitSpherical._intersects(cap2, cap1)
+        @test Extents.intersects(cap1, cap2)
+        @test Extents.intersects(cap2, cap1)
         @test !UnitSpherical._disjoint(cap1, cap2)
 
         # Create two caps that don't intersect
         cap3 = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π/8)
         cap4 = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), π/8)
-        @test !UnitSpherical._intersects(cap3, cap4)
+        @test !Extents.intersects(cap3, cap4)
         @test UnitSpherical._disjoint(cap3, cap4)
 
         # Test containment
         big_cap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π/2)
         small_cap = SphericalCap(UnitSphericalPoint(1/√2, 1/√2, 0.0), π/4)
-        @test UnitSpherical._contains(big_cap, small_cap)
-        @test !UnitSpherical._contains(small_cap, big_cap)
+        @test cap_contains(big_cap, small_cap)
+        @test !cap_contains(small_cap, big_cap)
+    end
+
+    @testset "ULP-near contact and coincident centres" begin
+        centre = UnitSphericalPoint(1.0, 0.0, 0.0)
+        for θ in (1e-10, 0.75, π / 2)
+            other = UnitSphericalPoint(cos(θ), sin(θ), 0.0)
+            contact = spherical_distance(centre, other)
+            pointcap = SphericalCap(other, 0.0)
+            @test !Extents.intersects(SphericalCap(centre, prevfloat(contact)), pointcap)
+            @test Extents.intersects(SphericalCap(centre, contact), pointcap)
+            @test Extents.intersects(SphericalCap(centre, nextfloat(contact)), pointcap)
+        end
+
+        pointcap = SphericalCap(centre, 0.0)
+        same = SphericalCap(centre, 0.0)
+        wider = SphericalCap(centre, 0.25)
+        @test Extents.intersects(pointcap, same)
+        @test cap_contains(pointcap, same)
+        @test cap_contains(wider, pointcap)
+        @test !cap_contains(pointcap, wider)
+        @test merge_caps(pointcap, same) === pointcap
+        @test merge_caps(wider, pointcap) === wider
+        @test merge_caps(pointcap, wider) === wider
+
+        whole = SphericalCap(centre, π)
+        antipode = UnitSphericalPoint(-1.0, 0.0, 0.0)
+        @test cap_contains(whole, antipode)
+        @test cap_contains(whole, SphericalCap(antipode, π / 3))
     end
 
     @testset "Circumcenter and circumradius" begin
@@ -416,15 +444,45 @@ end
             r2 = deg2rad(r2)
             cap1 = SphericalCap(p1, r1)
             cap2 = SphericalCap(p2, r2)
-            capmerged = UnitSpherical._merge(cap1, cap2)
+            capmerged = merge_caps(cap1, cap2)
             @test all(isapprox.(GeographicFromUnitSphere()(capmerged.point), pmerged))
             @test isapprox(capmerged.radius, deg2rad(rmerged))
+            @test cap_contains(capmerged, cap1)
+            @test cap_contains(capmerged, cap2)
         end
 
         test_merge((10.0, 0.0), (30.0, 0.0), 5, 10, (22.5, 0.0), 17.5)
         test_merge((10.0, 0.0), (30.0, 0.0), 15, 10, (17.5, 0.0), 22.5)
         test_merge((10.0, 0.0), (30.0, 0.0), 40, 5, (10.0, 0.0), 40.0)
         test_merge((10.0, 0.0), (30.0, 0.0), 5, 50, (30.0, 0.0), 50.0)
+
+        east = UnitSphericalPoint(1.0, 0.0, 0.0)
+        west = UnitSphericalPoint(-1.0, 0.0, 0.0)
+        antipodal_merge = merge_caps(SphericalCap(east, 0.0), SphericalCap(west, 0.0))
+        @test cap_contains(antipodal_merge, east)
+        @test cap_contains(antipodal_merge, west)
+        wide_merge = merge_caps(SphericalCap(east, 3π / 4), SphericalCap(west, 3π / 4))
+        @test wide_merge.radius == Float64(π)
+        @test cap_contains(wide_merge, SphericalCap(east, 3π / 4))
+        @test cap_contains(wide_merge, SphericalCap(west, 3π / 4))
+
+        using Random: Xoshiro
+        rng = Xoshiro(0xcafecafe)
+        for _ in 1:100
+            a = SphericalCap(rand(rng, UnitSphericalPoint{Float64}), 0.4 * rand(rng))
+            b = SphericalCap(rand(rng, UnitSphericalPoint{Float64}), 0.4 * rand(rng))
+            merged = merge_caps(a, b)
+            @test cap_contains(merged, a)
+            @test cap_contains(merged, b)
+        end
+
+        cap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 0.2)
+        @test dilate_cap(cap, 0.0) === cap
+        dilated = dilate_cap(cap, 0.3)
+        @test dilated.radius > 0.5
+        @test cap_contains(dilated, cap)
+        @test dilate_cap(cap, π).radius == Float64(π)
+        @test_throws DomainError dilate_cap(cap, -0.1)
     end
 end
 
@@ -546,6 +604,67 @@ end
     result = spherical_arc_intersection(a7, b7, a8, b8)
     @test result.type == arc_overlap
     @test length(result.points) == 2
+end
+
+@testset "Spherical cap XYZ bounds" begin
+    in_extent(p, ext) =
+        ext.X[1] <= p[1] <= ext.X[2] &&
+        ext.Y[1] <= p[2] <= ext.Y[2] &&
+        ext.Z[1] <= p[3] <= ext.Z[2]
+
+    function boundary_points(cap, n = 72)
+        c = collect(cap.point)
+        axis = abs(c[3]) < 0.9 ? [0.0, 0.0, 1.0] : [1.0, 0.0, 0.0]
+        u = normalize(cross(c, axis))
+        v = cross(c, u)
+        return [UnitSphericalPoint(Tuple(
+            cos(cap.radius) .* c .+
+            sin(cap.radius) .* (cos(ϕ) .* u .+ sin(ϕ) .* v)))
+            for ϕ in range(0.0, 2π; length = n + 1)[1:end-1]]
+    end
+
+    tiny = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 1e-12)
+    tiny_ext = cap_xyz_extent(tiny)
+    @test tiny_ext.X[1] <= cos(tiny.radius) <= tiny_ext.X[2]
+    @test tiny_ext.Y[1] <= -sin(tiny.radius) < sin(tiny.radius) <= tiny_ext.Y[2]
+    @test tiny_ext.Z[1] <= -sin(tiny.radius) < sin(tiny.radius) <= tiny_ext.Z[2]
+
+    polar = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), 0.2)
+    polar_ext = cap_xyz_extent(polar)
+    @test polar_ext.X[1] <= -sin(polar.radius) < sin(polar.radius) <= polar_ext.X[2]
+    @test polar_ext.Y[1] <= -sin(polar.radius) < sin(polar.radius) <= polar_ext.Y[2]
+    @test polar_ext.Z[1] <= cos(polar.radius) <= polar_ext.Z[2] == 1.0
+
+    antimeridian = SphericalCap(UnitSphereFromGeographic()((180.0, 0.0)), 0.3)
+    antimeridian_ext = cap_xyz_extent(antimeridian)
+    @test antimeridian_ext.X[1] == -1.0
+    @test antimeridian_ext.X[1] <= -cos(antimeridian.radius) <= antimeridian_ext.X[2]
+    @test antimeridian_ext.Y[1] <= -sin(antimeridian.radius) < sin(antimeridian.radius) <= antimeridian_ext.Y[2]
+
+    hemisphere = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), π / 2)
+    hemisphere_ext = cap_xyz_extent(hemisphere)
+    @test hemisphere_ext.X == (-1.0, 1.0)
+    @test hemisphere_ext.Y == (-1.0, 1.0)
+    @test hemisphere_ext.Z[1] <= 0.0 <= hemisphere_ext.Z[2] == 1.0
+
+    whole = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), nextfloat(Float64(π)))
+    whole_ext = cap_xyz_extent(whole)
+    @test whole_ext == Extents.Extent(X = (-1.0, 1.0), Y = (-1.0, 1.0), Z = (-1.0, 1.0))
+    @test Extents.extent(whole) === nothing
+
+    arbitrary = SphericalCap(normalize(UnitSphericalPoint(1.0, -2.0, 3.0)), 0.7)
+    for cap in (tiny, polar, antimeridian, hemisphere, arbitrary)
+        ext = cap_xyz_extent(cap)
+        @test in_extent(cap.point, ext)
+        @test all(p -> in_extent(p, ext), boundary_points(cap))
+        @test Extents.intersects(cap, ext)
+        @test Extents.intersects(cap, ext) == Extents.intersects(ext, cap)
+    end
+
+    cap32 = SphericalCap(UnitSphericalPoint(0.0f0, 0.0f0, 1.0f0), 0.2f0)
+    ext32 = cap_xyz_extent(cap32)
+    @test ext32.X isa Tuple{Float32, Float32}
+    @test all(p -> in_extent(p, ext32), boundary_points(cap32))
 end
 
 @testset "Cap–extent intersection" begin

--- a/test/utils/unitspherical.jl
+++ b/test/utils/unitspherical.jl
@@ -272,8 +272,11 @@ end
         # Test containment
         big_cap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), π/2)
         small_cap = SphericalCap(UnitSphericalPoint(1/√2, 1/√2, 0.0), π/4)
-        @test cap_contains(big_cap, small_cap)
-        @test !cap_contains(small_cap, big_cap)
+        @test Extents.contains(big_cap, small_cap)
+        @test Extents.within(small_cap, big_cap)
+        @test Extents.contains(big_cap, small_cap; strict=true)
+        @test !Extents.contains(small_cap, big_cap)
+        @test !Extents.within(big_cap, small_cap)
     end
 
     @testset "ULP-near contact and coincident centres" begin
@@ -291,17 +294,18 @@ end
         same = SphericalCap(centre, 0.0)
         wider = SphericalCap(centre, 0.25)
         @test Extents.intersects(pointcap, same)
-        @test cap_contains(pointcap, same)
-        @test cap_contains(wider, pointcap)
-        @test !cap_contains(pointcap, wider)
-        @test merge_caps(pointcap, same) === pointcap
-        @test merge_caps(wider, pointcap) === wider
-        @test merge_caps(pointcap, wider) === wider
+        @test Extents.contains(pointcap, same)
+        @test Extents.contains(wider, pointcap)
+        @test !Extents.contains(pointcap, wider)
+        @test Extents.union(pointcap, same) === pointcap
+        @test Extents.union(wider, pointcap) === wider
+        @test Extents.union(pointcap, wider) === wider
+        @test Extents.union(pointcap, wider; strict=true) === wider
 
         whole = SphericalCap(centre, π)
         antipode = UnitSphericalPoint(-1.0, 0.0, 0.0)
-        @test cap_contains(whole, antipode)
-        @test cap_contains(whole, SphericalCap(antipode, π / 3))
+        @test UnitSpherical._contains(whole, antipode)
+        @test Extents.contains(whole, SphericalCap(antipode, π / 3))
     end
 
     @testset "Circumcenter and circumradius" begin
@@ -438,17 +442,17 @@ end
         end
     end
 
-    @testset "Merging of SphericalCaps" begin
+    @testset "Union and growth of SphericalCaps" begin
         function test_merge(p1, p2, r1, r2, pmerged, rmerged)
             r1 = deg2rad(r1)
             r2 = deg2rad(r2)
             cap1 = SphericalCap(p1, r1)
             cap2 = SphericalCap(p2, r2)
-            capmerged = merge_caps(cap1, cap2)
+            capmerged = Extents.union(cap1, cap2)
             @test all(isapprox.(GeographicFromUnitSphere()(capmerged.point), pmerged))
             @test isapprox(capmerged.radius, deg2rad(rmerged))
-            @test cap_contains(capmerged, cap1)
-            @test cap_contains(capmerged, cap2)
+            @test Extents.contains(capmerged, cap1)
+            @test Extents.contains(capmerged, cap2)
         end
 
         test_merge((10.0, 0.0), (30.0, 0.0), 5, 10, (22.5, 0.0), 17.5)
@@ -458,31 +462,33 @@ end
 
         east = UnitSphericalPoint(1.0, 0.0, 0.0)
         west = UnitSphericalPoint(-1.0, 0.0, 0.0)
-        antipodal_merge = merge_caps(SphericalCap(east, 0.0), SphericalCap(west, 0.0))
-        @test cap_contains(antipodal_merge, east)
-        @test cap_contains(antipodal_merge, west)
-        wide_merge = merge_caps(SphericalCap(east, 3π / 4), SphericalCap(west, 3π / 4))
+        antipodal_merge = Extents.union(SphericalCap(east, 0.0), SphericalCap(west, 0.0))
+        @test UnitSpherical._contains(antipodal_merge, east)
+        @test UnitSpherical._contains(antipodal_merge, west)
+        wide_merge = Extents.union(SphericalCap(east, 3π / 4), SphericalCap(west, 3π / 4))
         @test wide_merge.radius == Float64(π)
-        @test cap_contains(wide_merge, SphericalCap(east, 3π / 4))
-        @test cap_contains(wide_merge, SphericalCap(west, 3π / 4))
+        @test Extents.contains(wide_merge, SphericalCap(east, 3π / 4))
+        @test Extents.contains(wide_merge, SphericalCap(west, 3π / 4))
 
         using Random: Xoshiro
         rng = Xoshiro(0xcafecafe)
         for _ in 1:100
             a = SphericalCap(rand(rng, UnitSphericalPoint{Float64}), 0.4 * rand(rng))
             b = SphericalCap(rand(rng, UnitSphericalPoint{Float64}), 0.4 * rand(rng))
-            merged = merge_caps(a, b)
-            @test cap_contains(merged, a)
-            @test cap_contains(merged, b)
+            merged = Extents.union(a, b)
+            @test Extents.contains(merged, a)
+            @test Extents.contains(merged, b)
         end
 
         cap = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 0.2)
-        @test dilate_cap(cap, 0.0) === cap
-        dilated = dilate_cap(cap, 0.3)
+        @test Extents.grow(cap, 0.0) === cap
+        dilated = Extents.grow(cap, 0.75)
         @test dilated.radius > 0.5
-        @test cap_contains(dilated, cap)
-        @test dilate_cap(cap, π).radius == Float64(π)
-        @test_throws DomainError dilate_cap(cap, -0.1)
+        @test Extents.contains(dilated, cap)
+        @test Extents.grow(cap, 0.5).radius > 2 * cap.radius
+        @test Extents.grow(cap, 10.0).radius == Float64(π)
+        @test Extents.grow(cap, -0.25).radius == cap.radius / 2
+        @test_throws DomainError Extents.grow(cap, -0.75)
     end
 end
 
@@ -624,37 +630,36 @@ end
     end
 
     tiny = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 1e-12)
-    tiny_ext = cap_xyz_extent(tiny)
+    tiny_ext = Extents.extent(tiny)
     @test tiny_ext.X[1] <= cos(tiny.radius) <= tiny_ext.X[2]
     @test tiny_ext.Y[1] <= -sin(tiny.radius) < sin(tiny.radius) <= tiny_ext.Y[2]
     @test tiny_ext.Z[1] <= -sin(tiny.radius) < sin(tiny.radius) <= tiny_ext.Z[2]
 
     polar = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), 0.2)
-    polar_ext = cap_xyz_extent(polar)
+    polar_ext = Extents.extent(polar)
     @test polar_ext.X[1] <= -sin(polar.radius) < sin(polar.radius) <= polar_ext.X[2]
     @test polar_ext.Y[1] <= -sin(polar.radius) < sin(polar.radius) <= polar_ext.Y[2]
     @test polar_ext.Z[1] <= cos(polar.radius) <= polar_ext.Z[2] == 1.0
 
     antimeridian = SphericalCap(UnitSphereFromGeographic()((180.0, 0.0)), 0.3)
-    antimeridian_ext = cap_xyz_extent(antimeridian)
+    antimeridian_ext = Extents.extent(antimeridian)
     @test antimeridian_ext.X[1] == -1.0
     @test antimeridian_ext.X[1] <= -cos(antimeridian.radius) <= antimeridian_ext.X[2]
     @test antimeridian_ext.Y[1] <= -sin(antimeridian.radius) < sin(antimeridian.radius) <= antimeridian_ext.Y[2]
 
     hemisphere = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), π / 2)
-    hemisphere_ext = cap_xyz_extent(hemisphere)
+    hemisphere_ext = Extents.extent(hemisphere)
     @test hemisphere_ext.X == (-1.0, 1.0)
     @test hemisphere_ext.Y == (-1.0, 1.0)
     @test hemisphere_ext.Z[1] <= 0.0 <= hemisphere_ext.Z[2] == 1.0
 
     whole = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), nextfloat(Float64(π)))
-    whole_ext = cap_xyz_extent(whole)
+    whole_ext = Extents.extent(whole)
     @test whole_ext == Extents.Extent(X = (-1.0, 1.0), Y = (-1.0, 1.0), Z = (-1.0, 1.0))
-    @test Extents.extent(whole) === nothing
 
     arbitrary = SphericalCap(normalize(UnitSphericalPoint(1.0, -2.0, 3.0)), 0.7)
     for cap in (tiny, polar, antimeridian, hemisphere, arbitrary)
-        ext = cap_xyz_extent(cap)
+        ext = Extents.extent(cap)
         @test in_extent(cap.point, ext)
         @test all(p -> in_extent(p, ext), boundary_points(cap))
         @test Extents.intersects(cap, ext)
@@ -662,7 +667,7 @@ end
     end
 
     cap32 = SphericalCap(UnitSphericalPoint(0.0f0, 0.0f0, 1.0f0), 0.2f0)
-    ext32 = cap_xyz_extent(cap32)
+    ext32 = Extents.extent(cap32)
     @test ext32.X isa Tuple{Float32, Float32}
     @test all(p -> in_extent(p, ext32), boundary_points(cap32))
 end

--- a/test/utils/unitspherical.jl
+++ b/test/utils/unitspherical.jl
@@ -630,36 +630,42 @@ end
     end
 
     tiny = SphericalCap(UnitSphericalPoint(1.0, 0.0, 0.0), 1e-12)
-    tiny_ext = Extents.extent(tiny)
+    @test which(Extents.extent, (typeof(tiny),)) == which(Extents.extent, (Any,))
+    @test Extents.extent(tiny) === nothing
+    tiny_ext = convert(Extents.Extent, tiny)
+    @test tiny_ext isa Extents.Extent{(:X, :Y, :Z)}
+    @test convert(Extents.Extent{(:X, :Y, :Z)}, tiny) === tiny_ext
+    @test convert(typeof(tiny_ext), tiny) === tiny_ext
+    @test_throws ArgumentError convert(Extents.Extent{(:X, :Y)}, tiny)
     @test tiny_ext.X[1] <= cos(tiny.radius) <= tiny_ext.X[2]
     @test tiny_ext.Y[1] <= -sin(tiny.radius) < sin(tiny.radius) <= tiny_ext.Y[2]
     @test tiny_ext.Z[1] <= -sin(tiny.radius) < sin(tiny.radius) <= tiny_ext.Z[2]
 
     polar = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), 0.2)
-    polar_ext = Extents.extent(polar)
+    polar_ext = convert(Extents.Extent, polar)
     @test polar_ext.X[1] <= -sin(polar.radius) < sin(polar.radius) <= polar_ext.X[2]
     @test polar_ext.Y[1] <= -sin(polar.radius) < sin(polar.radius) <= polar_ext.Y[2]
     @test polar_ext.Z[1] <= cos(polar.radius) <= polar_ext.Z[2] == 1.0
 
     antimeridian = SphericalCap(UnitSphereFromGeographic()((180.0, 0.0)), 0.3)
-    antimeridian_ext = Extents.extent(antimeridian)
+    antimeridian_ext = convert(Extents.Extent, antimeridian)
     @test antimeridian_ext.X[1] == -1.0
     @test antimeridian_ext.X[1] <= -cos(antimeridian.radius) <= antimeridian_ext.X[2]
     @test antimeridian_ext.Y[1] <= -sin(antimeridian.radius) < sin(antimeridian.radius) <= antimeridian_ext.Y[2]
 
     hemisphere = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), π / 2)
-    hemisphere_ext = Extents.extent(hemisphere)
+    hemisphere_ext = convert(Extents.Extent, hemisphere)
     @test hemisphere_ext.X == (-1.0, 1.0)
     @test hemisphere_ext.Y == (-1.0, 1.0)
     @test hemisphere_ext.Z[1] <= 0.0 <= hemisphere_ext.Z[2] == 1.0
 
     whole = SphericalCap(UnitSphericalPoint(0.0, 0.0, 1.0), nextfloat(Float64(π)))
-    whole_ext = Extents.extent(whole)
+    whole_ext = convert(Extents.Extent, whole)
     @test whole_ext == Extents.Extent(X = (-1.0, 1.0), Y = (-1.0, 1.0), Z = (-1.0, 1.0))
 
     arbitrary = SphericalCap(normalize(UnitSphericalPoint(1.0, -2.0, 3.0)), 0.7)
     for cap in (tiny, polar, antimeridian, hemisphere, arbitrary)
-        ext = Extents.extent(cap)
+        ext = convert(Extents.Extent, cap)
         @test in_extent(cap.point, ext)
         @test all(p -> in_extent(p, ext), boundary_points(cap))
         @test Extents.intersects(cap, ext)
@@ -667,7 +673,7 @@ end
     end
 
     cap32 = SphericalCap(UnitSphericalPoint(0.0f0, 0.0f0, 1.0f0), 0.2f0)
-    ext32 = Extents.extent(cap32)
+    ext32 = convert(Extents.Extent, cap32)
     @test ext32.X isa Tuple{Float32, Float32}
     @test all(p -> in_extent(p, ext32), boundary_points(cap32))
 end


### PR DESCRIPTION
Stacked on #476; the diff here is only the cap-primitives work (plus the merge that reconciled the shared predicate commits).

Makes `UnitSpherical.SphericalCap` a public extent primitive (src/utils/UnitSpherical/cap.jl): the cap type and its intersection/containment predicates get a documented public surface so downstream tree searches (ConservativeRegridding's dual DFS) can use caps as node extents generically instead of through private APIs. Consumed downstream by ConservativeRegridding's extent-generic search (see the `claude/regrid-prereqs` PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC7rbi9eqZypWseMjBGSJ2