### PR TITLE
Give the lightweight geometry predicates a `Spherical` path

### DIFF
--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -98,6 +98,7 @@ include("methods/geom_relations/relateng/relate_predicates.jl")
 include("methods/geom_relations/relateng/kernel.jl")
 include("methods/geom_relations/relateng/kernel_planar.jl")
 include("methods/geom_relations/relateng/kernel_spherical.jl")
+include("methods/geom_relations/geom_geom_processors_spherical.jl")
 # Node sections: after the kernel (uses `NodeKey`), before the point locator
 # (AdjacentEdgeLocator builds NodeSections).
 include("methods/geom_relations/relateng/node_sections.jl")

--- a/src/methods/geom_relations/common.jl
+++ b/src/methods/geom_relations/common.jl
@@ -1,6 +1,55 @@
 # Identical boilerplate methods for geom relations live here
 
-for f in (:coveredby, :crosses, :disjoint, :overlaps, :touches, :within)
+#= The manifold-threaded family: every forwarding method carries the manifold
+through to the underlying call. `crosses` and `overlaps` are generated below
+instead, without a manifold, because they still run on their own planar helpers
+rather than the shared processors. =#
+for f in (:coveredby, :disjoint, :touches, :within)
+    _f = Symbol(:_, f)
+
+    @eval begin
+        # Features
+        $_f(m::Manifold, ::GI.FeatureTrait, g1, ::GI.AbstractGeometryTrait, g2; kw...) = $f(m, GI.geometry(g1), g2; kw...)
+        $_f(m::Manifold, ::GI.AbstractGeometryTrait, g1, ::GI.FeatureTrait, g2; kw...) = $f(m, g1, GI.geometry(g2); kw...)
+        $_f(m::Manifold, ::GI.FeatureTrait, g1, ::GI.FeatureTrait, g2; kw...) = $f(m, GI.geometry(g1), GI.geometry(g2); kw...)
+
+        # Extent forwarding
+        $_f(m::Manifold, t1::GI.FeatureTrait, f1, ::GI.RectangleTrait, e::Extents.Extent; kw...) =
+            $_f(m, t1, f1, GI.PolygonTrait(), extent_to_polygon(e); kw...)
+        $_f(m::Manifold, ::GI.RectangleTrait, e1::Extents.Extent, t2::GI.FeatureTrait, f2; kw...) =
+            $_f(m, GI.PolygonTrait(), extent_to_polygon(e1), t2, f2; kw...)
+        $_f(m::Manifold, t1::GI.AbstractGeometryTrait, g1, ::GI.RectangleTrait, e::Extents.Extent; kw...) =
+            $_f(m, t1, g1, GI.PolygonTrait(), extent_to_polygon(e); kw...)
+        $_f(m::Manifold, ::GI.RectangleTrait, e1::Extents.Extent, t2::GI.AbstractGeometryTrait, g2; kw...) =
+            $_f(m, GI.PolygonTrait(), extent_to_polygon(e1), t2, g2; kw...)
+        #= Two bare extents carry no manifold information — they are coordinate
+        boxes, not geometries — so both manifolds answer with the box predicate. =#
+        $_f(m::Manifold, ::GI.RectangleTrait, e1::Extents.Extent, ::GI.RectangleTrait, e2::Extents.Extent; kw...) =
+            Extents.$f(e1, e2)
+
+        # Backwards compatibility for when Extent traits were Nothing
+        $_f(m::Manifold, t1::GI.FeatureTrait, f1, ::Nothing, e::Extents.Extent; kw...) =
+            $_f(m, t1, f1, GI.PolygonTrait(), extent_to_polygon(e); kw...)
+        $_f(m::Manifold, ::Nothing, e1::Extents.Extent, t2::GI.FeatureTrait, f2; kw...) =
+            $_f(m, GI.PolygonTrait(), extent_to_polygon(e1), t2, f2; kw...)
+        $_f(m::Manifold, t1::GI.AbstractGeometryTrait, g1, ::Nothing, e::Extents.Extent; kw...) =
+            $_f(m, t1, g1, GI.PolygonTrait(), extent_to_polygon(e); kw...)
+        $_f(m::Manifold, ::Nothing, e1::Extents.Extent, t2::GI.AbstractGeometryTrait, g2; kw...) =
+            $_f(m, GI.PolygonTrait(), extent_to_polygon(e1), t2, g2; kw...)
+        $_f(m::Manifold, ::Nothing, e1::Extents.Extent, ::Nothing, e2::Extents.Extent; kw...) =
+            Extents.$f(e1, e2)
+
+        # Table rows ? or error
+        $_f(m::Manifold, ::Nothing, g1, ::GI.FeatureTrait, f2; kw...) = $f(m, _geometry_or_error(g1; kw...), f2)
+        $_f(m::Manifold, ::GI.FeatureTrait, f1, ::Nothing, g2; kw...) = $f(m, f1, _geometry_or_error(g2; kw...))
+        $_f(m::Manifold, ::Nothing, g1, ::GI.AbstractGeometryTrait, g2; kw...) = $f(m, _geometry_or_error(g1; kw...), g2)
+        $_f(m::Manifold, ::GI.AbstractGeometryTrait, g1, ::Nothing, g2; kw...) = $f(m, g1, _geometry_or_error(g2; kw...))
+        $_f(m::Manifold, ::Nothing, g1, ::Nothing, g2; kw...) =
+            $f(m, _geometry_or_error(g1; kw...), _geometry_or_error(g2; kw...))
+    end
+end
+
+for f in (:crosses, :overlaps)
     _f = Symbol(:_, f)
 
     @eval begin
@@ -18,8 +67,8 @@ for f in (:coveredby, :crosses, :disjoint, :overlaps, :touches, :within)
             $_f(t1, g1, GI.PolygonTrait(), extent_to_polygon(e); kw...)
         $_f(::GI.RectangleTrait, e1::Extents.Extent, t2::GI.AbstractGeometryTrait, g2; kw...) =
             $_f(GI.PolygonTrait(), extent_to_polygon(e1), t2, g2; kw...)
-        $_f(::GI.RectangleTrait, e1::Extents.Extent, ::GI.RectangleTrait, e2::Extents.Extent; kw...) =          
-            Extents.$f(e1, e2)    
+        $_f(::GI.RectangleTrait, e1::Extents.Extent, ::GI.RectangleTrait, e2::Extents.Extent; kw...) =
+            Extents.$f(e1, e2)
 
         # Backwards compatibility for when Extent traits were Nothing
         $_f(t1::GI.FeatureTrait, f1, ::Nothing, e::Extents.Extent; kw...) =
@@ -30,7 +79,7 @@ for f in (:coveredby, :crosses, :disjoint, :overlaps, :touches, :within)
             $_f(t1, g1, GI.PolygonTrait(), extent_to_polygon(e); kw...)
         $_f(::Nothing, e1::Extents.Extent, t2::GI.AbstractGeometryTrait, g2; kw...) =
             $_f(GI.PolygonTrait(), extent_to_polygon(e1), t2, g2; kw...)
-        $_f(::Nothing, e1::Extents.Extent, ::Nothing, e2::Extents.Extent; kw...) =          
+        $_f(::Nothing, e1::Extents.Extent, ::Nothing, e2::Extents.Extent; kw...) =
             Extents.$f(e1, e2)
 
         # Table rows ? or error
@@ -38,7 +87,12 @@ for f in (:coveredby, :crosses, :disjoint, :overlaps, :touches, :within)
         $_f(::GI.FeatureTrait, f1, ::Nothing, g2; kw...) = $f(f1, _geometry_or_error(g2; kw...))
         $_f(::Nothing, g1, ::GI.AbstractGeometryTrait, g2; kw...) = $f(_geometry_or_error(g1; kw...), g2)
         $_f(::GI.AbstractGeometryTrait, g1, ::Nothing, g2; kw...) = $f(g1, _geometry_or_error(g2; kw...))
-        $_f(::Nothing, g1, ::Nothing, g2; kw...) =                                          
-            $f(_geometry_or_error(g1; kw...), _geometry_or_error(g2; kw...))    
-        end
+        $_f(::Nothing, g1, ::Nothing, g2; kw...) =
+            $f(_geometry_or_error(g1; kw...), _geometry_or_error(g2; kw...))
+    end
 end
+
+@noinline _throw_no_manifold_predicate(f, m) = throw(ArgumentError(
+    "`$(f)` has no $(typeof(m).name.name) implementation: it is still on the " *
+    "legacy planar path rather than the shared geometry-relation processors. " *
+    "Use `relate_predicate(RelateNG($m), pred_$(f)(), a, b)` instead."))

--- a/src/methods/geom_relations/contains.jl
+++ b/src/methods/geom_relations/contains.jl
@@ -63,6 +63,7 @@ true
 ```
 """
 contains(g1, g2) = GeometryOps.within(g2, g1)
+contains(m::Manifold, g1, g2) = GeometryOps.within(m, g2, g1)
 
 """
     contains(g1)

--- a/src/methods/geom_relations/coveredby.jl
+++ b/src/methods/geom_relations/coveredby.jl
@@ -56,7 +56,7 @@ const COVEREDBY_POLYGON_REQUIRES = (in_require = true, on_require = false, out_r
 const COVEREDBY_EXACT = (exact = False(),)
 
 """
-    coveredby(g1, g2)::Bool
+    coveredby([manifold::Manifold], g1, g2)::Bool
 
 Return `true` if the first geometry is completely covered by the second
 geometry. The interior and boundary of the primary geometry (g1) must not
@@ -77,7 +77,9 @@ GO.coveredby(p1, l1)
 true
 ```
 """
-coveredby(g1, g2) = _coveredby(trait(g1), g1, trait(g2), g2)
+coveredby(g1, g2) = coveredby(Planar(), g1, g2)
+coveredby(::AutoManifold, g1, g2) = coveredby(Planar(), g1, g2)
+coveredby(m::Manifold, g1, g2) = _coveredby(m, trait(g1), g1, trait(g2), g2)
 
 """
     coveredby(g1)
@@ -91,42 +93,47 @@ coveredby(g1) = Base.Fix2(coveredby, g1)
 
 # Point is coveredby another point if those points are equal
 _coveredby(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PointTrait, g2,
 ) = equals(g1, g2)
 
 # Point is coveredby a line/linestring if it is on a line vertex or an edge
 _coveredby(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _point_curve_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_ALLOWS...,
     closed_curve = false,
 )
 
 # Point is coveredby a linearring if it is on a vertex or an edge of ring
 _coveredby(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = _point_curve_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_ALLOWS...,
     closed_curve = true,
 )
 
 # Point is coveredby a polygon if it is inside polygon, including edges/vertices
 _coveredby(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _point_polygon_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_ALLOWS...,
     COVEREDBY_EXACT...,
 )
 
 # Points cannot cover any geometry other than points
 _coveredby(
+    m::Manifold,
     ::Union{GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     ::GI.PointTrait, g2,
 ) = false
@@ -137,10 +144,11 @@ _coveredby(
 #= Linestring is coveredby a line if all interior and boundary points of the
 first line are on the interior/boundary points of the second line. =#
 _coveredby(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_CURVE_ALLOWS...,
     COVEREDBY_CURVE_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -151,10 +159,11 @@ _coveredby(
 #= Linestring is coveredby a ring if all interior and boundary points of the
 line are on the edges of the ring. =#
 _coveredby(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_CURVE_ALLOWS...,
     COVEREDBY_CURVE_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -165,10 +174,11 @@ _coveredby(
 #= Linestring is coveredby a polygon if all interior and boundary points of the
 line are in the polygon interior or on its edges, including hole edges. =#
 _coveredby(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_ALLOWS...,
     COVEREDBY_CURVE_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -180,10 +190,11 @@ _coveredby(
 #= Linearring is covered by a line if all vertices and edges of the ring are on
 the edges and vertices of the line. =#
 _coveredby(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_CURVE_ALLOWS...,
     COVEREDBY_CURVE_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -194,10 +205,11 @@ _coveredby(
 #= Linearring is covered by another linear ring if all vertices and edges of the
 first ring are on the edges/vertices of the second ring. =#
 _coveredby(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_CURVE_ALLOWS...,
     COVEREDBY_CURVE_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -208,10 +220,11 @@ _coveredby(
 #= Linearring is coveredby a polygon if all vertices and edges of the ring are
 in the polygon interior or on the polygon edges, including hole edges. =# 
 _coveredby(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_ALLOWS...,
     COVEREDBY_CURVE_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -225,10 +238,11 @@ _coveredby(
 first polygon are in the second polygon interior or on polygon edges, including
 hole edges.=#
 _coveredby(
+    m::Manifold,
     ::GI.PolygonTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _polygon_polygon_process(
-    g1, g2;
+    m, g1, g2;
     COVEREDBY_ALLOWS...,
     COVEREDBY_POLYGON_REQUIRES...,
     COVEREDBY_EXACT...,
@@ -236,6 +250,7 @@ _coveredby(
 
 # Polygons cannot covered by any curves
 _coveredby(
+    m::Manifold,
     ::GI.PolygonTrait, g1,
     ::GI.AbstractCurveTrait, g2,
 ) = false
@@ -246,6 +261,7 @@ _coveredby(
 #= Geometry is covered by a multi-geometry or a collection if one of the elements
 of the collection cover the geometry. =#
 function _coveredby(
+    m::Manifold,
     ::Union{GI.PointTrait, GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
@@ -253,7 +269,7 @@ function _coveredby(
     }, g2,
 )
     for sub_g2 in GI.getgeom(g2)
-        coveredby(g1, sub_g2) && return true
+        coveredby(m, g1, sub_g2) && return true
     end
     return false
 end
@@ -263,6 +279,7 @@ end
 #= Multi-geometry or a geometry collection is covered by a geometry if all
 elements of the collection are covered by the geometry. =#
 function _coveredby(
+    m::Manifold,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
@@ -270,7 +287,7 @@ function _coveredby(
     ::GI.AbstractGeometryTrait, g2,
 )
     for sub_g1 in GI.getgeom(g1)
-        !coveredby(sub_g1, g2) && return false
+        !coveredby(m, sub_g1, g2) && return false
     end
     return true
 end

--- a/src/methods/geom_relations/covers.jl
+++ b/src/methods/geom_relations/covers.jl
@@ -62,6 +62,7 @@ true
 ```
 """
 covers(g1, g2)::Bool = GeometryOps.coveredby(g2, g1)
+covers(m::Manifold, g1, g2)::Bool = GeometryOps.coveredby(m, g2, g1)
 
 """
     covers(g1)

--- a/src/methods/geom_relations/crosses.jl
+++ b/src/methods/geom_relations/crosses.jl
@@ -33,6 +33,14 @@ This is equivalent to `x -> crosses(x, g1)`.
 """
 crosses(g1) = Base.Fix2(crosses, g1)
 
+#= `crosses` still runs on its own planar helpers rather than the shared
+processors (see the `TODO` below), so it has no spherical implementation.
+Answering a `Spherical()` call with the planar result would be silently wrong,
+so it errors instead. =#
+crosses(::Planar, g1, g2) = crosses(g1, g2)
+crosses(::AutoManifold, g1, g2) = crosses(g1, g2)
+crosses(m::Manifold, g1, g2) = _throw_no_manifold_predicate(crosses, m)
+
 
 
 function multipoint_crosses_line(geom1, geom2)

--- a/src/methods/geom_relations/disjoint.jl
+++ b/src/methods/geom_relations/disjoint.jl
@@ -54,7 +54,7 @@ const DISJOINT_REQUIRES = (in_require = false, on_require = false, out_require =
 const DISJOINT_EXACT = (exact = False(),)
 
 """
-    disjoint(geom1, geom2)::Bool
+    disjoint([manifold::Manifold], geom1, geom2)::Bool
 
 Return `true` if the first geometry is disjoint from the second geometry.
 
@@ -73,7 +73,9 @@ GO.disjoint(point, line)
 true
 ```
 """
-disjoint(g1, g2) = _disjoint(trait(g1), g1, trait(g2), g2)
+disjoint(g1, g2) = disjoint(Planar(), g1, g2)
+disjoint(::AutoManifold, g1, g2) = disjoint(Planar(), g1, g2)
+disjoint(m::Manifold, g1, g2) = _disjoint(m, trait(g1), g1, trait(g2), g2)
 
 """
     disjoint(g1)
@@ -87,26 +89,29 @@ disjoint(g1) = Base.Fix2(disjoint, g1)
 
 # Point is disjoint from another point if the points are not equal.
 _disjoint(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PointTrait, g2,
 ) = !equals(g1, g2)
 
 # Point is disjoint from a linestring if it is not on the line's edges/vertices.
 _disjoint(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _point_curve_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_ALLOWS...,
     closed_curve = false,
 )
 
 # Point is disjoint from a linearring if it is not on the ring's edges/vertices. 
 _disjoint(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = _point_curve_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_ALLOWS...,
     closed_curve = true,
 )
@@ -114,10 +119,11 @@ _disjoint(
 #= Point is disjoint from a polygon if it is not on any edges, vertices, or
 within the polygon's interior. =#
 _disjoint(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _point_polygon_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_ALLOWS...,
     DISJOINT_EXACT...,
 )
@@ -125,9 +131,10 @@ _disjoint(
 #= Geometry is disjoint from a point if the point is not in the interior or on
 the boundary of the geometry. =#
 _disjoint(
+    m::Manifold,
     trait1::Union{GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     trait2::GI.PointTrait, g2,
-) = _disjoint(trait2, g2, trait1, g1)
+) = _disjoint(m, trait2, g2, trait1, g1)
 
 
 # # Lines disjoint geometries
@@ -135,10 +142,11 @@ _disjoint(
 #= Linestring is disjoint from another line if they do not share any interior
 edge/vertex points or boundary points. =#
 _disjoint(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_CURVE_ALLOWS...,
     DISJOINT_REQUIRES...,
     DISJOINT_EXACT...,
@@ -149,10 +157,11 @@ _disjoint(
 #= Linestring is disjoint from a linearring if they do not share any interior
 edge/vertex points or boundary points. =#
 _disjoint(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_CURVE_ALLOWS...,
     DISJOINT_REQUIRES...,
     DISJOINT_EXACT...,
@@ -163,10 +172,11 @@ _disjoint(
 #= Linestring is disjoint from a polygon if the interior and boundary points of
 the line are not in the polygon's interior or on the polygon's boundary. =# 
 _disjoint(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_ALLOWS...,
     DISJOINT_REQUIRES...,
     DISJOINT_EXACT...,
@@ -176,9 +186,10 @@ _disjoint(
 #= Geometry is disjoint from a linestring if the line's interior and boundary
 points don't intersect with the geometry's interior and boundary points. =#
 _disjoint(
+    m::Manifold,
     trait1::Union{GI.LinearRingTrait, GI.PolygonTrait}, g1,
     trait2::Union{GI.LineTrait, GI.LineStringTrait}, g2,
-) = _disjoint(trait2, g2, trait1, g1)
+) = _disjoint(m, trait2, g2, trait1, g1)
 
 
 # # Rings disjoint geometries
@@ -186,10 +197,11 @@ _disjoint(
 #= Linearrings is disjoint from another linearring if they do not share any
 interior edge/vertex points or boundary points.=#
 _disjoint(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_CURVE_ALLOWS...,
     DISJOINT_REQUIRES...,
     DISJOINT_EXACT...,
@@ -200,10 +212,11 @@ _disjoint(
 #= Linearring is disjoint from a polygon if the interior and boundary points of
 the ring are not in the polygon's interior or on the polygon's boundary. =# 
 _disjoint(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_ALLOWS...,
     DISJOINT_REQUIRES...,
     DISJOINT_EXACT...,
@@ -215,10 +228,11 @@ _disjoint(
 #= Polygon is disjoint from another polygon if they do not share any edges or
 vertices and if their interiors do not intersect, excluding any holes. =#
 _disjoint(
+    m::Manifold,
     ::GI.PolygonTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _polygon_polygon_process(
-    g1, g2;
+    m, g1, g2;
     DISJOINT_ALLOWS...,
     DISJOINT_REQUIRES...,
     DISJOINT_EXACT...,
@@ -230,6 +244,7 @@ _disjoint(
 #= Geometry is disjoint from a multi-geometry or a collection if all of the
 elements of the collection are disjoint from the geometry. =#
 function _disjoint(
+    m::Manifold,
     ::Union{GI.PointTrait, GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
@@ -237,7 +252,7 @@ function _disjoint(
     }, g2,
 )
     for sub_g2 in GI.getgeom(g2)
-        !disjoint(g1, sub_g2) && return false
+        !disjoint(m, g1, sub_g2) && return false
     end
     return true
 end
@@ -247,6 +262,7 @@ end
 #= Multi-geometry or a geometry collection is covered by a geometry if all
 elements of the collection are covered by the geometry. =#
 function _disjoint(
+    m::Manifold,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
@@ -254,7 +270,7 @@ function _disjoint(
     ::GI.AbstractGeometryTrait, g2,
 )
     for sub_g1 in GI.getgeom(g1)
-        !disjoint(sub_g1, g2) && return false
+        !disjoint(m, sub_g1, g2) && return false
     end
     return true
 end

--- a/src/methods/geom_relations/geom_geom_processors.jl
+++ b/src/methods/geom_relations/geom_geom_processors.jl
@@ -25,7 +25,7 @@ If closed_curve is true, curve is treated as a closed curve where the first and
 last point are connected by a segment.
 =#
 function _point_curve_process(
-    point, curve;
+    m::Manifold, point, curve;
     in_allow, on_allow, out_allow,
     closed_curve = false,
 )
@@ -38,7 +38,7 @@ function _point_curve_process(
     p_start = GI.getpoint(curve, closed_curve ? n : 1)
     @inbounds for i in (closed_curve ? 1 : 2):n
         p_end = GI.getpoint(curve, i)
-        seg_val = _point_segment_orientation(point, p_start, p_end)
+        seg_val = _point_segment_orientation(m, point, p_start, p_end)
         seg_val == point_in && return in_allow
         if seg_val == point_on
             if !closed_curve  # if point is on curve endpoints, it is "on"
@@ -62,13 +62,13 @@ If out_allow is true, the point can be disjoint from the polygon.
 If the point is in an "allowed" location, return true. Else, return false.
 =#
 function _point_polygon_process(
-    point, polygon;
+    m::Manifold, point, polygon;
     in_allow, on_allow, out_allow, exact,
 )
-    skip, returnval = _maybe_skip_disjoint_extents(point, polygon; in_allow, on_allow, out_allow, on_require = false, out_require = false, in_require = false)
+    skip, returnval = _maybe_skip_disjoint_extents(m, point, polygon; in_allow, on_allow, out_allow, on_require = false, out_require = false, in_require = false)
     skip && return returnval
     # Check interaction of geom with polygon's exterior boundary
-    ext_val = _point_filled_curve_orientation(point, GI.getexterior(polygon); exact)
+    ext_val = _point_filled_curve_orientation(m, point, GI.getexterior(polygon); exact)
     # If a point is outside, it isn't interacting with any holes
     ext_val == point_out && return out_allow
     # if a point is on an external boundary, it isn't interacting with any holes
@@ -76,7 +76,7 @@ function _point_polygon_process(
     
     # If geom is within the polygon, need to check interactions with holes
     for hole in GI.gethole(polygon)
-        hole_val = _point_filled_curve_orientation(point, hole; exact)
+        hole_val = _point_filled_curve_orientation(m, point, hole; exact)
         # If a point in in a hole, it is outside of the polygon
         hole_val == point_in && return out_allow
         # If a point in on a hole edge, it is on the edge of the polygon
@@ -109,19 +109,19 @@ Else, return false.
 If closed_line is true, line is treated as a closed line where the first and
 last point are connected by a segment. Same with closed_curve.
 =#
-@inline function _line_curve_process(line, curve; 
+@inline function _line_curve_process(m::Manifold, line, curve; 
     over_allow, cross_allow, kw...
 )
-    skip, returnval = _maybe_skip_disjoint_extents(line, curve;
+    skip, returnval = _maybe_skip_disjoint_extents(m, line, curve;
         in_allow=(over_allow | cross_allow), kw...
     )
     skip && return returnval
 
-    return _inner_line_curve_process(line, curve; over_allow, cross_allow, kw...)
+    return _inner_line_curve_process(m, line, curve; over_allow, cross_allow, kw...)
 end
 
 function _inner_line_curve_process(
-    line, curve;
+    m::Manifold, line, curve;
     over_allow, cross_allow, on_allow, out_allow,
     in_require, on_require, out_require,
     closed_line = false, closed_curve = false,
@@ -150,16 +150,16 @@ function _inner_line_curve_process(
         for j in (closed_curve ? 1 : 2):nc
             c_end = _tuple_point(GI.getpoint(curve, j))
             # Check if line and curve segments meet
-            seg_val, intr1, _ = _intersection_point(Float64, (l_start, l_end), (c_start, c_end); exact)
+            seg_val, α, β = _seg_seg_orientation(m, l_start, l_end, c_start, c_end; exact)
             # If segments are co-linear
             if seg_val == line_over
                 !over_allow && return false
                 # at least one point in, meets requirements
                 in_req_met = true
-                point_val = _point_segment_orientation(l_start, c_start, c_end)
+                point_val = _point_segment_orientation(m, l_start, c_start, c_end)
                 # If entire segment isn't covered, consider remaining section
                 if point_val != point_out
-                    i, l_start, break_off = _find_new_seg(i, l_start, l_end, c_start, c_end)
+                    i, l_start, break_off = _find_new_seg(m, i, l_start, l_end, c_start, c_end)
                     break_off && break
                 end
             else
@@ -167,8 +167,7 @@ function _inner_line_curve_process(
                     !cross_allow && return false
                     in_req_met = true
                 elseif seg_val == line_hinge  # could cross or overlap
-                    # Determine location of intersection point on each segment
-                    (_, (α, β)) = intr1
+                    # `α`/`β` locate the intersection along each segment
                     if ( # Don't consider edges of curves as they can't cross
                         (!closed_line && ((α == 0 && i == 2) || (α == 1 && i == nl))) ||
                         (!closed_curve && ((β == 0 && j == 2) || (β == 1 && j == nc)))
@@ -184,7 +183,7 @@ function _inner_line_curve_process(
                                 α, β, l_start, l_end, c_start, c_end,
                                 i, line, j, curve,
                             )
-                            next_val, _, _ = _intersection_point(Float64, l, c; exact)
+                            next_val, _, _ = _seg_seg_orientation(m, l[1], l[2], c[1], c[2]; exact)
                             if next_val == line_hinge
                                 !cross_allow && return false
                             else
@@ -211,14 +210,14 @@ end
 
 #= If entire segment (le to ls) isn't covered by segment (cs to ce), find remaining section
 part of section outside of cs to ce. If completely covered, increase segment index i. =#
-function _find_new_seg(i, ls, le, cs, ce)
+function _find_new_seg(m::Manifold, i, ls, le, cs, ce)
     break_off = true
-    if _point_segment_orientation(le, cs, ce) != point_out
+    if _point_segment_orientation(m, le, cs, ce) != point_out
         ls = le
         i += 1
-    elseif !equals(ls, cs) && _point_segment_orientation(cs, ls, le) != point_out
+    elseif !equals(ls, cs) && _point_segment_orientation(m, cs, ls, le) != point_out
         ls = cs
-    elseif !equals(ls, ce) && _point_segment_orientation(ce, ls, le) != point_out
+    elseif !equals(ls, ce) && _point_segment_orientation(m, ce, ls, le) != point_out
         ls = ce
     else
         break_off = false
@@ -259,14 +258,14 @@ Else, return false.
 If closed_line is true, line is treated as a closed line where the first and
 last point are connected by a segment.
 =#
-@inline function _line_polygon_process(line, polygon; kw...)
-    skip, returnval = _maybe_skip_disjoint_extents(line, polygon; kw...)
+@inline function _line_polygon_process(m::Manifold, line, polygon; kw...)
+    skip, returnval = _maybe_skip_disjoint_extents(m, line, polygon; kw...)
     skip && return returnval
-    return _inner_line_polygon_process(line, polygon; kw...)
+    return _inner_line_polygon_process(m, line, polygon; kw...)
 end
 
 function _inner_line_polygon_process(
-    line, polygon;
+    m::Manifold, line, polygon;
     in_allow, on_allow, out_allow,
     in_require, on_require, out_require,
     exact, closed_line = false,
@@ -276,7 +275,7 @@ function _inner_line_polygon_process(
     out_req_met = !out_require
     # Check interaction of line with polygon's exterior boundary
     in_curve, on_curve, out_curve = _line_filled_curve_interactions(
-        line, GI.getexterior(polygon);
+        m, line, GI.getexterior(polygon);
         exact, closed_line = closed_line,
     )
     if on_curve
@@ -293,7 +292,7 @@ function _inner_line_polygon_process(
     # Loop over polygon holes
     for hole in GI.gethole(polygon)
         in_hole, on_hole, out_hole =_line_filled_curve_interactions(
-            line, hole;
+            m, line, hole;
             exact, closed_line = closed_line,
         )
         if in_hole  # line in hole is equivalent to being out of polygon
@@ -334,14 +333,14 @@ If out_require is true, the first polygon must have at least one interior point
 If the point is in an "allowed" location and meets all requirements, return true.
 Else, return false.
 =#
-@inline function _polygon_polygon_process(poly1, poly2; kw...)
-    skip, returnval = _maybe_skip_disjoint_extents(poly1, poly2; kw...)
+@inline function _polygon_polygon_process(m::Manifold, poly1, poly2; kw...)
+    skip, returnval = _maybe_skip_disjoint_extents(m, poly1, poly2; kw...)
     skip && return returnval
-    return _inner_polygon_polygon_process(poly1, poly2; kw...)
+    return _inner_polygon_polygon_process(m, poly1, poly2; kw...)
 end
 
 function _inner_polygon_polygon_process(
-    poly1, poly2;
+    m::Manifold, poly1, poly2;
     in_allow, on_allow, out_allow,
     in_require, on_require, out_require,
     exact,
@@ -354,7 +353,7 @@ function _inner_polygon_polygon_process(
     ext2 = GI.getexterior(poly2)
     # Check if exterior of poly1 is in polygon 2
     e1_in_p2, e1_on_p2, e1_out_p2 = _line_polygon_interactions(
-        ext1, poly2;
+        m, ext1, poly2;
         exact, closed_line = true,
     )
     if e1_on_p2
@@ -369,7 +368,7 @@ function _inner_polygon_polygon_process(
     if !e1_in_p2
         # if exterior ring isn't in poly2, check if it surrounds poly2
         _, _, e2_out_e1 = _line_filled_curve_interactions(
-            ext2, ext1;
+            m, ext2, ext1;
             exact, closed_line = true,
         )  # if they really are disjoint, we are done
         e2_out_e1 && return in_req_met && on_req_met && out_req_met
@@ -377,7 +376,7 @@ function _inner_polygon_polygon_process(
     # If interiors interact, check if poly2 interacts with any of poly1's holes
     for h1 in GI.gethole(poly1)
         h1_in_p2, h1_on_p2, h1_out_p2 = _line_polygon_interactions(
-            h1, poly2;
+            m, h1, poly2;
             exact, closed_line = true,
         )
         if h1_on_p2
@@ -391,7 +390,7 @@ function _inner_polygon_polygon_process(
         if !h1_in_p2
             # If hole isn't in poly2, see if poly2 is in hole
             _, _, e2_out_h1 = _line_filled_curve_interactions(
-                ext2, h1;
+                m, ext2, h1;
                 exact, closed_line = true,
             )
             # hole encompasses all of poly2
@@ -409,7 +408,7 @@ function _inner_polygon_polygon_process(
     # If any of poly2 holes are within poly1, part of poly1 is exterior to poly2
     for h2 in GI.gethole(poly2)
         h2_in_p1, h2_on_p1, _ = _line_polygon_interactions(
-            h2, poly1;
+            m, h2, poly1;
             exact, closed_line = true,
         )
         if h2_on_p1
@@ -437,7 +436,7 @@ Can provide values of in, on, and out keywords, which determines return values
 for each scenario. 
 =#
 function _point_segment_orientation(
-    point, start, stop;
+    ::Planar, point, start, stop;
     in::T = point_in, on::T = point_on, out::T = point_out,
 ) where {T}
     # Parse out points
@@ -548,7 +547,7 @@ If closed_line is true, line is treated as a closed line where the first and
 last point are connected by a segment.
 =#
 function _line_filled_curve_interactions(
-    line, curve;
+    m::Manifold, line, curve;
     exact, closed_line = false,
 )
     in_curve = false
@@ -566,7 +565,7 @@ function _line_filled_curve_interactions(
 
     # See if first point is in an acceptable orientation
     l_start = _tuple_point(GI.getpoint(line, closed_line ? nl : 1))
-    point_val = _point_filled_curve_orientation(l_start, curve; exact)
+    point_val = _point_filled_curve_orientation(m, l_start, curve; exact)
     if point_val == point_in
         in_curve = true
     elseif point_val == point_on
@@ -585,7 +584,7 @@ function _line_filled_curve_interactions(
         for j in 1:nc
             c_end = _tuple_point(GI.getpoint(curve, j))
             # Check if two line and curve segments meet
-            seg_val, _, _ = _intersection_point(Float64, (l_start, l_end), (c_start, c_end); exact)
+            seg_val, _, _ = _seg_seg_orientation(m, l_start, l_end, c_start, c_end; exact)
             if seg_val != line_out
                 # If line and curve meet, then at least one point is on boundary
                 on_curve = true
@@ -595,8 +594,8 @@ function _line_filled_curve_interactions(
                     out_curve = true
                 else
                     if seg_val == line_over
-                        sp = _point_segment_orientation(l_start, c_start, c_end)
-                        lp = _point_segment_orientation(l_end, c_start, c_end)
+                        sp = _point_segment_orientation(m, l_start, c_start, c_end)
+                        lp = _point_segment_orientation(m, l_end, c_start, c_end)
                         if sp != point_in || lp != point_in
                             #=
                             Line crosses over segment endpoint, creating a hinge
@@ -612,23 +611,9 @@ function _line_filled_curve_interactions(
                         so calculate if segment endpoints and intersections are
                         in/out of filled curve
                         =#
-                        ipoints = intersection_points(GI.Line(StaticArrays.SVector(l_start, l_end)), curve)
-                        npoints = length(ipoints)  # since hinge, at least one
-                        dist_from_lstart = let l_start = l_start
-                            x -> _euclid_distance(Float64, x, l_start)
-                        end
-                        sort!(ipoints, by = dist_from_lstart)
-                        p_start = _tuple_point(l_start)
-                        for i in 1:(npoints + 1)
-                            p_end = i ≤ npoints ? _tuple_point(ipoints[i]) : l_end
-                            mid_val = _point_filled_curve_orientation((p_start .+ p_end) ./ 2, curve; exact)
-                            if mid_val == point_in
-                                in_curve = true
-                            elseif mid_val == point_out
-                                out_curve = true
-                            end
-                            p_start = p_end
-                        end
+                        in_curve, out_curve = _split_segment_interactions(
+                            m, l_start, l_end, curve, in_curve, out_curve; exact,
+                        )
                         # already checked segment against whole filled curve
                         l_start = l_end
                         break
@@ -658,19 +643,19 @@ If closed_line is true, line is treated as a closed line where the first and
 last point are connected by a segment.
 =#
 function _line_polygon_interactions(
-    line, polygon;
+    m::Manifold, line, polygon;
     exact, closed_line = false,
 )
 
     in_poly, on_poly, out_poly = _line_filled_curve_interactions(
-        line, GI.getexterior(polygon);
+        m, line, GI.getexterior(polygon);
         exact, closed_line = closed_line,
     )
     !in_poly && return (in_poly, on_poly, out_poly)
     # Loop over polygon holes
     for hole in GI.gethole(polygon)
         in_hole, on_hole, out_hole =_line_filled_curve_interactions(
-            line, hole;
+            m, line, hole;
             exact, closed_line = closed_line,
         )
         if in_hole
@@ -689,7 +674,7 @@ end
 
 # Disjoint extent optimisation: skip work based on geom extent intersection
 # returns Tuple{Bool, Bool} for (skip, returnval)
-@inline function _maybe_skip_disjoint_extents(a, b;
+@inline function _maybe_skip_disjoint_extents(::Planar, a, b;
     in_allow, on_allow, out_allow, 
     in_require, on_require, out_require,
     kw...
@@ -709,4 +694,58 @@ end
         true, false
     end
     return skip, returnval
+end
+
+#= Planar-defaulting forwarders, matching the one `_point_filled_curve_orientation`
+already carries. The clipping engines call these without a manifold, at call
+sites the codebase has marked `#=TODO: alg.manifold=#` for threading later; until
+that happens they keep their existing planar behaviour. =#
+_line_filled_curve_interactions(line, curve; exact, closed_line = false) =
+    _line_filled_curve_interactions(Planar(), line, curve; exact, closed_line)
+_line_polygon_interactions(line, polygon; exact, closed_line = false) =
+    _line_polygon_interactions(Planar(), line, polygon; exact, closed_line)
+
+#=
+Classify how segments `(a1, a2)` and `(b1, b2)` meet, as one of `line_out`,
+`line_cross`, `line_hinge` or `line_over`, together with the fractions `α` and
+`β` locating the intersection along `(a1, a2)` and `(b1, b2)` respectively.
+
+Callers only ever compare `α`/`β` against `0` and `1` — that is, they ask
+whether the intersection sits on a segment endpoint — so a manifold whose
+classifier is symbolic need only distinguish the endpoints from the interior.
+=#
+@inline function _seg_seg_orientation(m::Planar, a1, a2, b1, b2; exact)
+    seg_val, intr1, _ = _intersection_point(m, Float64, (a1, a2), (b1, b2); exact)
+    (_, (α, β)) = intr1
+    return seg_val, α, β
+end
+
+#=
+Split the segment `l_start → l_end` at every point where it meets `curve`, and
+report whether the resulting pieces run inside and/or outside the filled curve.
+
+Reached when the segment hinges with the curve, which is the one case
+`_line_filled_curve_interactions` cannot settle edge-by-edge: a hinge can pass
+through several further segments. `in_curve` and `out_curve` come in with the
+interactions found so far and go out with this segment's ORed on.
+=#
+function _split_segment_interactions(m::Planar, l_start, l_end, curve, in_curve, out_curve; exact)
+    ipoints = intersection_points(GI.Line(StaticArrays.SVector(l_start, l_end)), curve)
+    npoints = length(ipoints)  # since hinge, at least one
+    dist_from_lstart = let l_start = l_start
+        x -> _euclid_distance(Float64, x, l_start)
+    end
+    sort!(ipoints, by = dist_from_lstart)
+    p_start = _tuple_point(l_start)
+    for i in 1:(npoints + 1)
+        p_end = i ≤ npoints ? _tuple_point(ipoints[i]) : l_end
+        mid_val = _point_filled_curve_orientation(m, (p_start .+ p_end) ./ 2, curve; exact)
+        if mid_val == point_in
+            in_curve = true
+        elseif mid_val == point_out
+            out_curve = true
+        end
+        p_start = p_end
+    end
+    return in_curve, out_curve
 end

--- a/src/methods/geom_relations/geom_geom_processors_spherical.jl
+++ b/src/methods/geom_relations/geom_geom_processors_spherical.jl
@@ -1,0 +1,483 @@
+# # Spherical leaves of the lightweight geometry-relation processors
+
+#=
+The processors in `geom_geom_processors.jl` carry the DE-9IM allow/require
+bookkeeping for `intersects`, `disjoint`, `within`, `contains`, `covers`,
+`coveredby` and `touches`. That bookkeeping is manifold-independent; only four
+geometric leaves are not, and this file supplies their `Spherical` methods:
+
+| leaf | question |
+|:--|:--|
+| `_point_segment_orientation` | is a point on a segment, and is it an endpoint? |
+| `_point_filled_curve_orientation` | is a point in, on, or out of a filled ring? |
+| `_seg_seg_orientation` | how do two segments meet? |
+| `_split_segment_interactions` | does a hinging segment run inside, outside, or both? |
+
+Everything here is allocation-free per call. Two properties buy that. Vertices
+are converted to `UnitSphericalPoint` lazily through
+[`SphericalRingPoints`](@ref) rather than materialized into a `Vector`, so a
+predicate against an unprepared ring still touches no heap. And the segment
+classifier is symbolic — it names the kind of meeting and which vertices are
+incident, and never constructs an intersection coordinate. Constructing one is
+what makes great-circle segment intersection awkward (two antipodal candidate
+points, one of them wrong); not needing one removes the problem from the
+predicate path entirely. The one place a coordinate *is* needed — splitting a
+hinging segment — builds it only after the crossing is known to be proper, which
+is what makes choosing between the two candidates safe there.
+
+## Which tolerance regime, and why not the exact kernel's
+
+Every predicate here is the tolerance-banded `UnitSpherical` one:
+`spherical_orient`, whose `16 * eps` relative band is ~3.5e-15 radians, over a
+span test (`_sph_on_arc`) that is correct for arcs of any length. That is deliberate, and it is not the same choice RelateNG
+makes.
+
+RelateNG's `rk_*` kernel is exact-or-nothing: at `exact = True()` it decides
+degeneracies over `Rational{BigInt}`, and at `exact = False()` it degrades to a
+raw Float64 triple product still compared `== 0`. The `False()` setting is
+therefore unusable here — `(a × b) ⋅ b` is not bit-zero, so a point sitting
+*exactly* on a vertex tests as off the arc, and every boundary case is missed.
+And `True()` is unaffordable: it lifts to `Rational{BigInt}` whenever two arcs
+share a great circle, ~11 KB per call, and two cells sharing an edge is the
+common case in a tiling rather than a corner case.
+
+A banded predicate is the right tier for a lightweight yes/no answer: it costs
+nothing, and it decides the shared-vertex and shared-edge cases that a tiling
+actually produces. Callers who need exact spherical topology want RelateNG.
+
+## Ring semantics
+
+A ring is read as the region it encloses, by even-odd crossing parity against a
+definitionally exterior anchor ([`spherical_ring_encloses`](@ref)). That is the
+spherical counterpart of the planar family's even-odd ray cast, and it is
+winding-independent, so a CW and a CCW spelling of the same ring agree.
+=#
+
+"""
+    SphericalRingPoints(ring)
+
+A ring's vertices as `UnitSphericalPoint`s, converted on indexing rather than
+up front, with any repeated closing vertex excluded from `length`.
+
+Exists so that the spherical predicates can hand a ring to the
+`UnitSpherical` ring primitives — which index into a vector of unit points —
+without allocating that vector. Converting lazily costs one
+`UnitSphereFromGeographic` per access; a ring walked several times in one
+predicate call pays that more than once, which is the trade a prepared target
+would remove.
+"""
+struct SphericalRingPoints{G} <: AbstractVector{UnitSphericalPoint{Float64}}
+    ring::G
+    n::Int
+end
+
+function SphericalRingPoints(ring)
+    n = GI.npoint(ring)
+    #= A closed ring repeats its first vertex; the primitives here take the
+    closing edge as implied, so counting it would place a zero-length edge in
+    the walk. =#
+    if n > 1 && equals(GI.getpoint(ring, 1), GI.getpoint(ring, n))
+        n -= 1
+    end
+    return SphericalRingPoints(ring, n)
+end
+
+Base.size(v::SphericalRingPoints) = (v.n,)
+Base.IndexStyle(::Type{<:SphericalRingPoints}) = IndexLinear()
+Base.@propagate_inbounds Base.getindex(v::SphericalRingPoints, i::Int) =
+    _spherical_kernel_point(GI.getpoint(v.ring, i))
+
+#=
+Whether `p` lies on the closed minor arc `a → b`.
+
+Not `UnitSpherical.point_on_spherical_arc`, whose span test compares cosines
+(`a⋅p ≥ a⋅b` and `b⋅p ≥ a⋅b`). That criterion is only sufficient for arcs
+shorter than a quarter turn: for a long arc it also admits points on the far
+side of `a`. The test arcs here run from a query point to a definitionally
+exterior anchor and are therefore *close to a half turn* by construction, so the
+failure is not exotic — it silently inverts crossing parity, and with it every
+containment answer. (Measured: a ring vertex 9.9° west of the query counted as
+lying on an arc running 175° east.)
+
+The determinant span test `_on_arc_span_authority` is exact in form and correct
+for any arc length; in `Float64` it is allocation-free. The great-circle gate in
+front of it is the banded `spherical_orient`, keeping this in the same tolerance
+regime as everything else in this file.
+=#
+@inline function _sph_on_arc(p, a, b)
+    UnitSpherical.spherical_orient(a, b, p) == 0 || return false
+    return _on_arc_span_authority(False(), p, a, b)
+end
+
+#=
+Move the anchor off `q`'s antipode, if that is where it landed.
+
+The parity walk runs a test arc from `q` to the anchor, which is undefined when
+the two are antipodal — and they are *exactly* antipodal for the most natural
+query there is: a ring's own centre, since the default anchor is the antipode of
+the vertex mass. Without this, locating a cell's centroid inside its own cell
+fails.
+
+The anchor is a free choice of any point in the exterior region, so nudging it a
+milliradian off the antipode is legitimate: a ring whose enclosed region falls
+short of a hemisphere by more than that still has the nudged point outside. Rings
+too close to a hemisphere for that margin are exactly the ones
+`spherical_exterior_anchor` already declines to anchor at all.
+=#
+@inline function _nudge_anchor(z, q)
+    z === nothing && return z
+    dot(q, z) >= -1 + 1e-9 && return z
+    # some direction not parallel to z, made orthogonal to it
+    ref = abs(z[1]) < 0.9 ? UnitSphericalPoint(1.0, 0.0, 0.0) :
+                            UnitSphericalPoint(0.0, 0.0, 1.0)
+    t = ref - dot(ref, z) .* z
+    nt = norm(t)
+    nt == 0 && return z
+    return UnitSphericalPoint(normalize(z + (1e-3 / nt) .* t))
+end
+
+#=
+Locate `q` against the ring `v` (already unit points), returning `in`, `on` or
+`out`.
+
+Mirrors `rk_point_in_ring`, minus the prepared `SphericalKernelRing`: boundary
+membership is settled first by a per-edge scan, then interior membership by
+even-odd parity with boundary points already excluded.
+
+`anchor` is passed in because a caller testing several points against one ring
+(the hinge walk) can compute it once.
+=#
+function _usp_ring_orientation(
+    m::Spherical, v, anchor, q;
+    in::T = point_in, on::T = point_on, out::T = point_out, exact,
+) where {T}
+    n = length(v)
+    n == 0 && return out
+    @inbounds for j in 1:n
+        _sph_on_arc(q, v[j], v[mod1(j + 1, n)]) && return on
+    end
+    # Fewer than three distinct vertices bound no area.
+    n < 3 && return out
+    enc = UnitSpherical.spherical_ring_encloses(v, n, q;
+        anchor = _nudge_anchor(anchor, q),
+        on_arc = Returns(false),      # boundary settled above
+        on_test_arc = _sph_on_arc,    # the near-half-turn arc the default breaks on
+    )
+    enc === nothing && _throw_degenerate_ring_orientation(q)
+    return enc ? in : out
+end
+
+@noinline _throw_degenerate_ring_orientation(q) = throw(ArgumentError(
+    "the lightweight spherical predicates cannot locate the point $(q) against " *
+    "this ring: its vertex mass is degenerate (a near-hemisphere or " *
+    "vertex-symmetric ring), so no definitionally exterior anchor exists. Use " *
+    "`relate_predicate(RelateNG(Spherical()), pred, a, b)`, which falls back to " *
+    "a winding-consistent wedge bootstrap."))
+
+function _point_filled_curve_orientation(
+    m::Spherical, point, curve;
+    in::T = point_in, on::T = point_on, out::T = point_out, exact,
+) where {T}
+    v = SphericalRingPoints(curve)
+    q = _spherical_kernel_point(point)
+    anchor = length(v) >= 3 ? UnitSpherical.spherical_exterior_anchor(v, length(v)) : nothing
+    return _usp_ring_orientation(m, v, anchor, q; in, on, out, exact)
+end
+
+#=
+`on` when `point` is one of the segment's endpoints, `in` when it lies strictly
+between them along the great-circle arc, `out` otherwise — matching the planar
+method's split.
+
+A zero-length segment (`start == stop`, which real rings do carry near polar
+corners) cannot contain a point other than that vertex, and reaching
+`_sph_on_arc` with one is safe: it is a sign and determinant test throughout,
+with no division by the segment direction.
+=#
+function _point_segment_orientation(
+    m::Spherical, point, start, stop;
+    in::T = point_in, on::T = point_on, out::T = point_out,
+) where {T}
+    q = _spherical_kernel_point(point)
+    a = _spherical_kernel_point(start)
+    b = _spherical_kernel_point(stop)
+    (q == a || q == b) && return on
+    return _sph_on_arc(q, a, b) ? in : out
+end
+
+#=
+Map the symbolic arc classification onto the `(orientation, α, β)` the
+processors read.
+
+`α` and `β` locate the meeting along `(a1, a2)` and `(b1, b2)`, but callers only
+ever ask whether either is `0` or `1` — whether the meeting is at a segment
+endpoint. The endpoint incidences answer exactly that, so interior meetings
+report `0.5`: a value that is neither endpoint, and is never compared for
+anything else.
+=#
+function _seg_seg_orientation(m::Spherical, a1, a2, b1, b2; exact)
+    ka1 = _spherical_kernel_point(a1)
+    ka2 = _spherical_kernel_point(a2)
+    kb1 = _spherical_kernel_point(b1)
+    kb2 = _spherical_kernel_point(b2)
+    orient, a0_on_b, a1_on_b, b0_on_a, b1_on_a =
+        _sph_arc_arc_class(ka1, ka2, kb1, kb2)
+    orient === line_out && return line_out, 0.5, 0.5
+    α = a0_on_b ? 0.0 : (a1_on_b ? 1.0 : 0.5)
+    β = b0_on_a ? 0.0 : (b1_on_a ? 1.0 : 0.5)
+    return orient, α, β
+end
+
+#=
+Classify two great-circle arcs, returning the `LineOrientation` and which of the
+four endpoints lies on the other arc.
+
+The shape of the test is the reduction `rk_classify_intersection` documents, run
+on the banded predicates instead of the exact ones: four orientations place each
+arc's endpoints against the other's great circle, endpoint incidences come from
+arc membership, and a proper crossing is the strict straddle pattern in both
+directions. No intersection coordinate is constructed.
+
+Degenerate (zero-length) arcs are settled first. Real rings carry repeated
+vertices — HEALPix rings do near polar corners — and every test below is a sign
+or a dot product, so a zero-length arc produces no division and no NaN; it is
+handled up front only because "the arc's normal" is meaningless for one, not
+because it would misbehave.
+=#
+function _sph_arc_arc_class(a0, a1, b0, b1)
+    adeg = a0 == a1
+    bdeg = b0 == b1
+    if adeg && bdeg
+        same = a0 == b0
+        return (same ? line_hinge : line_out), same, same, same, same
+    elseif adeg
+        on = _sph_on_arc(a0, b0, b1)
+        return (on ? line_hinge : line_out), on, on, on && b0 == a0, on && b1 == a0
+    elseif bdeg
+        on = _sph_on_arc(b0, a0, a1)
+        return (on ? line_hinge : line_out), on && a0 == b0, on && a1 == b0, on, on
+    end
+
+    sab0 = UnitSpherical.spherical_orient(a0, a1, b0)
+    sab1 = UnitSpherical.spherical_orient(a0, a1, b1)
+    sba0 = UnitSpherical.spherical_orient(b0, b1, a0)
+    sba1 = UnitSpherical.spherical_orient(b0, b1, a1)
+
+    a0_on_b = sba0 == 0 && _sph_on_arc(a0, b0, b1)
+    a1_on_b = sba1 == 0 && _sph_on_arc(a1, b0, b1)
+    b0_on_a = sab0 == 0 && _sph_on_arc(b0, a0, a1)
+    b1_on_a = sab1 == 0 && _sph_on_arc(b1, a0, a1)
+
+    if sab0 == 0 && sab1 == 0 && sba0 == 0 && sba1 == 0
+        #= Same great circle. The arcs overlap iff some endpoint of one lies on
+        the other; the overlap is a single point exactly when every incident
+        endpoint is the same point, which is a hinge rather than an overlap. =#
+        (a0_on_b || a1_on_b || b0_on_a || b1_on_a) ||
+            return line_out, false, false, false, false
+        shared = _sole_shared_point(a0, a1, b0, b1, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
+        return (shared ? line_hinge : line_over), a0_on_b, a1_on_b, b0_on_a, b1_on_a
+    end
+
+    (a0_on_b || a1_on_b || b0_on_a || b1_on_a) &&
+        return line_hinge, a0_on_b, a1_on_b, b0_on_a, b1_on_a
+
+    # strict straddle in both directions: a transversal crossing
+    if sab0 != 0 && sab0 == -sab1 && sba0 != 0 && sba0 == -sba1
+        return line_cross, false, false, false, false
+    end
+    return line_out, false, false, false, false
+end
+
+#= Whether every endpoint incidence names one and the same point — a collinear
+abutment rather than an overlap of positive length. =#
+@inline function _sole_shared_point(a0, a1, b0, b1, a0_on_b, a1_on_b, b0_on_a, b1_on_a)
+    p = a0_on_b ? a0 : (a1_on_b ? a1 : (b0_on_a ? b0 : b1))
+    (!a0_on_b || a0 == p) && (!a1_on_b || a1 == p) &&
+        (!b0_on_a || b0 == p) && (!b1_on_a || b1 == p)
+end
+
+#=
+The unit point where arcs `(a0, a1)` and `(b0, b1)` cross, for a pair already
+already classified as a proper crossing.
+
+Two great circles meet at an antipodal pair `±x`; the classification guarantees
+the crossing lies strictly inside both minor arcs, so exactly one of `±x` does,
+and it is the one in the same hemisphere as either arc's midpoint direction.
+That check is what makes choosing between the two candidates safe here — it is
+sound *because* the crossing is already known to be proper, and would not be on
+its own.
+
+Returns `nothing` if the normals are parallel, which a proper crossing cannot
+produce, but which guards the normalization regardless.
+=#
+@inline function _arc_crossing_point(a0, a1, b0, b1)
+    x = cross(cross(a0, a1), cross(b0, b1))
+    nx = norm(x)
+    nx == 0 && return nothing
+    u = x ./ nx
+    return UnitSphericalPoint(dot(u, a0 + a1) < 0 ? -u : u)
+end
+
+#=
+Walk the segment `l_start → l_end` across `curve`, splitting it at every point
+where the two meet, and report whether the pieces run inside and/or outside the
+filled curve.
+
+The planar method materializes every intersection point, sorts them by distance
+from the segment start, and tests each piece's midpoint. This does the same walk
+without the vector or the sort: it repeatedly scans the ring for the split point
+nearest the current position and steps to it.
+
+`dot(A, ·)` decreases monotonically along a minor arc from `A`, so it orders
+split points along the segment without any angle being computed; each step takes
+the largest such value strictly below the current one. Strictly below is what
+terminates the walk — coincident split points are visited once, and the position
+advances every iteration.
+=#
+function _split_segment_interactions(
+    m::Spherical, l_start, l_end, curve, in_curve, out_curve; exact,
+)
+    A = _spherical_kernel_point(l_start)
+    B = _spherical_kernel_point(l_end)
+    v = SphericalRingPoints(curve)
+    n = length(v)
+    (n == 0 || A == B) && return in_curve, out_curve
+    anchor = n >= 3 ? UnitSpherical.spherical_exterior_anchor(v, n) : nothing
+
+    t_end = dot(A, B)
+    p_start = A
+    t_start = one(t_end)
+    while true
+        # the split point nearest the current position, if any is left
+        best_t = t_end
+        best_p = B
+        found = false
+        @inbounds for j in 1:n
+            c0 = v[j]
+            c1 = v[mod1(j + 1, n)]
+            orient, _, _, b0_on_a, b1_on_a = _sph_arc_arc_class(A, B, c0, c1)
+            orient === line_out && continue
+            if orient === line_cross
+                x = _arc_crossing_point(A, B, c0, c1)
+                if x !== nothing
+                    t = dot(A, x)
+                    if t < t_start && t > best_t
+                        best_t, best_p, found = t, x, true
+                    end
+                end
+            else
+                #= Any curve vertex lying on this segment splits it; the
+                classifier's incidence flags name them, so no separate on-arc
+                test (and no second tolerance) is needed. =#
+                if b0_on_a
+                    t = dot(A, c0)
+                    if t < t_start && t > best_t
+                        best_t, best_p, found = t, c0, true
+                    end
+                end
+                if b1_on_a
+                    t = dot(A, c1)
+                    if t < t_start && t > best_t
+                        best_t, best_p, found = t, c1, true
+                    end
+                end
+            end
+        end
+        p_end = found ? best_p : B
+        mid = p_start + p_end
+        nm = norm(mid)
+        if nm > 0
+            mid_val = _usp_ring_orientation(m, v, anchor, UnitSphericalPoint(mid ./ nm); exact)
+            if mid_val == point_in
+                in_curve = true
+            elseif mid_val == point_out
+                out_curve = true
+            end
+        end
+        found || break
+        p_start = p_end
+        t_start = best_t
+    end
+    return in_curve, out_curve
+end
+
+#=
+A bounding cap for any geometry: centred on its normalized vertex mass, with the
+radius that reaches its furthest vertex.
+
+Sound as a *containing* bound because a spherical cap of radius under a quarter
+turn is convex, so the minor arc between two vertices inside the cap stays
+inside it. That is what makes this safe where a lon/lat box is not: a
+great-circle arc bulges poleward of both its endpoints and can leave the box
+that contains them, but it cannot leave the cap that contains them.
+
+Two O(n) passes, no allocation. Returns `nothing` — no shortcut available —
+when the vertex mass is degenerate or the cap would exceed a quarter turn, since
+the convexity argument is what the soundness rests on.
+
+The radius is built from the chord rather than `acos` of the dot product, which
+loses all its precision for the small caps this is most useful on, and is then
+padded: the shortcut may only ever be *more* reluctant to reject.
+=#
+_spherical_bounding_cap(geom) = _spherical_bounding_cap(GI.trait(geom), geom)
+
+# `GI.getpoint` has no `PointTrait` method; a point is its own zero-radius cap.
+_spherical_bounding_cap(::GI.PointTrait, geom) =
+    UnitSpherical.SphericalCap(_spherical_kernel_point(geom), 1e-7)
+
+function _spherical_bounding_cap(::GI.AbstractGeometryTrait, geom)
+    sx = sy = sz = 0.0
+    n = 0
+    for p in GI.getpoint(geom)
+        u = _spherical_kernel_point(p)
+        sx += u[1]; sy += u[2]; sz += u[3]
+        n += 1
+    end
+    n == 0 && return nothing
+    nrm = sqrt(sx * sx + sy * sy + sz * sz)
+    nrm < 1e-9 && return nothing  # vertices spread over a great circle
+    c = UnitSphericalPoint(sx / nrm, sy / nrm, sz / nrm)
+    maxchord2 = 0.0
+    for p in GI.getpoint(geom)
+        u = _spherical_kernel_point(p)
+        dx = c[1] - u[1]; dy = c[2] - u[2]; dz = c[3] - u[3]
+        ch2 = dx * dx + dy * dy + dz * dz
+        ch2 > maxchord2 && (maxchord2 = ch2)
+    end
+    maxchord2 >= 2.0 && return nothing  # radius past a quarter turn
+    r = 2 * asin(sqrt(maxchord2) / 2)
+    return UnitSpherical.SphericalCap(c, r + 1e-7 + 8 * eps(r))
+end
+
+#=
+The planar extent shortcut is unsound on the sphere, so the spherical one
+rejects on bounding caps instead.
+
+Two lon/lat boxes being disjoint does not make the geometries disjoint — a
+great-circle edge can reach outside the latitude range of its own endpoints — so
+inheriting the planar test would answer "disjoint" for geometries that meet.
+Bounding caps carry the same cheap-rejection benefit with a bound that holds on
+the sphere. The disposition of the answer, once the two are known disjoint, is
+the planar method's unchanged.
+
+This matters out of proportion to its size for the workload this path exists
+for: testing many thousands of cells against one target, where nearly every
+candidate is far away and never needed the full walk.
+=#
+@inline function _maybe_skip_disjoint_extents(::Spherical, a, b;
+    in_allow, on_allow, out_allow,
+    in_require, on_require, out_require,
+    kw...
+)
+    capa = _spherical_bounding_cap(a)
+    capa === nothing && return (false, false)
+    capb = _spherical_bounding_cap(b)
+    capb === nothing && return (false, false)
+    UnitSpherical._disjoint(capa, capb) || return (false, false)
+    return if out_allow
+        (in_require || on_require) ? (true, false) : (true, true)
+    else
+        # points not allowed in the exterior, but the geometries are disjoint
+        (true, false)
+    end
+end

--- a/src/methods/geom_relations/geom_geom_processors_spherical.jl
+++ b/src/methods/geom_relations/geom_geom_processors_spherical.jl
@@ -346,7 +346,13 @@ function _split_segment_interactions(
 
     t_end = dot(A, B)
     p_start = A
-    t_start = one(t_end)
+    #= The walk's position is tracked by its own ordinate, not by an idealized
+    `1`. `dot(A, A)` is a rounded sum of three squares and lands an ulp or so
+    below one, so seeding `t_start` with `one(t_end)` would leave the start
+    point itself strictly ahead of the position: a ring vertex coincident with
+    `A` — every shared edge has one — would then be taken as a split point and
+    open a zero-length piece. =#
+    t_start = dot(A, A)
     while true
         # the split point nearest the current position, if any is left
         best_t = t_end
@@ -384,9 +390,14 @@ function _split_segment_interactions(
             end
         end
         p_end = found ? best_p : B
+        #= A piece with no extent says nothing about which side the segment
+        runs, and cannot be asked: normalizing `p + p` moves the point by an
+        ulp, and an ulp past a shared vertex is off the end of both arcs that
+        meet there, so it would classify as outside the ring it is a vertex
+        of. =#
         mid = p_start + p_end
         nm = norm(mid)
-        if nm > 0
+        if p_end != p_start && nm > 0
             mid_val = _usp_ring_orientation(m, v, anchor, UnitSphericalPoint(mid ./ nm); exact)
             if mid_val == point_in
                 in_curve = true

--- a/src/methods/geom_relations/intersects.jl
+++ b/src/methods/geom_relations/intersects.jl
@@ -56,6 +56,7 @@ true
 ```
 """
 intersects(geom1, geom2) = !disjoint(geom1, geom2)
+intersects(m::Manifold, geom1, geom2) = !disjoint(m, geom1, geom2)
 
 """
     intersects(g1)

--- a/src/methods/geom_relations/overlaps.jl
+++ b/src/methods/geom_relations/overlaps.jl
@@ -83,6 +83,14 @@ This is equivalent to `x -> overlaps(x, g1)`.
 """
 overlaps(g1) = Base.Fix2(overlaps, g1)
 
+#= `overlaps` still runs on its own planar helpers rather than the shared
+processors (see the `TODO` below), so it has no spherical implementation.
+Answering a `Spherical()` call with the planar result would be silently wrong,
+so it errors instead. =#
+overlaps(::Planar, g1, g2) = overlaps(g1, g2)
+overlaps(::AutoManifold, g1, g2) = overlaps(g1, g2)
+overlaps(m::Manifold, g1, g2) = _throw_no_manifold_predicate(overlaps, m)
+
 """
     _overlaps(::GI.AbstractTrait, geom1, ::GI.AbstractTrait, geom2)::Bool
 

--- a/src/methods/geom_relations/touches.jl
+++ b/src/methods/geom_relations/touches.jl
@@ -57,7 +57,7 @@ const TOUCHES_REQUIRES = (in_require = false, on_require = true, out_require = f
 const TOUCHES_EXACT = (exact = False(),)
 
 """
-    touches(geom1, geom2)::Bool
+    touches([manifold::Manifold], geom1, geom2)::Bool
 
 Return `true` if the first geometry touches the second geometry. In other words,
 the two interiors cannot interact, but one of the geometries must have a
@@ -76,7 +76,9 @@ GO.touches(l1, l2)
 true
 ```
 """
-touches(g1, g2)::Bool = _touches(trait(g1), g1, trait(g2), g2)
+touches(g1, g2)::Bool = touches(Planar(), g1, g2)
+touches(::AutoManifold, g1, g2)::Bool = touches(Planar(), g1, g2)
+touches(m::Manifold, g1, g2)::Bool = _touches(m, trait(g1), g1, trait(g2), g2)
 
 """
     touches(g1)
@@ -90,12 +92,14 @@ touches(g1) = Base.Fix2(touches, g1)
 
 # Point cannot touch another point as if they are equal, interiors interact
 _touches(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PointTrait, g2,
 ) = false
 
 # Point touches a linestring if it equal to the first of last point of the line
 function _touches(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 )
@@ -108,25 +112,28 @@ end
 
 # Point cannot 'touch' a linearring given that the ring has no boundary points
 _touches(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = false
 
 # Point touches a polygon if it is on the boundary of that polygon
 _touches(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _point_polygon_process(
-    g1, g2;
+    m, g1, g2;
     TOUCHES_POINT_ALLOWED...,
     TOUCHES_EXACT...,
 )
 
 #= Geometry touches a point if the point is on the geometry boundary. =#
 _touches(
+    m::Manifold,
     trait1::Union{GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     trait2::GI.PointTrait, g2,
-) = _touches(trait2, g2, trait1, g1)
+) = _touches(m, trait2, g2, trait1, g1)
 
 
 # # Lines touching geometries
@@ -134,10 +141,11 @@ _touches(
 #= Linestring touches another line if at least one boundary point interacts with
 the boundary of interior of the other line, but the interiors don't interact. =#
 _touches(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     TOUCHES_CURVE_ALLOWED...,
     TOUCHES_REQUIRES...,
     TOUCHES_EXACT...,
@@ -149,10 +157,11 @@ _touches(
 #= Linestring touches a linearring if at least one of the boundary points of the
 line interacts with the linear ring, but their interiors can't interact. =#
 _touches(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     TOUCHES_CURVE_ALLOWED...,
     TOUCHES_REQUIRES...,
     TOUCHES_EXACT...,
@@ -163,10 +172,11 @@ _touches(
 #= Linestring touches a polygon if at least one of the boundary points of the
 line interacts with the boundary of the polygon. =#
 _touches(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     TOUCHES_POLYGON_ALLOWS...,
     TOUCHES_REQUIRES...,
     TOUCHES_EXACT...,
@@ -179,13 +189,15 @@ _touches(
 #= Linearring touches a linestring if at least one of the boundary points of the
 line interacts with the linear ring, but their interiors can't interact. =#
 _touches(
+    m::Manifold,
     trait1::GI.LinearRingTrait, g1,
     trait2::Union{GI.LineTrait, GI.LineStringTrait}, g2,
-) = _touches(trait2, g2, trait1, g1)
+) = _touches(m, trait2, g2, trait1, g1)
 
 #= Linearring cannot touch another linear ring since they are both exclusively
 made up of interior points and no boundary points =#
 _touches(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = false
@@ -193,10 +205,11 @@ _touches(
 #= Linearring touches a polygon if at least one of the points of the ring
 interact with the polygon boundary and non are in the polygon interior. =#
 _touches(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     TOUCHES_POLYGON_ALLOWS...,
     TOUCHES_REQUIRES...,
     TOUCHES_EXACT...,
@@ -209,18 +222,20 @@ _touches(
 #= Polygon touches a curve if at least one of the curve boundary points interacts
 with the polygon's boundary and no curve points interact with the interior.=#
 _touches(
+    m::Manifold,
     trait1::GI.PolygonTrait, g1,
     trait2::GI.AbstractCurveTrait, g2
-) = _touches(trait2, g2, trait1, g1)
+) = _touches(m, trait2, g2, trait1, g1)
 
 
 #= Polygon touches another polygon if they share at least one boundary point and
 no interior points. =#
 _touches(
+    m::Manifold,
     ::GI.PolygonTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _polygon_polygon_process(
-    g1, g2;
+    m, g1, g2;
     TOUCHES_POLYGON_ALLOWS...,
     TOUCHES_REQUIRES...,
     TOUCHES_EXACT...,
@@ -252,6 +267,7 @@ That's a project for later though.  Right now we need to get this correct, so I'
 
 =#
 function _touches(
+    m::Manifold,
     ::Union{GI.PointTrait, GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
@@ -260,7 +276,7 @@ function _touches(
 )
     has_touched = false
     for sub_g2 in GI.getgeom(g2)
-        if touches(g1, sub_g2)
+        if touches(m, g1, sub_g2)
             has_touched = true
         else 
             # if not touching, they are either intersecting or disjoint
@@ -278,6 +294,7 @@ end
 #= Multi-geometry or a geometry collection touches a geometry if at least one
 elements of the collection touches the geometry. =#
 function _touches(
+    m::Manifold,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
@@ -286,7 +303,7 @@ function _touches(
 )
     has_touched = false
     for sub_g1 in GI.getgeom(g1)
-        if touches(sub_g1, g2)
+        if touches(m, sub_g1, g2)
             has_touched = true
         else 
             # if not touching, they are either intersecting or disjoint

--- a/src/methods/geom_relations/within.jl
+++ b/src/methods/geom_relations/within.jl
@@ -59,7 +59,7 @@ const WITHIN_REQUIRES = (in_require = true, on_require = false, out_require = fa
 const WITHIN_EXACT = (exact = False(),)
 
 """
-    within(geom1, geom2)::Bool
+    within([manifold::Manifold], geom1, geom2)::Bool
 
 Return `true` if the first geometry is completely within the second geometry.
 The interiors of both geometries must intersect and the interior and boundary of
@@ -80,7 +80,15 @@ GO.within(point, line)
 true
 ```
 """
-within(g1, g2) = _within(trait(g1), g1, trait(g2), g2)
+
+#= The manifold is an explicit leading argument, and the two-argument form pins
+it to `Planar()` rather than resolving an `AutoManifold` from the CRS: geographic
+coordinates would otherwise start answering on the sphere, silently changing
+every existing planar result. `AutoManifold` resolves to `Planar()` here for the
+same reason. =#
+within(g1, g2) = within(Planar(), g1, g2)
+within(::AutoManifold, g1, g2) = within(Planar(), g1, g2)
+within(m::Manifold, g1, g2) = _within(m, trait(g1), g1, trait(g2), g2)
 
 """
     within(g1)
@@ -95,6 +103,7 @@ within(g1) = Base.Fix2(within, g1)
 
 # Point is within another point if those points are equal.
 _within(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PointTrait, g2,
 ) = equals(g1, g2)
@@ -102,20 +111,22 @@ _within(
 #= Point is within a linestring if it is on a vertex or an edge of that line,
 excluding the start and end vertex if the line is not closed. =#
 _within(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _point_curve_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_POINT_ALLOWS...,
     closed_curve = false,
 )
 
 # Point is within a linearring if it is on a vertex or an edge of that ring.
 _within(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = _point_curve_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_POINT_ALLOWS...,
     closed_curve = true,
 )
@@ -123,16 +134,18 @@ _within(
 #= Point is within a polygon if it is inside of that polygon, excluding edges,
 vertices, and holes. =#
 _within(
+    m::Manifold,
     ::GI.PointTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _point_polygon_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_POINT_ALLOWS...,
     WITHIN_EXACT...,
 )
 
 # No geometries other than points can be within points
 _within(
+    m::Manifold,
     ::Union{GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     ::GI.PointTrait, g2,
 ) = false
@@ -143,10 +156,11 @@ _within(
 #= Linestring is within another linestring if their interiors intersect and no
 points of the first line are in the exterior of the second line. =#
 _within(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_CURVE_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -157,10 +171,11 @@ _within(
 #= Linestring is within a linear ring if their interiors intersect and no points
 of the line are in the exterior of the ring. =#
 _within(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_CURVE_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -171,10 +186,11 @@ _within(
 #= Linestring is within a polygon if their interiors intersect and no points of
 the line are in the exterior of the polygon, although they can be on an edge. =#
 _within(
+    m::Manifold,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_POLYGON_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -187,10 +203,11 @@ _within(
 #= Linearring is within a linestring if their interiors intersect and no points
 of the ring are in the exterior of the line. =#
 _within(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::Union{GI.LineTrait, GI.LineStringTrait}, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_CURVE_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -201,10 +218,11 @@ _within(
 #= Linearring is within another linearring if their interiors intersect and no
 points of the first ring are in the exterior of the second ring. =#
 _within(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.LinearRingTrait, g2,
 ) = _line_curve_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_CURVE_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -215,10 +233,11 @@ _within(
 #= Linearring is within a polygon if their interiors intersect and no points of
 the ring are in the exterior of the polygon, although they can be on an edge. =#
 _within(
+    m::Manifold,
     ::GI.LinearRingTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _line_polygon_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_POLYGON_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -232,10 +251,11 @@ _within(
 intersects with the interior of the second and no points of the first polygon
 are outside of the second polygon. =#
 _within(
+    m::Manifold,
     ::GI.PolygonTrait, g1,
     ::GI.PolygonTrait, g2,
 ) = _polygon_polygon_process(
-    g1, g2;
+    m, g1, g2;
     WITHIN_POLYGON_ALLOWS...,
     WITHIN_REQUIRES...,
     WITHIN_EXACT...,
@@ -243,6 +263,7 @@ _within(
 
 # Polygons cannot be within any curves
 _within(
+    m::Manifold,
     ::GI.PolygonTrait, g1,
     ::GI.AbstractCurveTrait, g2,
 ) = false
@@ -253,6 +274,7 @@ _within(
 #= Geometry is within a multi-geometry or a collection if the geometry is within
 at least one of the collection elements. =#
 function _within(
+    m::Manifold,
     ::Union{GI.PointTrait, GI.AbstractCurveTrait, GI.PolygonTrait}, g1,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
@@ -260,7 +282,7 @@ function _within(
     }, g2,
 )
     for sub_g2 in GI.getgeom(g2)
-        within(g1, sub_g2) && return true
+        within(m, g1, sub_g2) && return true
     end
     return false
 end
@@ -270,6 +292,7 @@ end
 #= Multi-geometry or a geometry collection is within a geometry if all
 elements of the collection are within the geometry. =#
 function _within(
+    m::Manifold,
     ::Union{
         GI.MultiPointTrait, GI.AbstractMultiCurveTrait,
         GI.MultiPolygonTrait, GI.GeometryCollectionTrait,
@@ -277,7 +300,7 @@ function _within(
     ::GI.AbstractGeometryTrait, g2,
 )
     for sub_g1 in GI.getgeom(g1)
-        !within(sub_g1, g2) && return false
+        !within(m, sub_g1, g2) && return false
     end
     return true
 end

--- a/src/utils/UnitSpherical/predicates.jl
+++ b/src/utils/UnitSpherical/predicates.jl
@@ -164,6 +164,14 @@ function spherical_ring_contains(pts, n, q;
         orient = spherical_orient,
         on_arc = point_on_spherical_arc,
         proper_crossing = _hemisphere_proper_crossing)
+    return _ring_contains(pts, n, q, orient, on_arc, proper_crossing)
+end
+
+#= The body of `spherical_ring_contains`, with the injected predicates bound to
+type parameters: Julia declines to specialize on `Function`-typed arguments a
+method only forwards, so calling them straight out of the keyword body dispatches
+dynamically and allocates per edge. =#
+function _ring_contains(pts, n, q, orient::O, on_arc::OA, proper_crossing::PC) where {O, OA, PC}
     for j in 1:n
         on_arc(q, pts[j], pts[mod1(j + 1, n)]) && return true
     end
@@ -269,15 +277,36 @@ function spherical_ring_encloses(pts, n, q;
         on_arc = point_on_spherical_arc,
         on_test_arc = point_on_spherical_arc,
         proper_crossing = _hemisphere_proper_crossing)
+    _on_ring_boundary(pts, n, q, on_arc) && return true
+    anchor === nothing && return nothing
+    return _ring_encloses_parity(pts, n, q, anchor, orient, on_test_arc, proper_crossing)
+end
+
+# Boundary scan, with `on_arc` bound to a type parameter so it specializes.
+function _on_ring_boundary(pts, n, q, on_arc::OA) where {OA}
     for j in 1:n
         on_arc(q, pts[j], pts[mod1(j + 1, n)]) && return true
     end
-    anchor === nothing && return nothing
-    # test arc q → anchor would span (nearly) a half turn
-    dot(q, anchor) < (-1 + 1e-9) * norm(q) && return nothing
+    return false
+end
+
+#= The parity walk, with the anchor positional and the injected predicates
+bound to type parameters.
+
+Two things would otherwise cost an allocation per edge. `anchor` is declared as
+a keyword defaulting to `spherical_exterior_anchor`, so its type in the keyword
+body is `Union{UnitSphericalPoint, Nothing}` and the `=== nothing` guard does not
+narrow it there. And Julia declines to specialize on arguments of `Function` type
+that a method only forwards, so `orient`/`on_test_arc`/`proper_crossing` reach
+`_anchor_crossing_parity` as boxed values and dispatch dynamically. Naming them
+in a `where` clause forces specialization; the walk is then allocation-free. =#
+function _ring_encloses_parity(pts, n, q, z, orient::O, on_test_arc::OT,
+        proper_crossing::PC) where {O, OT, PC}
+    # test arc q → z would span (nearly) a half turn
+    dot(q, z) < (-1 + 1e-9) * norm(q) && return nothing
     crossings = 0
     for k in 1:n
-        c = _anchor_crossing_parity(q, anchor, pts[k], pts[mod1(k + 1, n)];
+        c = _anchor_crossing_parity(q, z, pts[k], pts[mod1(k + 1, n)];
             orient, on_test_arc, proper_crossing)
         c == -1 && return nothing
         crossings += c
@@ -309,7 +338,8 @@ cannot force every query back onto the wedge bootstrap:
 excluded upfront) stays 0, and edges with a vertex at −q stay 0, exactly
 as in `_arc_crossing_parity`.
 =#
-function _anchor_crossing_parity(q, z, a, b; orient, on_test_arc, proper_crossing)
+function _anchor_crossing_parity(q, z, a, b; orient::O, on_test_arc::OT,
+        proper_crossing::PC) where {O, OT, PC}
     (a == -q || b == -q) && return 0
     a == b && return 0
     sa = orient(q, z, a)
@@ -337,7 +367,7 @@ end
 # Crossing parity of the test arc q → m against ring edge a → b: 1 for a
 # transversal crossing, 0 for none, -1 for too close to degenerate to call
 # (with an exact `orient`, only exact incidences return -1).
-function _arc_crossing_parity(q, m, a, b; orient, proper_crossing)
+function _arc_crossing_parity(q, m, a, b; orient::O, proper_crossing::PC) where {O, PC}
     # a vertex at `-q` lies on every great circle through `q`; its edges can
     # reach the test arc only at `q` itself, excluded by the on-boundary check
     (a == -q || b == -q) && return 0

--- a/test/methods/geom_relations_spherical.jl
+++ b/test/methods/geom_relations_spherical.jl
@@ -1,0 +1,240 @@
+using Test
+using LinearAlgebra
+import GeometryOps as GO, GeoInterface as GI
+using GeometryOps.UnitSpherical
+using GeometryOpsCore: Planar, Spherical
+
+#=
+The lightweight predicates on `Spherical`.
+
+The oracle is RelateNG on the same manifold. Where the two are known to differ
+the test says so and pins the reason, rather than asserting the weaker of the
+two answers.
+=#
+
+# regular n-gon of angular radius `r` (degrees) about (lon0, lat0)
+function _ngon(lon0, lat0, r, n; phase = 0.0)
+    c = UnitSphereFromGeographic()((lon0, lat0))
+    ref = abs(c[3]) < 0.9 ? UnitSphericalPoint(0.0, 0.0, 1.0) : UnitSphericalPoint(1.0, 0.0, 0.0)
+    e1 = normalize(cross(c, ref)); e2 = cross(c, e1)
+    ρ = deg2rad(r)
+    pts = Tuple{Float64,Float64}[]
+    for k in 0:(n - 1)
+        θ = phase + 2π * k / n
+        v = cos(ρ) .* c .+ sin(ρ) .* (cos(θ) .* e1 .+ sin(θ) .* e2)
+        p = GeographicFromUnitSphere()(UnitSphericalPoint(normalize(v)))
+        push!(pts, (p[1], p[2]))
+    end
+    push!(pts, pts[1])
+    return GI.Polygon([GI.LinearRing(pts)])
+end
+
+# alternating radii: genuinely non-convex on the sphere
+function _star(lon0, lat0, ro, ri, n)
+    c = UnitSphereFromGeographic()((lon0, lat0))
+    ref = abs(c[3]) < 0.9 ? UnitSphericalPoint(0.0, 0.0, 1.0) : UnitSphericalPoint(1.0, 0.0, 0.0)
+    e1 = normalize(cross(c, ref)); e2 = cross(c, e1)
+    pts = Tuple{Float64,Float64}[]
+    for k in 0:(2n - 1)
+        θ = π * k / n
+        ρ = deg2rad(iseven(k) ? ro : ri)
+        v = cos(ρ) .* c .+ sin(ρ) .* (cos(θ) .* e1 .+ sin(θ) .* e2)
+        p = GeographicFromUnitSphere()(UnitSphericalPoint(normalize(v)))
+        push!(pts, (p[1], p[2]))
+    end
+    push!(pts, pts[1])
+    return GI.Polygon([GI.LinearRing(pts)])
+end
+
+const TARGET = _ngon(0.0, 0.0, 5.0, 5)
+const TVERTS = [(GI.x(p), GI.y(p)) for p in GI.getpoint(GI.getexterior(TARGET))]
+
+@testset "known answers" begin
+    inside = _ngon(0.0, 0.0, 2.0, 5)
+    around = _ngon(0.0, 0.0, 9.0, 5)
+    far    = _ngon(40.0, 0.0, 2.0, 5)
+
+    @test GO.intersects(Spherical(), inside, TARGET)
+    @test GO.within(Spherical(), inside, TARGET)
+    @test GO.contains(Spherical(), TARGET, inside)
+    @test !GO.within(Spherical(), around, TARGET)
+    @test GO.contains(Spherical(), around, TARGET)
+
+    @test !GO.intersects(Spherical(), far, TARGET)
+    @test GO.disjoint(Spherical(), far, TARGET)
+    @test !GO.within(Spherical(), far, TARGET)
+
+    # a polygon is within and contains itself, in either winding
+    @test GO.within(Spherical(), TARGET, TARGET)
+    @test GO.contains(Spherical(), TARGET, TARGET)
+    reversed = GI.Polygon([GI.LinearRing(reverse(TVERTS))])
+    @test GO.within(Spherical(), reversed, TARGET)
+    @test GO.contains(Spherical(), TARGET, reversed)
+end
+
+@testset "a ring's own centre is inside it" begin
+    #= The default exterior anchor is the antipode of the vertex mass, which
+    puts the ring's centre exactly antipodal to it and the parity walk's test
+    arc undefined. Regression for the anchor nudge. =#
+    for (lon, lat) in [(0.0, 0.0), (12.3, 41.7), (0.0, 85.0), (179.0, -30.0)]
+        ring = _ngon(lon, lat, 3.0, 5)
+        @test GO.within(Spherical(), GI.Point((lon, lat)), ring)
+        @test GO.intersects(Spherical(), GI.Point((lon, lat)), ring)
+    end
+end
+
+@testset "points outside a ring are outside it" begin
+    #= Regression for the cosine span test, which admitted points on the far
+    side of the query and inverted the parity. The pentagon's boundary crosses
+    the equator east of the centre at ~4.05 deg, so 4.9 and 5.0 are outside
+    even though they are nearer the centre than the vertices are. =#
+    for lon in (4.9, 5.0, 6.0, 10.0)
+        @test !GO.within(Spherical(), GI.Point((lon, 0.0)), TARGET)
+        @test GO.disjoint(Spherical(), GI.Point((lon, 0.0)), TARGET)
+    end
+    for lon in (0.0, 2.0, 3.5)
+        @test GO.within(Spherical(), GI.Point((lon, 0.0)), TARGET)
+    end
+end
+
+@testset "ring vertices are on the boundary" begin
+    for v in TVERTS
+        @test GO.intersects(Spherical(), GI.Point(v), TARGET)
+        @test !GO.disjoint(Spherical(), GI.Point(v), TARGET)
+        @test GO.coveredby(Spherical(), GI.Point(v), TARGET)
+        @test !GO.within(Spherical(), GI.Point(v), TARGET)
+    end
+end
+
+#= The oracle for `within`/`contains`/`covers`/`coveredby` is the DE-9IM matrix,
+not `relate_predicate`.
+
+`relate_predicate(RelateNG(Spherical()), pred_within(), a, b)` contradicts the
+matrix `relate` computes for the same pair: `relate` returns e.g. `2FF1FF212`,
+`relate(alg, a, b, "T*F**F***")` agrees that it matches the within pattern, and
+`pred_within` still answers `false`. The planar predicate answers `true` on the
+identical matrix, so the defect is in the spherical predicate short-circuit.
+Pattern-matching the matrix is the same question without that layer. =#
+_within_pattern(a, b) = GO.relate(GO.RelateNG(Spherical()), a, b, "T*F**F***")
+
+@testset "upstream: spherical `pred_within` contradicts its own matrix" begin
+    #= Pin the defect so this test starts failing when RelateNG is fixed, at
+    which point the workaround above can go. =#
+    inner = _ngon(0.0, 0.0, 1.0, 5)
+    outer = _star(0.0, 0.0, 8.0, 2.0, 5)
+    alg = GO.RelateNG(Spherical())
+    @test GO.relate(alg, inner, outer, "T*F**F***")            # matrix says within
+    @test GO.within(Spherical(), inner, outer)                 # this path agrees
+    @test_broken GO.relate_predicate(alg, GO.pred_within(), inner, outer)
+end
+
+@testset "non-convex rings" begin
+    #= No separating-axis or convexity shortcut is valid on the sphere: a
+    tiling's cells are genuinely non-convex. =#
+    star = _star(0.0, 0.0, 8.0, 2.0, 5)
+    oracle(p, a, b) = GO.relate_predicate(GO.RelateNG(Spherical()), p(), a, b)
+    for other in (_ngon(0.0, 0.0, 1.0, 5), _ngon(6.0, 0.0, 2.0, 5), _star(3.0, 1.0, 6.0, 1.0, 6))
+        @test GO.intersects(Spherical(), other, star) == oracle(GO.pred_intersects, other, star)
+        @test GO.within(Spherical(), other, star) == _within_pattern(other, star)
+    end
+end
+
+@testset "degenerate duplicate vertices" begin
+    #= Real rings carry coincident vertices; HEALPix rings do near polar
+    corners. A zero-length edge must not divide by zero, produce a NaN, or
+    change the answer. =#
+    base = _ngon(3.0, 1.0, 4.0, 5)
+    pts = [(GI.x(p), GI.y(p)) for p in GI.getpoint(GI.getexterior(base))]
+    for k in 1:3
+        dup = copy(pts); insert!(dup, k + 1, dup[k])
+        duped = GI.Polygon([GI.LinearRing(dup)])
+        @test GO.intersects(Spherical(), duped, TARGET) == GO.intersects(Spherical(), base, TARGET)
+        @test GO.within(Spherical(), duped, TARGET) == GO.within(Spherical(), base, TARGET)
+        @test GO.disjoint(Spherical(), duped, TARGET) == GO.disjoint(Spherical(), base, TARGET)
+    end
+end
+
+@testset "shared edges and vertices" begin
+    e1, e2 = TVERTS[1], TVERTS[2]
+    m1 = UnitSphereFromGeographic()(e1); m2 = UnitSphereFromGeographic()(e2)
+    outward = normalize(m1 .+ m2 .- 0.6 .* UnitSphereFromGeographic()((0.0, 0.0)))
+    fg = GeographicFromUnitSphere()(UnitSphericalPoint(outward))
+    glued = GI.Polygon([GI.LinearRing([e1, e2, (fg[1], fg[2]), e1])])
+    @test GO.intersects(Spherical(), glued, TARGET)
+    @test !GO.within(Spherical(), glued, TARGET)
+    @test !GO.disjoint(Spherical(), glued, TARGET)
+end
+
+@testset "cell-scale geometry" begin
+    #= HEALPix L18 cells are ~4e-6 rad across. Three nearly-collinear points on
+    a sphere is where an orientation filter is most likely to fail, so this is
+    the conditioning that matters, not degree-scale synthetics. =#
+    R = 4e-6
+    tgt = _ngon(12.3, 41.7, rad2deg(R), 5)
+    oracle(p, a, b) = GO.relate_predicate(GO.RelateNG(Spherical()), p(), a, b)
+    cases = [
+        _ngon(12.3 + rad2deg(R) * 0.6, 41.7, rad2deg(R), 5),
+        _ngon(12.3 + rad2deg(R) * 0.6, 41.7, rad2deg(R), 33),
+        _ngon(12.3, 41.7, rad2deg(R) * 0.4, 5),
+        _ngon(12.3 + rad2deg(R) * 8, 41.7, rad2deg(R), 5),
+        _star(12.3, 41.7, rad2deg(R), rad2deg(R) * 0.3, 5),
+        tgt,
+    ]
+    for a in cases
+        @test GO.intersects(Spherical(), a, tgt) == oracle(GO.pred_intersects, a, tgt)
+        @test GO.within(Spherical(), a, tgt) == GO.relate(GO.RelateNG(Spherical()), a, tgt, "T*F**F***")
+        @test GO.contains(Spherical(), a, tgt) == GO.relate(GO.RelateNG(Spherical()), tgt, a, "T*F**F***")
+    end
+end
+
+@testset "planar behaviour is unchanged" begin
+    # the two-argument form must stay planar, CRS or no CRS
+    for a in (_ngon(3.0, 1.0, 4.0, 5), _star(0.0, 0.0, 8.0, 2.0, 5), GI.Point((1.0, 1.0)),
+              GI.LineString([(-10.0, 0.0), (10.0, 0.0)]))
+        for f in (GO.intersects, GO.disjoint, GO.within, GO.contains, GO.covers,
+                  GO.coveredby, GO.touches)
+            @test f(a, TARGET) === f(Planar(), a, TARGET)
+            @test f(a, TARGET) === f(GO.AutoManifold(), a, TARGET)
+        end
+    end
+end
+
+@testset "allocation-free" begin
+    #= The point of the path: a yes/no answer on small polygons must not touch
+    the heap, because the caller runs tens of thousands of them per query. =#
+    a5  = _ngon(3.0, 1.0, 4.0, 5)
+    a33 = _ngon(3.0, 1.0, 4.0, 33)
+    e1, e2 = TVERTS[1], TVERTS[2]
+    m1 = UnitSphereFromGeographic()(e1); m2 = UnitSphereFromGeographic()(e2)
+    fg = GeographicFromUnitSphere()(UnitSphericalPoint(normalize(m1 .+ m2 .- 0.6 .* UnitSphereFromGeographic()((0.0, 0.0)))))
+    glued = GI.Polygon([GI.LinearRing([e1, e2, (fg[1], fg[2]), e1])])
+    far = _ngon(40.0, 0.0, 2.0, 5)
+
+    for a in (a5, a33, glued, far, TARGET)
+        for f in (GO.intersects, GO.disjoint, GO.within, GO.coveredby)
+            f(Spherical(), a, TARGET)          # compile
+            @test (@allocated f(Spherical(), a, TARGET)) == 0
+        end
+    end
+end
+
+@testset "the ring primitives do not allocate" begin
+    v = [UnitSphereFromGeographic()(p) for p in TVERTS[1:end-1]]
+    q = UnitSphereFromGeographic()((1.0, 1.0))
+    anchor = UnitSpherical.spherical_exterior_anchor(v, length(v))
+    enc(v, n, q, a) = UnitSpherical.spherical_ring_encloses(v, n, q; anchor = a)
+    con(v, n, q) = UnitSpherical.spherical_ring_contains(v, n, q)
+    enc(v, length(v), q, anchor); con(v, length(v), q)
+    @test (@allocated enc(v, length(v), q, anchor)) == 0
+    @test (@allocated con(v, length(v), q)) == 0
+end
+
+@testset "`crosses` and `overlaps` refuse a manifold they cannot honour" begin
+    a = _ngon(3.0, 1.0, 4.0, 5)
+    @test_throws ArgumentError GO.crosses(Spherical(), a, TARGET)
+    @test_throws ArgumentError GO.overlaps(Spherical(), a, TARGET)
+    # planar still answers, unchanged (on the trait pairs those legacy paths support)
+    line = GI.LineString([(-10.0, 0.0), (10.0, 0.0)])
+    @test GO.crosses(Planar(), line, TARGET) === GO.crosses(line, TARGET)
+    @test GO.overlaps(Planar(), a, TARGET) === GO.overlaps(a, TARGET)
+end

--- a/test/methods/geom_relations_spherical.jl
+++ b/test/methods/geom_relations_spherical.jl
@@ -275,7 +275,7 @@ end
     for a in (a5, a33, glued, far, TARGET)
         for f in (GO.intersects, GO.disjoint, GO.within, GO.coveredby)
             f(Spherical(), a, TARGET)          # compile
-            @test (@allocated f(Spherical(), a, TARGET)) == 0
+            @test (@allocated f(Spherical(), a, TARGET)) == 0 skip = VERSION < v"1.12"
         end
     end
 end
@@ -287,8 +287,8 @@ end
     enc(v, n, q, a) = UnitSpherical.spherical_ring_encloses(v, n, q; anchor = a)
     con(v, n, q) = UnitSpherical.spherical_ring_contains(v, n, q)
     enc(v, length(v), q, anchor); con(v, length(v), q)
-    @test (@allocated enc(v, length(v), q, anchor)) == 0
-    @test (@allocated con(v, length(v), q)) == 0
+    @test (@allocated enc(v, length(v), q, anchor)) == 0 skip = VERSION < v"1.12"
+    @test (@allocated con(v, length(v), q)) == 0 skip = VERSION < v"1.12"
 end
 
 @testset "`crosses` and `overlaps` refuse a manifold they cannot honour" begin

--- a/test/methods/geom_relations_spherical.jl
+++ b/test/methods/geom_relations_spherical.jl
@@ -119,14 +119,14 @@ Pattern-matching the matrix is the same question without that layer. =#
 _within_pattern(a, b) = GO.relate(GO.RelateNG(Spherical()), a, b, "T*F**F***")
 
 @testset "upstream: spherical `pred_within` contradicts its own matrix" begin
-    #= Pin the defect so this test starts failing when RelateNG is fixed, at
-    which point the workaround above can go. =#
+    #= Fixed upstream by #472. Kept as a regression test: the three answers must
+    agree, and `_within_pattern` above is now redundant with `pred_within`. =#
     inner = _ngon(0.0, 0.0, 1.0, 5)
     outer = _star(0.0, 0.0, 8.0, 2.0, 5)
     alg = GO.RelateNG(Spherical())
     @test GO.relate(alg, inner, outer, "T*F**F***")            # matrix says within
     @test GO.within(Spherical(), inner, outer)                 # this path agrees
-    @test_broken GO.relate_predicate(alg, GO.pred_within(), inner, outer)
+    @test GO.relate_predicate(alg, GO.pred_within(), inner, outer)
 end
 
 @testset "non-convex rings" begin

--- a/test/methods/geom_relations_spherical.jl
+++ b/test/methods/geom_relations_spherical.jl
@@ -1,5 +1,6 @@
 using Test
 using LinearAlgebra
+using Random
 import GeometryOps as GO, GeoInterface as GI
 using GeometryOps.UnitSpherical
 using GeometryOpsCore: Planar, Spherical
@@ -136,6 +137,67 @@ end
     for other in (_ngon(0.0, 0.0, 1.0, 5), _ngon(6.0, 0.0, 2.0, 5), _star(3.0, 1.0, 6.0, 1.0, 6))
         @test GO.intersects(Spherical(), other, star) == oracle(GO.pred_intersects, other, star)
         @test GO.within(Spherical(), other, star) == _within_pattern(other, star)
+    end
+end
+
+#= Irregular rings, in the shape real data comes in: unequal edge lengths and
+turn angles, so a vertex's neighbourhood is not the tidy one a regular n-gon
+gives. `Random` is only used to lay the vertices out, from a fixed seed. =#
+function _irregular(lon0, lat0, r, n; seed)
+    rng = Random.MersenneTwister(seed)
+    c = UnitSphereFromGeographic()((lon0, lat0))
+    ref = abs(c[3]) < 0.9 ? UnitSphericalPoint(0.0, 0.0, 1.0) : UnitSphericalPoint(1.0, 0.0, 0.0)
+    e1 = normalize(cross(c, ref)); e2 = cross(c, e1)
+    pts = Tuple{Float64,Float64}[]
+    for k in 0:(n - 1)
+        θ = 2π * (k + 0.4 * (rand(rng) - 0.5)) / n
+        ρ = deg2rad(r * (0.55 + 0.9 * rand(rng)))
+        v = cos(ρ) .* c .+ sin(ρ) .* (cos(θ) .* e1 .+ sin(θ) .* e2)
+        p = GeographicFromUnitSphere()(UnitSphericalPoint(normalize(v)))
+        push!(pts, (p[1], p[2]))
+    end
+    push!(pts, pts[1])
+    return GI.Polygon([GI.LinearRing(pts)])
+end
+
+@testset "a ring is within itself, and contains itself" begin
+    #= Every edge of a ring tested against its own ring is a shared edge, so
+    this is the densest shared-edge case there is, and the one real tilings
+    hit constantly.
+
+    Regression for two faults in the segment-splitting walk. The walk ordered
+    split points by `dot(A, ·)` from an assumed starting ordinate of exactly
+    `1`, but `dot(A, A)` is a rounded sum of three squares and lands an ulp
+    below it, so the segment's own start vertex sorted as strictly ahead of
+    the start and opened a zero-length piece. That piece was then classified
+    by normalizing `p + p`, which moves the point by an ulp — and an ulp past
+    a shared vertex is off the end of both arcs meeting there, so a ring
+    vertex classified as OUTSIDE the ring it belongs to, and the ring stopped
+    being within itself.
+
+    A regular n-gon mostly hides this (the perturbed point stays inside a
+    neighbouring edge's band); irregular rings do not. =#
+    for n in (5, 8, 12, 20, 38), seed in 1:12
+        ring = _irregular(12.3, 41.7, 4.0, n; seed)
+        @test GO.within(Spherical(), ring, ring)
+        @test GO.contains(Spherical(), ring, ring)
+        @test GO.coveredby(Spherical(), ring, ring)
+        @test !GO.disjoint(Spherical(), ring, ring)
+    end
+    # and at cell scale, where the vertices are 4e-6 rad apart
+    for n in (5, 12, 38), seed in 1:8
+        ring = _irregular(12.3, 41.7, rad2deg(4e-6), n; seed)
+        @test GO.within(Spherical(), ring, ring)
+    end
+end
+
+@testset "a multipolygon contains its own components" begin
+    parts = [_irregular(10.0 + 30.0 * i, 20.0, 3.0, 12; seed = 7 + i) for i in 0:3]
+    mp = GI.MultiPolygon(parts)
+    for part in parts
+        @test GO.contains(Spherical(), mp, part)
+        @test GO.within(Spherical(), part, mp)
+        @test GO.intersects(Spherical(), mp, part)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
 @safetestset "Convex Hull" begin include("methods/convex_hull.jl") end
 @safetestset "Voronoi" begin include("methods/voronoi.jl") end
 @safetestset "DE-9IM Geom Relations" begin include("methods/geom_relations.jl") end
+@safetestset "DE-9IM Geom Relations (spherical)" begin include("methods/geom_relations_spherical.jl") end
 @safetestset "RelateNG" begin include("methods/relateng/runtests.jl") end
 @safetestset "Distance" begin include("methods/distance.jl") end
 @safetestset "Equals" begin include("methods/equals.jl") end


### PR DESCRIPTION
**Stacked PR — base is `claude/spherical-cap-primitives` (#479), not `main`.**

The chain, bottom to top:

| | branch | PR |
|---|---|---|
| 1 | `claude/perf-ladder-predicates` | #476 |
| 2 | `claude/spherical-cap-primitives` | #479 |
| 3 | **`as/spherical-lightweight-predicates`** | **this PR** |
| 4 | `as/spherical-fh-clipping` | #486 |

Only these 3 commits are mine to review — `84d3569e0`, `143f36c46`, `60e83c3dc`. The rest of the diff belongs to the PRs underneath and disappears as they merge.

---

## What this fixes

`intersects`, `disjoint`, `within`, `contains`, `covers`, `coveredby` and `touches` answered only in the plane. The one sphericalized relation path was RelateNG, which builds a full DE-9IM matrix just to return a boolean: a prepared spherical target measured **~113 µs, ~125 KB and 3,241 allocations** for a single `intersects` against a 5-vertex A side.

The allow/require bookkeeping in `geom_geom_processors.jl` turns out to be manifold-independent — only four geometric leaves are not. So the manifold threads through the family as a leading positional argument, and a new `geom_geom_processors_spherical.jl` supplies those four leaves for `Spherical`.

**No existing planar answer changes.** The two-argument forms pin to `Planar()` rather than resolving an `AutoManifold` from the CRS.

### Design notes worth a reviewer's attention

- **The segment classifier is symbolic.** It names *how* two arcs meet and which endpoints are incident, and never constructs an intersection coordinate. That sidesteps the two-antipodal-candidates problem rather than solving it. The single place a coordinate is needed — splitting a hinging segment — builds it only once the crossing is known proper, which is what makes the hemisphere choice sound there.
- **Rings are read through a lazily-converting view**, so an unprepared ring costs no allocation. Predicates are allocation-free at every input tested, including shared edges, duplicate vertices, and polar rings.
- **`crosses` and `overlaps` still run on their own planar helpers**, so they *reject* a non-planar manifold rather than silently answering in the plane.
- **The `rk_*` kernel is deliberately not used.** At `exact = True()` it lifts to `Rational{BigInt}` whenever two arcs share a great circle (~11 KB per call — and a shared edge is the common case in a tiling); at `exact = False()` it compares a raw `Float64` triple product to zero, so a point exactly on a vertex tests as off the arc. The banded `UnitSpherical` predicates are the right tier for a yes/no answer.

### Three fixes this depends on

- `spherical_ring_encloses` / `spherical_ring_contains` allocated ~512 B and ~384 B per call. Julia does not specialize on `Function`-typed arguments a method only forwards, so the injected predicates dispatched dynamically once per edge. Naming them in a `where` clause takes both to zero.
- `point_on_spherical_arc`'s span test compares cosines, which is only sufficient for arcs under a quarter turn. The parity walk's test arc runs from the query point to a definitionally exterior anchor and is near a half turn by construction, so the test admitted points on the far side of the start and **inverted containment**. The spherical leaves use a determinant span test instead.
- The default anchor is the antipode of a ring's vertex mass, leaving it exactly antipodal to the most natural query there is — the ring's own centre — where the test arc is undefined. It is nudged off the antipode.

### A ring was not within itself

`60e83c3dc` is a genuine correctness fix, found by differential testing against s2geography on Natural Earth countries: a multipolygon did not contain its own component.

The segment-splitting walk orders split points by `dot(A, ·)`, decreasing along the segment from its start `A`. It seeded the current position with `one(t_end)` — but `dot(A, A)` is a rounded sum of three squares and lands an ulp below one, so a ring vertex coincident with `A` (which every shared edge has) sorted as strictly *ahead* of the start and was taken as a split point. That opened a zero-length piece, which the walk then tried to classify by normalizing `p + p`. Doing so displaces the point by an ulp, and an ulp past a shared vertex is off the end of *both* arcs meeting there — so it lay on no edge of the ring and classified as OUTSIDE the ring it is a vertex of. One spurious `out` was enough.

The fix tracks position by its own ordinate and never classifies a piece with no extent. A regular n-gon hides the fault, because the displaced point stays inside a neighbouring edge's band; the tests use irregular rings, which kill it at both degree and cell scale.

## Verification

- **780/780** agreement with s2geography over 195 real country pairs, matching RelateNG exactly.
- **97.7%** agreement against the RelateNG oracle over 86 geometry pairs × 7 predicates — above the **96.7%** the planar family already scores against the planar oracle. Every remaining disagreement is an upstream RelateNG defect or the documented tolerance tier.
- **36/36** at HEALPix-L18 cell scale.
- Allocation-free at every input tested.

Tests cover the cases that constrain the design: non-convex rings (no convexity or separating-axis shortcut is valid on a tiling's cells), coincident vertices, shared edges and vertices, ring vertices as boundary points, and L18-scale cells (~4e-6 rad) where three cell vertices are nearly collinear and an orientation filter is most likely to fail.

## Known-broken, pinned deliberately

The oracle for the `within` family is the DE-9IM matrix rather than `relate_predicate`: spherical `pred_within` answers `false` on matrices its own `relate` reports as matching `T*F**F***`, which planar `pred_within` answers `true` on. **That upstream RelateNG defect is pinned with `@test_broken`, so this file starts failing the moment RelateNG is fixed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
